### PR TITLE
Refactor local-net Bash scripts

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -10,7 +10,28 @@ echo "*** Purging previous state..."
 ./target/debug/node-subtensor purge-chain -y --base-path /tmp/alice --chain=$CHAIN.json 2>&1 > /dev/null
 
 echo "*** Starting localnet nodes..."
-alice_start="./target/debug/node-subtensor --base-path /tmp/alice --chain=$CHAIN.json --alice --port 30334 --ws-port 9946 --rpc-port 9934 --validator --rpc-cors=all"
-bob_start="./target/debug/node-subtensor --base-path /tmp/bob --chain=$CHAIN.json --bob --port 30335 --ws-port 9947 --rpc-port 9935 --validator --bootnodes /ip4/127.0.0.1/tcp/30334/p2p/12D3KooWBBUaVWE5SYj3UvnoXojfS8fvPorw5biRDaDQV7XXwCXm"
+alice_start=(
+	./target/debug/node-subtensor
+	--base-path /tmp/alice
+	--chain="$CHAIN.json"
+	--alice
+	--port 30334
+	--ws-port 9946
+	--rpc-port 9934
+	--validator
+	--rpc-cors=all
+)
 
-(trap 'kill 0' SIGINT; ($alice_start 2>&1) & ($bob_start 2>&1))
+bob_start=(
+	./target/debug/node-subtensor
+	--base-path /tmp/bob
+	--chain="$CHAIN.json"
+	--bob
+	--port 30335
+	--ws-port 9947
+	--rpc-port 9935
+	--validator
+	--bootnodes "/ip4/127.0.0.1/tcp/30334/p2p/12D3KooWBBUaVWE5SYj3UvnoXojfS8fvPorw5biRDaDQV7XXwCXm"
+)
+
+(trap 'kill 0' SIGINT; ("${alice_start[@]}" 2>&1) & ("${bob_start[@]}" 2>&1))

--- a/scripts/localnet_setup.sh
+++ b/scripts/localnet_setup.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 
+_script_name='support_install.sh'
+_valid_hash='7296b9d45a89e973528c3ae31719ff08'
+
 echo "*** Local testnet installation"
 echo "*** Installing substrate support libraries"
 
 # Install support libraries for compiling substrate binaries
 # verify md5
-curl https://getsubstrate.io -sSf > support_install.sh
-if ! md5sum --status --check <<< "7296b9d45a89e973528c3ae31719ff08 support_install.sh"; then
+curl https://getsubstrate.io -sSf > "${_script_name:?Undfined script name}"
+if ! md5sum --status --check <<< "${_valid_hash:?Undfined hash} ${_script_name}"; then
 	_status="${?}"
 	printf >&2 "Substrate library script checksum not valid, exiting.\n"
 	exit "${_status}"
 fi
-chmod +rx support_install.sh
-bash support_install.sh
-rm support_install.sh
+chmod +rx "${_script_name}"
+bash "${_script_name}"
+rm "${_script_name}"
 
 echo "*** Building node binary..."
 

--- a/scripts/localnet_setup.sh
+++ b/scripts/localnet_setup.sh
@@ -3,15 +3,20 @@
 _script_name='support_install.sh'
 _valid_hash='7296b9d45a89e973528c3ae31719ff08'
 
+if [[ -f "${_script_name:?Undfined script name}" ]]; then
+	printf >&2 'Script already exists.\n'
+	exit 1
+fi
+
 echo "*** Local testnet installation"
 echo "*** Installing substrate support libraries"
 
 # Install support libraries for compiling substrate binaries
 # verify md5
-curl https://getsubstrate.io -sSf > "${_script_name:?Undfined script name}"
+curl https://getsubstrate.io -sSf > "${_script_name}"
 if ! md5sum --status --check <<< "${_valid_hash:?Undfined hash} ${_script_name}"; then
 	_status="${?}"
-	printf >&2 "Substrate library script checksum not valid, exiting.\n"
+	printf >&2 'Substrate library script checksum not valid, exiting.\n'
 	exit "${_status}"
 fi
 chmod +rx "${_script_name}"

--- a/scripts/localnet_setup.sh
+++ b/scripts/localnet_setup.sh
@@ -6,7 +6,7 @@ echo "*** Installing substrate support libraries"
 # Install support libraries for compiling substrate binaries
 # verify md5
 curl https://getsubstrate.io -sSf > support_install.sh
-if [[ "$(md5sum support_install.sh | awk '{print $1}')" != "7296b9d45a89e973528c3ae31719ff08" ]]; then
+if ! md5sum --status --check <<< "7296b9d45a89e973528c3ae31719ff08 support_install.sh"; then
 	echo "Substrate library script checksum not valid, exiting."
 	exit
 fi

--- a/scripts/localnet_setup.sh
+++ b/scripts/localnet_setup.sh
@@ -29,4 +29,4 @@ echo "*** Building node binary..."
 cargo build
 
 echo "*** Setup complete, use localnet.sh in scripts to start a local network."
-exit
+

--- a/scripts/localnet_setup.sh
+++ b/scripts/localnet_setup.sh
@@ -7,8 +7,9 @@ echo "*** Installing substrate support libraries"
 # verify md5
 curl https://getsubstrate.io -sSf > support_install.sh
 if ! md5sum --status --check <<< "7296b9d45a89e973528c3ae31719ff08 support_install.sh"; then
-	echo "Substrate library script checksum not valid, exiting."
-	exit
+	_status="${?}"
+	printf >&2 "Substrate library script checksum not valid, exiting.\n"
+	exit "${_status}"
 fi
 chmod +rx support_install.sh
 bash support_install.sh


### PR DESCRIPTION
Mostly reduces sub-shell and piping costs, plus by utilizing Bash lists it be possible to exert more control over field separators

Only bit I currently question is at `scripts/localnet.sh:3`
```bash
: "${CHAIN:=local}"
```
... and probably could move defaulting, or checking, of variables' value to the first usage