### PR TITLE
Add `sudo_set_bonds_reset_enabled`

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -84,6 +84,13 @@ pub mod pallet {
             /// Indicates if the Yuma3 enable was enabled or disabled.
             enabled: bool,
         },
+        /// Event emitted when Bonds Reset is toggled.
+        BondsResetToggled {
+            /// The network identifier.
+            netuid: u16,
+            /// Indicates if the Bonds Reset was enabled or disabled.
+            enabled: bool,
+        },
     }
 
     // Errors inform users that something went wrong.
@@ -1596,6 +1603,34 @@ pub mod pallet {
             Self::deposit_event(Event::Yuma3EnableToggled { netuid, enabled });
             log::debug!(
                 "Yuma3EnableToggled( netuid: {:?}, Enabled: {:?} ) ",
+                netuid,
+                enabled
+            );
+            Ok(())
+        }
+
+        /// Enables or disables Bonds Reset for a given subnet.
+        ///
+        /// # Parameters
+        /// - `origin`: The origin of the call, which must be the root account or subnet owner.
+        /// - `netuid`: The unique identifier for the subnet.
+        /// - `enabled`: A boolean flag to enable or disable Bonds Reset.
+        ///
+        /// # Weight
+        /// This function has a fixed weight of 0 and is classified as an operational transaction that does not incur any fees.
+        #[pallet::call_index(70)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_bonds_reset_enabled(
+            origin: OriginFor<T>,
+            netuid: u16,
+            enabled: bool,
+        ) -> DispatchResult {
+            pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin, netuid)?;
+            pallet_subtensor::Pallet::<T>::set_bonds_reset(netuid, enabled);
+
+            Self::deposit_event(Event::BondsResetToggled { netuid, enabled });
+            log::debug!(
+                "BondsResetToggled( netuid: {:?} bonds_reset: {:?} ) ",
                 netuid,
                 enabled
             );

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1786,8 +1786,10 @@ fn test_sudo_set_bonds_reset_enabled() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 1;
         let to_be_set: bool = true;
+        let sn_owner = U256::from(1);
         add_network(netuid, 10);
         let init_value: bool = SubtensorModule::get_bonds_reset(netuid);
+
         assert_eq!(
             AdminUtils::sudo_set_bonds_reset_enabled(
                 <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
@@ -1796,6 +1798,7 @@ fn test_sudo_set_bonds_reset_enabled() {
             ),
             Err(DispatchError::BadOrigin)
         );
+
         assert_ok!(AdminUtils::sudo_set_bonds_reset_enabled(
             <<Test as Config>::RuntimeOrigin>::root(),
             netuid,
@@ -1803,6 +1806,15 @@ fn test_sudo_set_bonds_reset_enabled() {
         ));
         assert_eq!(SubtensorModule::get_bonds_reset(netuid), to_be_set);
         assert_ne!(SubtensorModule::get_bonds_reset(netuid), init_value);
+
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, sn_owner);
+
+        assert_ok!(AdminUtils::sudo_set_bonds_reset_enabled(
+            <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+            netuid,
+            !to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_bonds_reset(netuid), !to_be_set);
     });
 }
 
@@ -1811,8 +1823,10 @@ fn test_sudo_set_yuma3_enabled() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 1;
         let to_be_set: bool = true;
+        let sn_owner = U256::from(1);
         add_network(netuid, 10);
         let init_value: bool = SubtensorModule::get_yuma3_enabled(netuid);
+
         assert_eq!(
             AdminUtils::sudo_set_yuma3_enabled(
                 <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
@@ -1821,6 +1835,7 @@ fn test_sudo_set_yuma3_enabled() {
             ),
             Err(DispatchError::BadOrigin)
         );
+
         assert_ok!(AdminUtils::sudo_set_yuma3_enabled(
             <<Test as Config>::RuntimeOrigin>::root(),
             netuid,
@@ -1828,5 +1843,14 @@ fn test_sudo_set_yuma3_enabled() {
         ));
         assert_eq!(SubtensorModule::get_yuma3_enabled(netuid), to_be_set);
         assert_ne!(SubtensorModule::get_yuma3_enabled(netuid), init_value);
+
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, sn_owner);
+
+        assert_ok!(AdminUtils::sudo_set_yuma3_enabled(
+            <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+            netuid,
+            !to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_yuma3_enabled(netuid), !to_be_set);
     });
 }

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1780,3 +1780,53 @@ fn test_set_sn_owner_hotkey_root() {
         assert_eq!(actual_hotkey, hotkey);
     });
 }
