### PR TITLE
Install and set toolchain 1.88 as default in `Dockerfile-localnet`

### DIFF
--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -51,6 +51,13 @@ jobs:
         with:
           ref: ${{ env.ref }}
 
+      - name: Show current Git branch
+        run: |
+          echo "==============================="
+          echo "Current Git branch:"
+          git rev-parse --abbrev-ref HEAD
+          echo "==============================="
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: [self-hosted, type-ccx53, type-ccx43, type-ccx33]
+    runs-on: SubtensorCI
 
     steps:
       - name: Determine Docker tag and ref

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -26,7 +26,8 @@ WORKDIR /build
 # Install Rust
 RUN set -o pipefail && curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install
+RUN rustup toolchain install 1.88.0
+RUN rustup default 1.88.0''
 RUN rustup target add wasm32v1-none
 
 ## Build fast-runtime node

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -26,7 +26,7 @@ WORKDIR /build
 # Install Rust
 RUN set -o pipefail && curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install 1.88.0
+RUN rustup toolchain install 1.88.0 --profile minimal
 RUN rustup default 1.88.0''
 RUN rustup target add wasm32v1-none
 


### PR DESCRIPTION
Currently, building a docker image takes 6 hours or more. This needs to be fixed.