### PR TITLE
Introduce dynamic EMA parameter that evolves with pool liquidity 

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1684,7 +1684,7 @@ pub mod pallet {
         ///
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
-        #[pallet::call_index(67)]
+        #[pallet::call_index(70)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
         pub fn sudo_set_liquidity_scale_max(
             origin: OriginFor<T>,

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1516,7 +1516,7 @@ pub mod pallet {
             Ok(())
         }
 
-        ///
+        /// Change liquidity scale max for a given subnet.
         ///
         /// # Arguments
         /// * `origin` - The origin of the call, which must be the root account.

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1671,6 +1671,36 @@ pub mod pallet {
             );
             Ok(())
         }
+
+        /// Change liquidity scale max for a given subnet.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which must be the root account.
+        /// * `netuid` - The unique identifier for the subnet.
+        /// * `liquidity_scale_max` - The new maximum liquidity scale value.
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the caller is not the root account.
+        ///
+        /// # Weight
+        /// Weight is handled by the `#[pallet::weight]` attribute.
+        #[pallet::call_index(67)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_liquidity_scale_max(
+            origin: OriginFor<T>,
+            netuid: u16,
+            liquidity_scale_max: u64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            pallet_subtensor::LiquidityScaleMax::<T>::set(netuid, liquidity_scale_max);
+
+            log::debug!(
+                "LiquidityScaleMax( netuid: {:?}, liquidity_scale_max: {:?} )",
+                netuid,
+                liquidity_scale_max
+            );
+            Ok(())
+        }
     }
 }
 

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -139,6 +139,7 @@ parameter_types! {
     pub const InitialDissolveNetworkScheduleDuration: u64 = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const InitialTaoWeight: u64 = u64::MAX/10; // 10% global weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
+    pub const LiquidityScaleMax: u64 = 2000;
     pub const DurationOfStartCall: u64 = 7 * 24 * 60 * 60 / 12; // 7 days
 }
 
@@ -208,6 +209,7 @@ impl pallet_subtensor::Config for Test {
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
+    type LiquidityScaleMax = LiquidityScaleMax;
     type DurationOfStartCall = DurationOfStartCall;
 }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -476,6 +476,11 @@ pub mod pallet {
         T::InitialEmaPriceHalvingPeriod::get()
     }
     #[pallet::type_value]
