### PR TITLE
Remove some `assert`s

### DIFF
--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -171,7 +171,7 @@ impl<T: Config> Pallet<T> {
 
         // By this point, there should be enough stake in the hotkey account for this to work.
         debug_assert!(hotkey_stake >= amount);
-        neuron.stake = neuron.stake.hot_key(amount);
+        neuron.stake = neuron.stake.saturating_sub(amount);
 
         Neurons::<T>::insert(uid, neuron);
         Self::decrease_total_stake(amount);


### PR DESCRIPTION
The `assert`s will panic at runtime if the condition is false. Oftentimes this is not desirable, and could even brick the chain if the panic is on a critical logic path.

Where it looked reasonable, I replaced some of these with `debug_assert`s. `debug_assert`s will panic in debug builds and tests, but won't get compiled and won't panic in release builds.

The main pattern I saw for the asserts was checking for underflow / overflow. In these situations I also added saturating logic to ensure the arithmetic itself won't panic (see https://docs.rs/sp-arithmetic/latest/sp_arithmetic/traits/trait.Saturating.html). If these are extremely defensive and should never happen saturating logic should be fine. 

However, if there is concern that some of these edge case might get hit you could check out some of the "checked" arithmetic ops, which return an Option in the event of underflow/overflow (ex: https://docs.rs/sp-arithmetic/latest/sp_arithmetic/traits/trait.CheckedSub.html). 

You could do something like this if you simply wanted to log an error:

```
let result = if let Some(result) = a.check_sub(b) {
   result
} else {
    log::error!(target: LOG_TARGET, "Defensive: a - b underflowed");
    0
}
```

This is a bit verbose, but the latest substrate actually even has a new defensive trait just for this pattern https://github.com/paritytech/substrate/blob/d5090c66cf013b065bc00c987dfdbf64c85f04b3/frame/support/src/traits/misc.rs#L311