### PR TITLE
fix: correct burn and recycle logic

### DIFF
--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{Error, system::ensure_signed};
 
 impl<T: Config> Pallet<T> {
-    /// Recycles alpha from a cold/hot key pair, reducing AlphaOut on a subnet
+    /// Burns alpha from a cold/hot key pair, reducing AlphaOut on a subnet
     ///
     /// # Arguments
     ///
@@ -10,56 +10,6 @@ impl<T: Config> Pallet<T> {
     /// * `hotkey` - The hotkey account
     /// * `amount` - The amount of alpha to recycle
     /// * `netuid` - The subnet ID from which to reduce AlphaOut
-    ///
-    /// # Returns
-    ///
-    /// * `DispatchResult` - Success or error
-    pub(crate) fn do_recycle_alpha(
-        origin: T::RuntimeOrigin,
-        hotkey: T::AccountId,
-        amount: u64,
-        netuid: u16,
-    ) -> DispatchResult {
-        let coldkey = ensure_signed(origin)?;
-
-        ensure!(
-            Self::if_subnet_exist(netuid),
-            Error::<T>::SubNetworkDoesNotExist
-        );
-
-        ensure!(
-            Self::coldkey_owns_hotkey(&coldkey, &hotkey),
-            Error::<T>::NonAssociatedColdKey
-        );
-
-        ensure!(
-            TotalHotkeyAlpha::<T>::get(&hotkey, netuid) >= amount,
-            Error::<T>::NotEnoughStakeToWithdraw
-        );
-
-        ensure!(
-            SubnetAlphaOut::<T>::get(netuid) >= amount,
-            Error::<T>::InsufficientLiquidity
-        );
-
-        TotalHotkeyAlpha::<T>::mutate(&hotkey, netuid, |v| *v = v.saturating_sub(amount));
-        SubnetAlphaOut::<T>::mutate(netuid, |total| {
-            *total = total.saturating_sub(amount);
-        });
-
-        Self::deposit_event(Event::AlphaRecycled(coldkey, hotkey, amount, netuid));
-
-        Ok(())
-    }
-
-    /// Burns alpha from a cold/hot key pair without reducing AlphaOut
-    ///
-    /// # Arguments
-    ///
-    /// * `origin` - The origin of the call (must be signed by the coldkey)
-    /// * `hotkey` - The hotkey account
-    /// * `amount` - The "up to" amount of alpha to burn
-    /// * `netuid` - The subnet ID
     ///
     /// # Returns
     ///
@@ -93,9 +43,59 @@ impl<T: Config> Pallet<T> {
         );
 
         TotalHotkeyAlpha::<T>::mutate(&hotkey, netuid, |v| *v = v.saturating_sub(amount));
+        SubnetAlphaOut::<T>::mutate(netuid, |total| {
+            *total = total.saturating_sub(amount);
+        });
+
+        Self::deposit_event(Event::AlphaBurned(coldkey, hotkey, amount, netuid));
+
+        Ok(())
+    }
+
+    /// Recycles alpha from a cold/hot key pair without reducing AlphaOut
+    ///
+    /// # Arguments
+    ///
+    /// * `origin` - The origin of the call (must be signed by the coldkey)
+    /// * `hotkey` - The hotkey account
+    /// * `amount` - The "up to" amount of alpha to burn
+    /// * `netuid` - The subnet ID
+    ///
+    /// # Returns
+    ///
+    /// * `DispatchResult` - Success or error
+    pub(crate) fn do_recycle_alpha(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        amount: u64,
+        netuid: u16,
+    ) -> DispatchResult {
+        let coldkey = ensure_signed(origin)?;
+
+        ensure!(
+            Self::if_subnet_exist(netuid),
+            Error::<T>::SubNetworkDoesNotExist
+        );
+
+        ensure!(
+            Self::coldkey_owns_hotkey(&coldkey, &hotkey),
+            Error::<T>::NonAssociatedColdKey
+        );
+
+        ensure!(
+            TotalHotkeyAlpha::<T>::get(&hotkey, netuid) >= amount,
+            Error::<T>::NotEnoughStakeToWithdraw
+        );
+
+        ensure!(
+            SubnetAlphaOut::<T>::get(netuid) >= amount,
+            Error::<T>::InsufficientLiquidity
+        );
+
+        TotalHotkeyAlpha::<T>::mutate(&hotkey, netuid, |v| *v = v.saturating_sub(amount));
 
         // Deposit event
-        Self::deposit_event(Event::AlphaBurned(coldkey, hotkey, amount, netuid));
+        Self::deposit_event(Event::AlphaRecycled(coldkey, hotkey, amount, netuid));
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Fixes wrong implementation of burn and recycle logic for alpha tokens

## Related Issue(s)

- Closes #1450 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
