### PR TITLE
Make associate_evm_key extrinsic be signed by coldkey

### DIFF
--- a/evm-tests/test/evm-uid.precompile.lookup.test.ts
+++ b/evm-tests/test/evm-uid.precompile.lookup.test.ts
@@ -55,11 +55,12 @@ describe("Test the UID Lookup precompile", () => {
         const signature = await evmWallet.signMessage(concatenatedArray);
         const associateEvmKeyTx = api.tx.SubtensorModule.associate_evm_key({
             netuid: netuid,
+            hotkey: convertPublicKeyToSs58(hotkey.publicKey),
             evm_key: convertToFixedSizeBinary(evmWallet.address, 20),
             block_number: BigInt(blockNumber),
             signature: convertToFixedSizeBinary(signature, 65)
         });
-        const signer = getSignerFromKeypair(hotkey);
+        const signer = getSignerFromKeypair(coldkey);
         await waitForTransactionCompletion(api, associateEvmKeyTx, signer)
             .then(() => { })
             .catch((error) => { console.log(`transaction error ${error}`) });

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2048,11 +2048,12 @@ mod dispatches {
         pub fn associate_evm_key(
             origin: T::RuntimeOrigin,
             netuid: NetUid,
+            hotkey: T::AccountId,
             evm_key: H160,
             block_number: u64,
             signature: Signature,
         ) -> DispatchResult {
-            Self::do_associate_evm_key(origin, netuid, evm_key, block_number, signature)
+            Self::do_associate_evm_key(origin, netuid, hotkey, evm_key, block_number, signature)
         }
 
         /// Recycles alpha from a cold/hot key pair, reducing AlphaOut on a subnet

--- a/pallets/subtensor/src/utils/evm.rs
+++ b/pallets/subtensor/src/utils/evm.rs
@@ -24,11 +24,12 @@ impl<T: Config> Pallet<T> {
 
     /// Associate an EVM key with a hotkey.
     ///
-    /// This function accepts a Signature, which is a signed message containing the hotkey concatenated with
-    /// the hashed block number. It will then attempt to recover the EVM key from the signature and compare it
-    /// with the `evm_key` parameter, and ensures that they match.
+    /// This function accepts a Signature, which is a signed message containing the hotkey
+    /// concatenated with the hashed block number. It will then attempt to recover the EVM key from
+    /// the signature and compare it with the `evm_key` parameter, and ensures that they match.
     ///
-    /// The EVM key is expected to sign the message according to this formula to produce the signature:
+    /// The EVM key is expected to sign the message according to this formula to produce the
+    /// signature:
     /// ```text
     /// keccak_256(hotkey ++ keccak_256(block_number))
     /// ```
@@ -40,15 +41,22 @@ impl<T: Config> Pallet<T> {
     /// * `hotkey` - The hotkey associated with the `origin` coldkey.
     /// * `evm_key` - The EVM address to associate with the `hotkey`.
     /// * `block_number` - The block number used in the `signature`.
-    /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed `block_number`.
+    /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed
+    ///   `block_number`.
     pub fn do_associate_evm_key(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
+        hotkey: T::AccountId,
         evm_key: H160,
         block_number: u64,
         mut signature: Signature,
     ) -> dispatch::DispatchResult {
-        let hotkey = ensure_signed(origin)?;
+        let coldkey = ensure_signed(origin)?;
+
+        ensure!(
+            Self::get_owning_coldkey_for_hotkey(&hotkey) == coldkey,
+            Error::<T>::NonAssociatedColdKey
+        );
 
         // Normalize the v value to 0 or 1
         if signature.0[64] >= 27 {


### PR DESCRIPTION
## Description

Revert changes from [this PR](https://github.com/opentensor/subtensor/pull/1764).


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

`associate_evm_key` extrinsic signature has changed.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.