### PR TITLE
CD: copy WebAssembly artifacts to subtensor-localnet docker image

### DIFF
--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -52,6 +52,10 @@ COPY --from=builder /build/snapshot.json /snapshot.json
 COPY --from=builder /build/scripts/localnet.sh scripts/localnet.sh
 RUN chmod +x /scripts/localnet.sh
 
+# Copy WebAssembly artifacts
+COPY --from=builder /build/target/fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm target/fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+COPY --from=builder /build/target/non-fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm target/non-fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+
 ## Ubdate certificates
 RUN apt-get update && apt-get install -y ca-certificates
 


### PR DESCRIPTION
For upgrading a running network it's required to upload new WebAssembly artifact into the chain.
Those are built anyway right now so it may save time for some of us.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules