### PR TITLE
fix: run subnet identity v3 migration (and ignore if already exists)

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -123,7 +123,9 @@ mod hooks {
                 // Fix the root subnet TAO storage value
                 .saturating_add(migrations::migrate_fix_root_subnet_tao::migrate_fix_root_subnet_tao::<T>())
                 // Fix the owner disable the registration
-                .saturating_add(migrations::migrate_set_registration_enable::migrate_set_registration_enable::<T>());
+                .saturating_add(migrations::migrate_set_registration_enable::migrate_set_registration_enable::<T>())
+                // Migrate Subnet Identities to V3
+                .saturating_add(migrations::migrate_subnet_identities_to_v3::migrate_subnet_identities_to_v3::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_subnet_identities_to_v3.rs
+++ b/pallets/subtensor/src/migrations/migrate_subnet_identities_to_v3.rs
@@ -30,6 +30,10 @@ pub fn migrate_subnet_identities_to_v3<T: Config>() -> Weight {
     // -----------------------------
     let old_subnet_identities = SubnetIdentitiesV2::<T>::iter().collect::<Vec<_>>();
     for (netuid, old_subnet_identity) in old_subnet_identities.clone() {
+        // check for existing SubnetIdentitiesV3 entry, skip if found
+        if SubnetIdentitiesV3::<T>::contains_key(netuid) {
+            continue;
+        }
         let new_subnet_identity = SubnetIdentityV3 {
             subnet_name: old_subnet_identity.subnet_name,
             github_repo: old_subnet_identity.github_repo,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -218,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 290,
+    spec_version: 291,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Forgot to actually run the migration in the original PR. New V3 identities already exist, so now ignores if found in the migration file.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.