+    /// Default Liquidity Scale Max factor for which to retain ema
+    pub fn DefaultLiquidityScaleMax<T: Config>() -> u64 {
+        T::LiquidityScaleMax::get()
+    }
+    #[pallet::type_value]
     /// Default registrations this block.
     pub fn DefaultBurn<T: Config>() -> u64 {
         T::InitialBurn::get()
@@ -1448,6 +1453,10 @@ pub mod pallet {
     /// --- MAP ( netuid ) --> Halving time of average moving price.
     pub type EMAPriceHalvingBlocks<T> =
         StorageMap<_, Identity, u16, u64, ValueQuery, DefaultEMAPriceMovingBlocks<T>>;
+    #[pallet::storage]
+    /// --- MAP ( netuid) ) --> Liquidity level at which to remove EMA
+    pub type LiquidityScaleMax<T> =
+        StorageMap<_, Identity, u16, u64, ValueQuery, DefaultLiquidityScaleMax<T>>;
     #[pallet::storage]
     /// --- MAP ( netuid ) --> global_RAO_recycled_for_registration
     pub type RAORecycledForRegistration<T> =

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -221,6 +221,9 @@ mod config {
         /// Initial EMA price halving period
         #[pallet::constant]
         type InitialEmaPriceHalvingPeriod: Get<u64>;
+        /// Maximum liquidity scale after which to drop the EMA
+        #[pallet::constant]
+        type LiquidityScaleMax: Get<u64>;
         /// Block number after a new subnet accept the start call extrinsic.
         #[pallet::constant]
         type DurationOfStartCall: Get<u64>;

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -61,7 +61,7 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-	/// Computes the smoothing factor α for the exponential moving average (EMA)
+    /// Computes the smoothing factor α for the exponential moving average (EMA)
     /// based on current pool liquidity.
     ///
     /// This function implements a custom curve:
@@ -115,7 +115,7 @@ impl<T: Config> Pallet<T> {
         U96F32::saturating_from_num(alpha)
     }
 
-	/// Updates the stored “moving” alpha price for a subnet using a dynamic EMA.
+    /// Updates the stored “moving” alpha price for a subnet using a dynamic EMA.
     ///
     /// Steps performed:
     /// 1. Load raw TAO and α reserves (`SubnetTAO`, `SubnetAlphaIn`) and down-scale by 1e9 (to TAO units)

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -65,7 +65,10 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn compute_alpha_for_ema(l: U96F32, l_max: U96F32) -> U96F32 {
-        // comment this
+        if l >= l_max {
+            return U96F32::saturating_from_num(1);
+        }
+
         let i_l_max = I96F32::saturating_from_num(l_max);
         let i_l = I96F32::saturating_from_num(l);
         let neg_one = I96F32::from_num(-1);

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -60,36 +60,67 @@ impl<T: Config> Pallet<T> {
         }
     }
 
+    pub fn get_l_max() -> U96F32 {
+        U96F32::saturating_from_num(2000)
+    }
+
+    pub fn compute_alpha_for_ema(l: U96F32, l_max: U96F32) -> U96F32 {
+        // comment this
+        let i_l_max = I96F32::saturating_from_num(l_max);
+        let i_l = I96F32::saturating_from_num(l);
+        let neg_one = I96F32::from_num(-1);
+        let two = I96F32::from_num(2);
+        let a = I96F32::from_num(7).saturating_div(two);
+        let b = neg_one;
+        let c = I96F32::from_num(3).saturating_div(two);
+        let d = neg_one.saturating_mul(I96F32::from_num(4));
+        let x = (two.saturating_mul(i_l).saturating_div(i_l_max)).saturating_add(neg_one);
+
+        let x_cubed = x.saturating_mul(x).saturating_mul(x);
+        let f_x = ((a.saturating_mul(x_cubed).saturating_add(b))
+            .saturating_mul(x_cubed)
+            .saturating_add(c))
+        .saturating_mul(x)
+        .saturating_add(d);
+
+        let abs_f_x = f_x.saturating_neg();
+        let exp = abs_f_x.ceil();
+
+        let exp_int = exp.to_num::<u32>();
+        let mut alpha = I96F32::from_num(1);
+        let ten = I96F32::from_num(10);
+
+        for _ in 0..exp_int {
+            alpha = alpha.saturating_div(ten);
+        }
+
+        U96F32::saturating_from_num(alpha)
+    }
+
     pub fn update_moving_price(netuid: u16) {
-        let blocks_since_start_call = U96F32::saturating_from_num({
-            // We expect FirstEmissionBlockNumber to be set earlier, and we take the block when
-            // `start_call` was called (first block before FirstEmissionBlockNumber).
-            let start_call_block = FirstEmissionBlockNumber::<T>::get(netuid)
-                .unwrap_or_default()
-                .saturating_sub(1);
+        let tao_reserves = U96F32::saturating_from_num(SubnetTAO::<T>::get(netuid));
+        let alpha_reserves = U96F32::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
 
-            Self::get_current_block_as_u64().saturating_sub(start_call_block)
-        });
+        let k = tao_reserves.saturating_mul(alpha_reserves);
+        let epsilon: U96F32 = U96F32::from_num(0.0000001); // TODO: how accurate to make this baby
+        let l = checked_sqrt(k, epsilon).unwrap_or(U96F32::from_num(0));
+        let l_max = Self::get_l_max();
+        let alpha = Self::compute_alpha_for_ema(l, l_max);
 
-        // Use halving time hyperparameter. The meaning of this parameter can be best explained under
-        // the assumption of a constant price and SubnetMovingAlpha == 0.5: It is how many blocks it
-        // will take in order for the distance between current EMA of price and current price to shorten
-        // by half.
-        let halving_time = EMAPriceHalvingBlocks::<T>::get(netuid);
-        let current_ma_unsigned = U96F32::saturating_from_num(SubnetMovingAlpha::<T>::get());
-        let alpha: U96F32 = current_ma_unsigned.saturating_mul(blocks_since_start_call.safe_div(
-            blocks_since_start_call.saturating_add(U96F32::saturating_from_num(halving_time)),
-        ));
         // Because alpha = b / (b + h), where b and h > 0, alpha < 1, so 1 - alpha > 0.
         // We can use unsigned type here: U96F32
         let one_minus_alpha: U96F32 = U96F32::saturating_from_num(1.0).saturating_sub(alpha);
-        let current_price: U96F32 = alpha
-            .saturating_mul(Self::get_alpha_price(netuid).min(U96F32::saturating_from_num(1.0)));
-        let current_moving: U96F32 =
-            one_minus_alpha.saturating_mul(Self::get_moving_alpha_price(netuid));
-        // Convert batch to signed I96F32 to avoid migration of SubnetMovingPrice for now``
-        let new_moving: I96F32 =
-            I96F32::saturating_from_num(current_price.saturating_add(current_moving));
+        let moving_price = Self::get_moving_alpha_price(netuid);
+        let current_price = Self::get_alpha_price(netuid);
+        let weighted_current_price: U96F32 = alpha.saturating_mul(current_price);
+        let weighted_current_moving: U96F32 = one_minus_alpha.saturating_mul(moving_price);
+
+        // Convert batch to signed I96F32 to avoid migration of SubnetMovingPrice for now
+        let mut new_moving: I96F32 = I96F32::saturating_from_num(
+            weighted_current_price.saturating_add(weighted_current_moving),
+        );
+
+        new_moving = new_moving.min(I96F32::from_num(current_price));
         SubnetMovingPrice::<T>::insert(netuid, new_moving);
     }
 

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -86,12 +86,12 @@ impl<T: Config> Pallet<T> {
 
         let i_l_max = I96F32::saturating_from_num(liquidity_scale_max);
         let i_l = I96F32::saturating_from_num(l);
-        let neg_one = I96F32::from_num(-1);
-        let two = I96F32::from_num(2);
-        let a = I96F32::from_num(7).safe_div(two);
+        let neg_one = I96F32::saturating_from_num(-1);
+        let two = I96F32::saturating_from_num(2);
+        let a = I96F32::saturating_from_num(7).safe_div(two);
         let b = neg_one;
-        let c = I96F32::from_num(3).safe_div(two);
-        let d = neg_one.saturating_mul(I96F32::from_num(4));
+        let c = I96F32::saturating_from_num(3).safe_div(two);
+        let d = neg_one.saturating_mul(I96F32::saturating_from_num(4));
         let x = (two.saturating_mul(i_l).safe_div(i_l_max)).saturating_add(neg_one);
 
         let x_cubed = x.saturating_mul(x).saturating_mul(x);
@@ -105,8 +105,8 @@ impl<T: Config> Pallet<T> {
         let exp = abs_f_x.ceil();
 
         let exp_int = exp.to_num::<u32>();
-        let mut alpha = I96F32::saturating_to_num(1);
-        let ten = I96F32::saturating_to_num(10);
+        let mut alpha = I96F32::saturating_from_num(1);
+        let ten = I96F32::saturating_from_num(10);
 
         for _ in 0..exp_int {
             alpha = alpha.safe_div(ten);
@@ -140,8 +140,8 @@ impl<T: Config> Pallet<T> {
             alpha_reserves_rao.safe_div(U96F32::saturating_from_num(1_000_000_000));
 
         let k = tao_reserves.saturating_mul(alpha_reserves);
-        let epsilon: U96F32 = U96F32::from_num(0.0000001);
-        let l = checked_sqrt(k, epsilon).unwrap_or(U96F32::from_num(0));
+        let epsilon: U96F32 = U96F32::saturating_from_num(0.0000001);
+        let l = checked_sqrt(k, epsilon).unwrap_or(U96F32::saturating_from_num(0));
         let liquidity_scale_max = U96F32::saturating_from_num(LiquidityScaleMax::<T>::get(netuid));
         let alpha = Self::compute_alpha_for_ema(l, liquidity_scale_max);
 
@@ -155,7 +155,7 @@ impl<T: Config> Pallet<T> {
             weighted_current_price.saturating_add(weighted_current_moving),
         );
 
-        new_moving = new_moving.min(I96F32::from_num(current_price));
+        new_moving = new_moving.min(I96F32::saturating_from_num(current_price));
         SubnetMovingPrice::<T>::insert(netuid, new_moving);
     }
 

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -88,11 +88,11 @@ impl<T: Config> Pallet<T> {
         let i_l = I96F32::saturating_from_num(l);
         let neg_one = I96F32::from_num(-1);
         let two = I96F32::from_num(2);
-        let a = I96F32::from_num(7).saturating_div(two);
+        let a = I96F32::from_num(7).safe_div(two);
         let b = neg_one;
-        let c = I96F32::from_num(3).saturating_div(two);
+        let c = I96F32::from_num(3).safe_div(two);
         let d = neg_one.saturating_mul(I96F32::from_num(4));
-        let x = (two.saturating_mul(i_l).saturating_div(i_l_max)).saturating_add(neg_one);
+        let x = (two.saturating_mul(i_l).safe_div(i_l_max)).saturating_add(neg_one);
 
         let x_cubed = x.saturating_mul(x).saturating_mul(x);
         let f_x = ((a.saturating_mul(x_cubed).saturating_add(b))
@@ -105,11 +105,11 @@ impl<T: Config> Pallet<T> {
         let exp = abs_f_x.ceil();
 
         let exp_int = exp.to_num::<u32>();
-        let mut alpha = I96F32::from_num(1);
-        let ten = I96F32::from_num(10);
+        let mut alpha = I96F32::saturating_to_num(1);
+        let ten = I96F32::saturating_to_num(10);
 
         for _ in 0..exp_int {
-            alpha = alpha.saturating_div(ten);
+            alpha = alpha.safe_div(ten);
         }
 
         U96F32::saturating_from_num(alpha)
@@ -135,10 +135,9 @@ impl<T: Config> Pallet<T> {
     pub fn update_moving_price(netuid: u16) {
         let tao_reserves_rao = U96F32::saturating_from_num(SubnetTAO::<T>::get(netuid));
         let alpha_reserves_rao = U96F32::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
-        let tao_reserves =
-            tao_reserves_rao.saturating_div(U96F32::saturating_from_num(1_000_000_000));
+        let tao_reserves = tao_reserves_rao.safe_div(U96F32::saturating_from_num(1_000_000_000));
         let alpha_reserves =
-            alpha_reserves_rao.saturating_div(U96F32::saturating_from_num(1_000_000_000));
+            alpha_reserves_rao.safe_div(U96F32::saturating_from_num(1_000_000_000));
 
         let k = tao_reserves.saturating_mul(alpha_reserves);
         let epsilon: U96F32 = U96F32::from_num(0.0000001);

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -189,7 +189,7 @@ parameter_types! {
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
     pub const InitialTaoWeight: u64 = 0; // 100% global weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
-    pub const LiquidityScaleMax: u64 = 2000; // TODO: figure out what this value should be
+    pub const LiquidityScaleMax: u64 = 2000;
     pub const DurationOfStartCall: u64 =  7 * 24 * 60 * 60 / 12; // Default as 7 days
 }
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -189,6 +189,7 @@ parameter_types! {
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
     pub const InitialTaoWeight: u64 = 0; // 100% global weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
+    pub const LiquidityScaleMax: u64 = 2000; // TODO: figure out what this value should be
     pub const DurationOfStartCall: u64 =  7 * 24 * 60 * 60 / 12; // Default as 7 days
 }
 
@@ -417,6 +418,7 @@ impl crate::Config for Test {
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
+    type LiquidityScaleMax = LiquidityScaleMax;
     type DurationOfStartCall = DurationOfStartCall;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1091,6 +1091,7 @@ parameter_types! {
     pub const InitialDissolveNetworkScheduleDuration: BlockNumber = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const SubtensorInitialTaoWeight: u64 = 971_718_665_099_567_868; // 0.05267697438728329% tao weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
+    pub const LiquidityScaleMax: u64 = 2000; // TODO: figure out what this should be
     pub const DurationOfStartCall: u64 = if cfg!(feature = "fast-blocks") {
         10 // Only 10 blocks for fast blocks
     } else {
@@ -1164,6 +1165,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialColdkeySwapRescheduleDuration = InitialColdkeySwapRescheduleDuration;
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
+    type LiquidityScaleMax = LiquidityScaleMax;
     type DurationOfStartCall = DurationOfStartCall;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1091,7 +1091,7 @@ parameter_types! {
     pub const InitialDissolveNetworkScheduleDuration: BlockNumber = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const SubtensorInitialTaoWeight: u64 = 971_718_665_099_567_868; // 0.05267697438728329% tao weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
-    pub const LiquidityScaleMax: u64 = 2000; // TODO: figure out what this should be
+    pub const LiquidityScaleMax: u64 = 2000;
     pub const DurationOfStartCall: u64 = if cfg!(feature = "fast-blocks") {
         10 // Only 10 blocks for fast blocks
     } else {


### PR DESCRIPTION
## Description

The EMA parameter (alpha) is more crucial when the pool has low liquidity.  As the pool liquidity increases, the EMA parameter can be relaxed, until we reach a saturation point, where sufficient liquidity means we can eliminate the EMA altogether (i.e. alpha=1.0).  We have a mathematical function that takes the pool liquidity scale as input, and provides the appropriate alpha value (described in detail in the corresponding documentation)

## Related Issue(s)

n/a 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.
<img width="659" alt="image" src="https://github.com/user-attachments/assets/f51beb8f-1419-4d8f-b5a4-c42aae2b443e" />

## Additional Notes

