### PR TITLE
fix: scaling values of alpha precompiles

### DIFF
--- a/precompiles/src/alpha.rs
+++ b/precompiles/src/alpha.rs
@@ -32,14 +32,16 @@ where
             <pallet_subtensor_swap::Pallet<R> as SwapHandler<R::AccountId>>::current_alpha_price(
                 netuid.into(),
             );
-        Ok(U256::from(price.saturating_to_num::<u64>()))
+        let price_scaled = price.saturating_mul(U96F32::saturating_from_num(1_000_000_000));
+        Ok(U256::from(price_scaled.saturating_to_num::<u64>()))
     }
 
     #[precompile::public("getMovingAlphaPrice(uint16)")]
     #[precompile::view]
     fn get_moving_alpha_price(_handle: &mut impl PrecompileHandle, netuid: u16) -> EvmResult<U256> {
         let price: U96F32 = pallet_subtensor::Pallet::<R>::get_moving_alpha_price(netuid.into());
-        Ok(U256::from(price.saturating_to_num::<u64>()))
+        let price_scaled = price.saturating_mul(U96F32::saturating_from_num(1_000_000_000));
+        Ok(U256::from(price_scaled.saturating_to_num::<u64>()))
     }
 
     #[precompile::public("getTaoInPool(uint16)")]
@@ -75,8 +77,8 @@ where
     #[precompile::public("getTaoWeight()")]
     #[precompile::view]
     fn get_tao_weight(_handle: &mut impl PrecompileHandle) -> EvmResult<U256> {
-        let weight = pallet_subtensor::Pallet::<R>::get_tao_weight();
-        Ok(U256::from(weight.saturating_to_num::<u64>()))
+        let tao_weight = pallet_subtensor::TaoWeight::<R>::get();
+        Ok(U256::from(tao_weight))
     }
 
     #[precompile::public("simSwapTaoForAlpha(uint16,uint64)")]


### PR DESCRIPTION
## Description
Alpha precompile was converting the U96F32 price directly to u64 without proper scaling, while the runtime API applies a scaling factor of 1_000_000_000.
Introduced fix to apply proper scaling to getAlphaPrice and getMovingAlphaPrice and pull raw storage value of tao weight. 



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

No breaking change.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules