### PR TITLE
[BIT-634] Epoch cleanup: Remove WeightConsensus, WeightCuts

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -474,16 +474,6 @@ benchmarks! {
 
   }: sudo_set_kappa(RawOrigin::<AccountIdOf<T>>::Root, netuid, kappa)
 
-  benchmark_sudo_set_weight_cuts {
-    let netuid: u16 = 1;
-    let tempo: u16 = 1;
-    let modality: u16 = 0;
-    let weight_cuts: u16 = 3;
-
-    assert_ok!( Subtensor::<T>::do_add_network( RawOrigin::Root.into(), netuid.try_into().unwrap(), tempo.into(), modality.into()));
-
-  }: sudo_set_weight_cuts(RawOrigin::<AccountIdOf<T>>::Root, netuid, weight_cuts)
-
   benchmark_sudo_set_max_allowed_uids {
     let netuid: u16 = 1;
     let tempo: u16 = 1;

--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -206,7 +206,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_prunning_socres: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
         Consensus::<T>::insert( netuid, cloned_consensus );
         Incentive::<T>::insert( netuid, cloned_incentive );
         Dividends::<T>::insert( netuid, cloned_dividends );
-        PruningScores::<T>::insert( netuid, cloned_prunning_socres );
+        PruningScores::<T>::insert( netuid, cloned_pruning_scores );
         ValidatorTrust::<T>::insert( netuid, cloned_validator_trust );
         ValidatorPermit::<T>::insert( netuid, new_validator_permits.clone() );
 
@@ -469,7 +469,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_prunning_socres: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );
@@ -478,7 +478,7 @@ impl<T: Config> Pallet<T> {
         Consensus::<T>::insert( netuid, cloned_consensus );
         Incentive::<T>::insert( netuid, cloned_incentive );
         Dividends::<T>::insert( netuid, cloned_dividends );
-        PruningScores::<T>::insert( netuid, cloned_prunning_socres );
+        PruningScores::<T>::insert( netuid, cloned_pruning_scores );
         ValidatorTrust::<T>::insert( netuid, cloned_validator_trust );
         ValidatorPermit::<T>::insert( netuid, new_validator_permits.clone() );
 

--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -158,7 +158,8 @@ impl<T: Config> Pallet<T> {
         // log::trace!( "ΔB:\n{:?}\n", &bonds_delta );
     
         // Compute bonds moving average.
-        let alpha: I32F32 = I32F32::from_num( 0.1 );
+        let bonds_moving_average: I64F64 = I64F64::from_num( Self::get_bonds_moving_average( netuid ) ) / I64F64::from_num( 1_000_000 );
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num( bonds_moving_average );
         let mut ema_bonds: Vec<Vec<I32F32>> = mat_ema( &bonds_delta, &bonds, alpha );
         inplace_col_normalize( &mut ema_bonds ); // sum_i b_ij = 1
         // log::trace!( "emaB:\n{:?}\n", &ema_bonds );
@@ -416,7 +417,8 @@ impl<T: Config> Pallet<T> {
         // log::trace!( "ΔB (norm): {:?}", &bonds_delta );
     
         // Compute bonds moving average.
-        let alpha: I32F32 = I32F32::from_num( 0.1 );
+        let bonds_moving_average: I64F64 = I64F64::from_num( Self::get_bonds_moving_average( netuid ) ) / I64F64::from_num( 1_000_000 );
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num( bonds_moving_average );
         let mut ema_bonds: Vec<Vec<(u16, I32F32)>> = mat_ema_sparse( &bonds_delta, &bonds, alpha );
 
         // Normalize EMA bonds.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -124,8 +124,6 @@ pub mod pallet {
 		type InitialBondsMovingAverage: Get<u64>;
 		#[pallet::constant] // Initial target registrations per interval.
 		type InitialTargetRegistrationsPerInterval: Get<u16>;
-		#[pallet::constant] // Initial number of weight cuts in epoch.
-		type InitialWeightCuts: Get<u16>;
 		#[pallet::constant] // Rho constant
 		type InitialRho: Get<u16>;
 		#[pallet::constant] // Kappa constant
@@ -368,8 +366,6 @@ pub mod pallet {
 	#[pallet::type_value] 
 	pub fn DefaultBlockAtRegistration<T: Config>() -> u64 { 0 }
 	#[pallet::type_value]
-	pub fn DefaultWeightCuts<T: Config>() -> u16 { T::InitialWeightCuts::get() }
-	#[pallet::type_value]
 	pub fn DefaultRho<T: Config>() -> u16 { T::InitialRho::get() }
 	#[pallet::type_value]
 	pub fn DefaultKappa<T: Config>() -> u16 { T::InitialKappa::get() }
@@ -413,8 +409,6 @@ pub mod pallet {
 	pub fn DefaultTargetRegistrationsPerInterval<T: Config>() -> u16 { T::InitialTargetRegistrationsPerInterval::get() }
 
 
-	#[pallet::storage] // --- MAP ( netuid ) --> WeightCuts
-	pub type WeightCuts<T> =  StorageMap<_, Identity, u16, u16, ValueQuery, DefaultWeightCuts<T> >;
 	#[pallet::storage] // --- MAP ( netuid ) --> Rho
 	pub type Rho<T> =  StorageMap<_, Identity, u16, u16, ValueQuery, DefaultRho<T> >;
 	#[pallet::storage] // --- MAP ( netuid ) --> Kappa
@@ -552,7 +546,6 @@ pub mod pallet {
 		RegistrationPerIntervalSet( u16, u16 ), // --- Event created when registeration per interval is set for a subnet.
 		MaxRegistrationsPerBlockSet( u16, u16), // --- Event created when we set max registrations per block
 		ActivityCutoffSet( u16, u16 ), // --- Event created when an activity cutoff is set for a subnet.
-		WeightCutsSet( u16, u16 ), // --- Event created when WeightCuts value is set.
 		RhoSet( u16, u16 ), // --- Event created when Rho value is set.
 		KappaSet( u16, u16 ), // --- Event created when kappa is set for a subnet.
 		MinAllowedWeightSet( u16, u16 ), // --- Event created when minimun allowed weight is set for a subnet.
@@ -1311,10 +1304,6 @@ pub mod pallet {
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_kappa( origin:OriginFor<T>, netuid: u16, kappa: u16 ) -> DispatchResult {
 			Self::do_sudo_set_kappa( origin, netuid, kappa )
-		}
-		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-		pub fn sudo_set_weight_cuts( origin:OriginFor<T>, netuid: u16, weight_cuts: u16 ) -> DispatchResult {
-			Self::do_sudo_set_weight_cuts( origin, netuid, weight_cuts )
 		}
 		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
 		pub fn sudo_set_max_allowed_uids( origin:OriginFor<T>, netuid: u16, max_allowed_uids: u16 ) -> DispatchResult {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -511,8 +511,6 @@ pub mod pallet {
 	pub(super) type LastUpdate<T:Config> = StorageMap< _, Identity, u16, Vec<u64>, ValueQuery, EmptyU64Vec<T>>;
 	#[pallet::storage] // --- DMAP ( netuid ) --> validator_trust
 	pub(super) type ValidatorTrust<T:Config> = StorageMap< _, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
-	#[pallet::storage] // --- DMAP ( netuid ) --> weight_consensus
-	pub(super) type WeightConsensus<T:Config> = StorageMap< _, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 	#[pallet::storage] // --- DMAP ( netuid ) --> pruning_scores
 	pub(super) type PruningScores<T:Config> = StorageMap< _, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T> >;
 	#[pallet::storage] // --- DMAP ( netuid ) --> validator_permit

--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -815,6 +815,15 @@ mod tests {
         // let one: I96F32 = I96F32::from_num(1);
         // let prod_96: I96F32 = (I96F32::from_num(max_32) + one) * I96F32::from_num(max_u64); // overflows
         let _prod_110: I110F18 = I110F18::from_num(max_32) * I110F18::from_num(max_u64);
+
+        let bonds_moving_average_val: u64 = 900_000 as u64;
+        let bonds_moving_average: I64F64 = I64F64::from_num( bonds_moving_average_val ) / I64F64::from_num( 1_000_000 );
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num( bonds_moving_average );
+        assert_eq!( I32F32::from_num(0.1), alpha);
+
+        let bonds_moving_average: I64F64 = I64F64::from_num( max_32 ) / I64F64::from_num( max_32 );
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num( bonds_moving_average );
+        assert_eq!( I32F32::from_num(0), alpha);
     }
 
     #[test]

--- a/pallets/subtensor/src/networks.rs
+++ b/pallets/subtensor/src/networks.rs
@@ -300,7 +300,6 @@ impl<T: Config> Pallet<T> {
         LastUpdate::<T>::remove( netuid );
         ValidatorPermit::<T>::remove( netuid );
         ValidatorTrust::<T>::remove( netuid );
-        WeightConsensus::<T>::remove( netuid );
 
         // --- 2. Erase network parameters.
         Tempo::<T>::remove( netuid );

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -20,7 +20,6 @@ pub struct NeuronInfo {
     emission: u64,
     incentive: u16,
     consensus: u16,
-    weight_consensus: u16,
     trust: u16,
     validator_trust: u16,
     dividends: u16,
@@ -70,7 +69,6 @@ impl<T: Config> Pallet<T> {
             let emission = Self::get_emission_for_uid( netuid, uid as u16 );
             let incentive = Self::get_incentive_for_uid( netuid, uid as u16 );
             let consensus = Self::get_consensus_for_uid( netuid, uid as u16 );
-            let weight_consensus = Self::get_weight_consensus_for_uid( netuid, uid as u16 );
             let trust = Self::get_trust_for_uid( netuid, uid as u16 );
             let validator_trust = Self::get_validator_trust_for_uid( netuid, uid as u16 );
             let dividends = Self::get_dividends_for_uid( netuid, uid as u16 );
@@ -101,7 +99,6 @@ impl<T: Config> Pallet<T> {
                 emission,
                 incentive,
                 consensus,
-                weight_consensus,
                 trust,
                 validator_trust,
                 dividends,
@@ -148,7 +145,6 @@ impl<T: Config> Pallet<T> {
         let emission = Self::get_emission_for_uid( netuid, uid as u16 );
         let incentive = Self::get_incentive_for_uid( netuid, uid as u16 );
         let consensus = Self::get_consensus_for_uid( netuid, uid as u16 );
-        let weight_consensus = Self::get_weight_consensus_for_uid( netuid, uid as u16 );
         let trust = Self::get_trust_for_uid( netuid, uid as u16 );
         let validator_trust = Self::get_validator_trust_for_uid( netuid, uid as u16 );
         let dividends = Self::get_dividends_for_uid( netuid, uid as u16 );
@@ -179,7 +175,6 @@ impl<T: Config> Pallet<T> {
             emission,
             incentive,
             consensus,
-            weight_consensus,
             trust,
             validator_trust,
             dividends,

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -349,17 +349,6 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
             
-    pub fn get_weight_cuts( netuid: u16 ) -> u16  { WeightCuts::<T>::get( netuid ) }
-    pub fn set_weight_cuts( netuid: u16, weight_cuts: u16 ) { WeightCuts::<T>::insert( netuid, weight_cuts ); }
-    pub fn do_sudo_set_weight_cuts( origin:T::RuntimeOrigin, netuid: u16, weight_cuts: u16 ) -> DispatchResult {
-        ensure_root( origin )?;
-        ensure!(Self::if_subnet_exist(netuid), Error::<T>::NetworkDoesNotExist);
-        Self::set_weight_cuts( netuid, weight_cuts );
-        log::info!("WeightCutsSet( netuid: {:?} weight_cuts: {:?} ) ", netuid, weight_cuts );
-        Self::deposit_event( Event::WeightCutsSet( netuid, weight_cuts ) );
-        Ok(())
-    }
-            
     pub fn get_activity_cutoff( netuid: u16 ) -> u16  { ActivityCutoff::<T>::get( netuid ) }
     pub fn set_activity_cutoff( netuid: u16, activity_cutoff: u16 ) { ActivityCutoff::<T>::insert( netuid, activity_cutoff ); }
     pub fn do_sudo_set_activity_cutoff( origin:T::RuntimeOrigin, netuid: u16, activity_cutoff: u16 ) -> DispatchResult {

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -39,7 +39,6 @@ impl<T: Config> Pallet<T> {
     pub fn get_last_update( netuid:u16 ) -> Vec<u64> { LastUpdate::<T>::get( netuid ) }
     pub fn get_pruning_score( netuid:u16 ) -> Vec<u16> { PruningScores::<T>::get( netuid ) }
     pub fn get_validator_trust( netuid:u16 ) -> Vec<u16> { ValidatorTrust::<T>::get( netuid ) }
-    pub fn get_weight_consensus( netuid:u16 ) -> Vec<u16> { WeightConsensus::<T>::get( netuid ) }
     pub fn get_validator_permit( netuid:u16 ) -> Vec<bool> { ValidatorPermit::<T>::get( netuid ) }
 
     // ==================================
@@ -84,7 +83,6 @@ impl<T: Config> Pallet<T> {
     pub fn get_last_update_for_uid( netuid:u16, uid: u16) -> u64 { let vec = LastUpdate::<T>::get( netuid ); if (uid as usize) < vec.len() { return vec[uid as usize] } else{ return 0 } }
     pub fn get_pruning_score_for_uid( netuid:u16, uid: u16) -> u16 { let vec = PruningScores::<T>::get( netuid ); if (uid as usize) < vec.len() { return vec[uid as usize] } else{ return u16::MAX } }
     pub fn get_validator_trust_for_uid( netuid:u16, uid: u16) -> u16 { let vec = ValidatorTrust::<T>::get( netuid ); if (uid as usize) < vec.len() { return vec[uid as usize] } else{ return 0 } }
-    pub fn get_weight_consensus_for_uid( netuid:u16, uid: u16) -> u16 { let vec = WeightConsensus::<T>::get( netuid ); if (uid as usize) < vec.len() { return vec[uid as usize] } else{ return 0 } }
     pub fn get_validator_permit_for_uid( netuid:u16, uid: u16) -> bool { let vec = ValidatorPermit::<T>::get( netuid ); if (uid as usize) < vec.len() { return vec[uid as usize] } else{ return false } }
 
     // ============================

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -108,7 +108,7 @@ parameter_types! {
 	pub const SelfOwnership: u64 = 2;
 	pub const InitialImmunityPeriod: u16 = 2;
 	pub const InitialMaxAllowedUids: u16 = 2;
-	pub const InitialBondsMovingAverage: u64 = 500_000;
+	pub const InitialBondsMovingAverage: u64 = 900_000;
 	pub const InitialStakePruningMin: u16 = 0;
 	pub const InitialFoundationDistribution: u64 = 0;
 	pub const InitialDefaultTake: u16 = 11_796; // 18% honest number.

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -102,7 +102,6 @@ parameter_types! {
 	pub const ExistentialDeposit: Balance = 1;
 	pub const TransactionByteFee: Balance = 100;
 	pub const SDebug:u64 = 1;
-	pub const InitialWeightCuts: u16 = 3;
 	pub const InitialRho: u16 = 30;
 	pub const InitialKappa: u16 = 32_767;
 	pub const InitialTempo: u16 = 0;
@@ -155,7 +154,6 @@ impl pallet_subtensor::Config for Test {
 	type InitialDifficulty = InitialDifficulty;
 	type InitialAdjustmentInterval = InitialAdjustmentInterval;
 	type InitialTargetRegistrationsPerInterval = InitialTargetRegistrationsPerInterval;
-	type InitialWeightCuts = InitialWeightCuts;
 	type InitialRho = InitialRho;
 	type InitialKappa = InitialKappa;
 	type InitialMaxAllowedUids = InitialMaxAllowedUids;

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -13,7 +13,6 @@ fn test_defaults() {
         add_network(netuid, 10, 0);
         assert_eq!( SubtensorModule::get_number_of_subnets(), 1 ); // There is a single network.
         assert_eq!( SubtensorModule::get_subnetwork_n( netuid ), 0 ); // Network size is zero.
-        assert_eq!( SubtensorModule::get_weight_cuts( netuid ), 3 );
         assert_eq!( SubtensorModule::get_rho( netuid ), 30 );
         assert_eq!( SubtensorModule::get_tempo( netuid ), 10 );
         assert_eq!( SubtensorModule::get_kappa( netuid ), 32_767 );
@@ -369,21 +368,6 @@ fn test_sudo_set_max_allowed_uids() {
         assert_eq!( SubtensorModule::get_max_allowed_uids(netuid), init_value);
         assert_ok!( SubtensorModule::sudo_set_max_allowed_uids(<<Test as Config>::RuntimeOrigin>::root(), netuid, to_be_set) );
         assert_eq!( SubtensorModule::get_max_allowed_uids(netuid), to_be_set);
-    });
-}
-
-#[test]
-fn test_sudo_set_weight_cuts() {
-	new_test_ext().execute_with(|| {
-        let netuid: u16 = 1;
-        let to_be_set: u16 = 3;
-        let init_value: u16 = SubtensorModule::get_weight_cuts( netuid );
-        add_network(netuid, 10, 0);
-		assert_eq!( SubtensorModule::sudo_set_weight_cuts(<<Test as Config>::RuntimeOrigin>::signed(0), netuid, to_be_set),  Err(DispatchError::BadOrigin.into()) );
-        assert_eq!( SubtensorModule::sudo_set_weight_cuts(<<Test as Config>::RuntimeOrigin>::root(), netuid + 1, to_be_set), Err(Error::<Test>::NetworkDoesNotExist.into()) );
-        assert_eq!( SubtensorModule::get_weight_cuts(netuid), init_value);
-        assert_ok!( SubtensorModule::sudo_set_weight_cuts(<<Test as Config>::RuntimeOrigin>::root(), netuid, to_be_set) );
-        assert_eq!( SubtensorModule::get_weight_cuts(netuid), to_be_set);
     });
 }
 

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -27,7 +27,7 @@ fn test_defaults() {
         assert_eq!( SubtensorModule::get_max_allowed_uids( netuid ), 2 );
         assert_eq!( SubtensorModule::get_min_allowed_weights( netuid ), 0 );
         assert_eq!( SubtensorModule::get_adjustment_interval( netuid ), 100 );
-        assert_eq!( SubtensorModule::get_bonds_moving_average( netuid ), 500_000 );
+        assert_eq!( SubtensorModule::get_bonds_moving_average( netuid ), 900_000 );
         assert_eq!( SubtensorModule::get_validator_batch_size( netuid ), 10 );
         assert_eq!( SubtensorModule::get_last_adjustment_block( netuid ), 0 );
         assert_eq!( SubtensorModule::get_last_mechanism_step_block( netuid ), 0 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 102,
+	spec_version: 103,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -314,7 +314,6 @@ impl pallet_sudo::Config for Runtime {
 parameter_types! {
 	pub const SubtensorInitialRho: u16 = 30;
     pub const SubtensorInitialKappa: u16 = 32_767; // 0.5 = 65535/2 
-    pub const SubtensorInitialWeightCuts: u16 = 3;
     pub const SubtensorInitialMaxAllowedUids: u16 = 512;
     pub const SubtensorInitialIssuance: u64 = 0;
     pub const SubtensorInitialMinAllowedWeights: u16 = 0;
@@ -354,7 +353,6 @@ impl pallet_subtensor::Config for Runtime {
 	type Currency = Balances;
 	type InitialRho = SubtensorInitialRho;
 	type InitialKappa = SubtensorInitialKappa;
-	type InitialWeightCuts = SubtensorInitialWeightCuts;
 	type InitialMaxAllowedUids = SubtensorInitialMaxAllowedUids;
 	type InitialBondsMovingAverage = SubtensorInitialBondsMovingAverage;
 	type InitialIssuance = SubtensorInitialIssuance;


### PR DESCRIPTION
### [BIT-634] Epoch cleanup: Remove WeightConsensus, WeightCuts

Unused storage since the last consensus revision.

[BIT-634]: https://opentensor.atlassian.net/browse/BIT-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