### PR TITLE
doc: added comment in localnet Dockerfile about fastblocks default

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -62,4 +62,6 @@ ENV RUN_IN_DOCKER=1
 EXPOSE 30334 30335 9944 9945
 
 ENTRYPOINT ["/scripts/localnet.sh"]
+# Fast blocks defaults to True, you can disable it by passing False to the docker command, e.g.:
+# docker run ghcr.io/opentensor/subtensor-localnet False
 CMD ["True"]


### PR DESCRIPTION
## Description
Added a comment to specify that CMD set to `True` in the `Dockerfile-localnet` means fast blocks are enabled by default and that you can disable it by passing `False` when running a docker command.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.