+
+#[test]
+fn test_sudo_set_bonds_reset_enabled() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: bool = true;
+        add_network(netuid, 10);
+        let init_value: bool = SubtensorModule::get_bonds_reset(netuid);
+        assert_eq!(
+            AdminUtils::sudo_set_bonds_reset_enabled(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                netuid,
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+        assert_ok!(AdminUtils::sudo_set_bonds_reset_enabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_bonds_reset(netuid), to_be_set);
+        assert_ne!(SubtensorModule::get_bonds_reset(netuid), init_value);
+    });
+}
+
+#[test]
+fn test_sudo_set_yuma3_enabled() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: bool = true;
+        add_network(netuid, 10);
+        let init_value: bool = SubtensorModule::get_yuma3_enabled(netuid);
+        assert_eq!(
+            AdminUtils::sudo_set_yuma3_enabled(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                netuid,
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+        assert_ok!(AdminUtils::sudo_set_yuma3_enabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_yuma3_enabled(netuid), to_be_set);
+        assert_ne!(SubtensorModule::get_yuma3_enabled(netuid), init_value);
+    });
+}

--- a/precompiles/src/solidity/subnet.abi
+++ b/precompiles/src/solidity/subnet.abi
@@ -88,6 +88,25 @@
 				"type": "uint16"
 			}
 		],
+		"name": "getBondsResetEnabled",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			}
+		],
 		"name": "getCommitRevealWeightsEnabled",
 		"outputs": [
 			{
@@ -575,6 +594,24 @@
 			}
 		],
 		"name": "setBondsMovingAverage",
+		"outputs": [],
+		"stateMutability": "payable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			},
+			{
+				"internalType": "bool",
+				"name": "bondsResetEnabled",
+				"type": "bool"
+			}
+		],
+		"name": "setBondsResetEnabled",
 		"outputs": [],
 		"stateMutability": "payable",
 		"type": "function"

--- a/precompiles/src/solidity/subnet.sol
+++ b/precompiles/src/solidity/subnet.sol
@@ -159,6 +159,14 @@ interface ISubnet {
         bool yuma3Enabled
     ) external payable;
 
+    function getBondsResetEnabled(uint16 netuid) external view returns (bool);
+
+    function setBondsResetEnabled(
+        uint16 netuid, 
+        bool bondsResetEnabled
+    ) external payable;
+
+
     function getAlphaValues(
         uint16 netuid
     ) external view returns (uint16, uint16);

--- a/precompiles/src/subnet.rs
+++ b/precompiles/src/subnet.rs
@@ -577,6 +577,12 @@ where
         Ok(pallet_subtensor::Yuma3On::<R>::get(netuid))
     }
 
+    #[precompile::public("getBondsResetEnabled(uint16)")]
+    #[precompile::view]
+    fn get_bonds_reset_enabled(_: &mut impl PrecompileHandle, netuid: u16) -> EvmResult<bool> {
+        Ok(pallet_subtensor::BondsResetOn::<R>::get(netuid))
+    }
+
     #[precompile::public("setYuma3Enabled(uint16,bool)")]
     #[precompile::payable]
     fn set_yuma3_enabled(
@@ -585,6 +591,21 @@ where
         enabled: bool,
     ) -> EvmResult<()> {
         let call = pallet_admin_utils::Call::<R>::sudo_set_yuma3_enabled { netuid, enabled };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
+    #[precompile::public("setBondsResetEnabled(uint16,bool)")]
+    #[precompile::payable]
+    fn set_bonds_reset_enabled(
+        handle: &mut impl PrecompileHandle,
+        netuid: u16,
+        enabled: bool,
+    ) -> EvmResult<()> {
+        let call = pallet_admin_utils::Call::<R>::sudo_set_bonds_reset_enabled { netuid, enabled };
 
         handle.try_dispatch_runtime_call::<R, _>(
             call,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

Adds `sudo_set_bonds_reset_enabled` to allow SN owners to call this hyperparameter.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.