### PR TITLE
:shell: Fix shellcheck warnings...

### DIFF
--- a/scripts/docker_run.sh
+++ b/scripts/docker_run.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "*** Start Substrate node subtensor ***"
 
-cd $(dirname ${BASH_SOURCE[0]})/..
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
 
 docker-compose down --remove-orphans
-docker-compose run --rm --service-ports dev $@
+docker-compose run --rm --service-ports dev "$@"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "*** Initializing WASM build environment"
 
-if [ -z $CI_PROJECT_NAME ] ; then
+if ! (( ${#CI_PROJECT_NAME} )) ; then
    rustup update nightly
    rustup update stable
 fi

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -13,19 +13,19 @@ if [[ $BUILD_BINARY == "1" ]]; then
 fi
 
 echo "*** Building chainspec..."
-./target/debug/node-subtensor build-spec --disable-default-bootnode --chain $CHAIN > $FULL_PATH
+./target/debug/node-subtensor build-spec --disable-default-bootnode --chain "$CHAIN" > "$FULL_PATH"
 echo "*** Chainspec built and output to file"
 
 echo "*** Purging previous state..."
-./target/debug/node-subtensor purge-chain -y --base-path /tmp/bob --chain=$FULL_PATH 2>&1 > /dev/null
-./target/debug/node-subtensor purge-chain -y --base-path /tmp/alice --chain=$FULL_PATH 2>&1 > /dev/null
+./target/debug/node-subtensor purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
+./target/debug/node-subtensor purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
 echo "*** Previous chainstate purged"
 
 echo "*** Starting localnet nodes..."
 alice_start=(
 	./target/debug/node-subtensor
 	--base-path /tmp/alice
-	--chain=$FULL_PATH
+	--chain="$FULL_PATH"
 	--alice
 	--port 30334
 	--ws-port 9946
@@ -37,7 +37,7 @@ alice_start=(
 bob_start=(
 	./target/debug/node-subtensor
 	--base-path /tmp/bob
-	--chain=$FULL_PATH
+	--chain="$FULL_PATH"
 	--bob
 	--port 30335
 	--ws-port 9947


### PR DESCRIPTION
- Double quote variables to prevent word expansion
- Use `>/dev/null 2>&1` instead of `2>&1 >/dev/null`