### PR TITLE
docs: fix broken Substrate docs link

### DIFF
--- a/docs/rust-setup.md
+++ b/docs/rust-setup.md
@@ -2,7 +2,7 @@
 title: Installation
 ---
 This guide is for reference only, please check the latest information on getting starting with Substrate
-[here](https://docs.substrate.io/main-docs/install/).
+[here](https://docs.polkadot.com/main-docs/install/).
 
 This page will guide you through the **2 steps** needed to prepare a computer for **Substrate** development.
 Since Substrate is built with [the Rust programming language](https://www.rust-lang.org/), the first
@@ -14,7 +14,7 @@ Unix-based operating systems.
 ## Build dependencies
 
 Substrate development is easiest on Unix-based operating systems like macOS or Linux. The examples
-in the [Substrate Docs](https://docs.substrate.io) use Unix-style terminals to demonstrate how to
+in the [Substrate Docs](https://docs.polkadot.com) use Unix-style terminals to demonstrate how to
 interact with Substrate from the command line.
 
 ### Ubuntu/Debian
@@ -76,7 +76,7 @@ brew install openssl
 recommend to use [Windows Subsystem Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 (WSL) and follow the instructions for [Ubuntu/Debian](#ubuntudebian).
 Please refer to the separate
-[guide for native Windows development](https://docs.substrate.io/main-docs/install/windows/).
+[guide for native Windows development](https://docs.polkadot.com/main-docs/install/windows/).
 
 ## Rust developer environment
 
@@ -102,7 +102,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly
 ## Test your set-up
 
 Now the best way to ensure that you have successfully prepared a computer for Substrate
-development is to follow the steps in [our first Substrate tutorial](https://docs.substrate.io/tutorials/v3/create-your-first-substrate-chain/).
+development is to follow the steps in [our first Substrate tutorial](https://docs.polkadot.com/tutorials/v3/create-your-first-substrate-chain/).
 
 ## Troubleshooting Substrate builds
 


### PR DESCRIPTION
## Description

Hey, noticed the old link to the Substrate docs was broken (https://docs.substrate.io/).  
Updated it to the correct one: https://docs.polkadot.com/.  

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
