### PR TITLE
Revert back to ema-prices

### DIFF
--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -51,6 +51,7 @@ impl<T: Config> Pallet<T> {
 
     // Update SubnetEmaTaoFlow if needed and return its value for
     // the current block
+    #[allow(dead_code)]
     fn get_ema_flow(netuid: NetUid) -> I64F64 {
         let current_block: u64 = Self::get_current_block_as_u64();
 
@@ -87,6 +88,7 @@ impl<T: Config> Pallet<T> {
     // Either the minimal EMA flow L = min{Si}, or an artificial
     // cut off at some higher value A (TaoFlowCutoff)
     // L = max {A, min{min{S[i], 0}}}
+    #[allow(dead_code)]
     fn get_lower_limit(ema_flows: &BTreeMap<NetUid, I64F64>) -> I64F64 {
         let zero = I64F64::saturating_from_num(0);
         let min_flow = ema_flows
@@ -178,6 +180,7 @@ impl<T: Config> Pallet<T> {
     }
 
     // Implementation of shares that uses TAO flow
+    #[allow(dead_code)]
     fn get_shares_flow(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
         // Get raw flows
         let ema_flows = subnets_to_emit_to
@@ -210,8 +213,37 @@ impl<T: Config> Pallet<T> {
         offset_flows
     }
 
+    // DEPRECATED: Implementation of shares that uses EMA prices will be gradually deprecated
+    fn get_shares_price_ema(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
+        // Get sum of alpha moving prices
+        let total_moving_prices = subnets_to_emit_to
+            .iter()
+            .map(|netuid| U64F64::saturating_from_num(Self::get_moving_alpha_price(*netuid)))
+            .fold(U64F64::saturating_from_num(0.0), |acc, ema| {
+                acc.saturating_add(ema)
+            });
+        log::debug!("total_moving_prices: {total_moving_prices:?}");
+
+        // Calculate shares.
+        subnets_to_emit_to
+            .iter()
+            .map(|netuid| {
+                let moving_price =
+                    U64F64::saturating_from_num(Self::get_moving_alpha_price(*netuid));
+                log::debug!("moving_price_i: {moving_price:?}");
+
+                let share = moving_price
+                    .checked_div(total_moving_prices)
+                    .unwrap_or(U64F64::saturating_from_num(0));
+
+                (*netuid, share)
+            })
+            .collect::<BTreeMap<NetUid, U64F64>>()
+    }
+
     // Combines ema price method and tao flow method linearly over FlowHalfLife blocks
     pub(crate) fn get_shares(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
-        Self::get_shares_flow(subnets_to_emit_to)
+        // Self::get_shares_flow(subnets_to_emit_to)
+        Self::get_shares_price_ema(subnets_to_emit_to)
     }
 }

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -115,28 +115,28 @@ fn test_coinbase_tao_issuance_base_low() {
 }
 
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::coinbase::test_coinbase_tao_issuance_base_low_flow --exact --show-output --nocapture
-#[test]
-fn test_coinbase_tao_issuance_base_low_flow() {
-    new_test_ext(1).execute_with(|| {
-        let emission = TaoCurrency::from(1_234_567);
-        let subnet_owner_ck = U256::from(1001);
-        let subnet_owner_hk = U256::from(1002);
-        let netuid = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
-        let emission = TaoCurrency::from(1);
+// #[test]
+// fn test_coinbase_tao_issuance_base_low_flow() {
+//     new_test_ext(1).execute_with(|| {
+//         let emission = TaoCurrency::from(1_234_567);
+//         let subnet_owner_ck = U256::from(1001);
+//         let subnet_owner_hk = U256::from(1002);
+//         let netuid = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
+//         let emission = TaoCurrency::from(1);
 
-        // 100% tao flow method
-        let block_num = FlowHalfLife::<Test>::get();
-        SubnetEmaTaoFlow::<Test>::insert(netuid, (block_num, I64F64::from_num(1_000_000_000)));
-        System::set_block_number(block_num);
+//         // 100% tao flow method
+//         let block_num = FlowHalfLife::<Test>::get();
+//         SubnetEmaTaoFlow::<Test>::insert(netuid, (block_num, I64F64::from_num(1_000_000_000)));
+//         System::set_block_number(block_num);
 
-        let tao_in_before = SubnetTAO::<Test>::get(netuid);
-        let total_stake_before = TotalStake::<Test>::get();
-        SubtensorModule::run_coinbase(U96F32::from_num(emission));
-        assert_eq!(SubnetTAO::<Test>::get(netuid), tao_in_before + emission);
-        assert_eq!(TotalIssuance::<Test>::get(), emission);
-        assert_eq!(TotalStake::<Test>::get(), total_stake_before + emission);
-    });
-}
+//         let tao_in_before = SubnetTAO::<Test>::get(netuid);
+//         let total_stake_before = TotalStake::<Test>::get();
+//         SubtensorModule::run_coinbase(U96F32::from_num(emission));
+//         assert_eq!(SubnetTAO::<Test>::get(netuid), tao_in_before + emission);
+//         assert_eq!(TotalIssuance::<Test>::get(), emission);
+//         assert_eq!(TotalStake::<Test>::get(), total_stake_before + emission);
+//     });
+// }
 
 // Test emission distribution across multiple subnets.
 // This test verifies that:
@@ -260,85 +260,85 @@ fn test_coinbase_tao_issuance_different_prices() {
 }
 
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::coinbase::test_coinbase_tao_issuance_different_flows --exact --show-output --nocapture
-#[test]
-fn test_coinbase_tao_issuance_different_flows() {
-    new_test_ext(1).execute_with(|| {
-        let subnet_owner_ck = U256::from(1001);
-        let subnet_owner_hk = U256::from(1002);
-        let netuid1 = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
-        let netuid2 = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
-        let emission = 100_000_000;
+// #[test]
+// fn test_coinbase_tao_issuance_different_flows() {
+//     new_test_ext(1).execute_with(|| {
+//         let subnet_owner_ck = U256::from(1001);
+//         let subnet_owner_hk = U256::from(1002);
+//         let netuid1 = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
+//         let netuid2 = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
+//         let emission = 100_000_000;
 
-        // Setup prices 0.1 and 0.2
-        let initial_tao: u64 = 100_000_u64;
-        let initial_alpha1: u64 = initial_tao * 10;
-        let initial_alpha2: u64 = initial_tao * 5;
-        mock::setup_reserves(netuid1, initial_tao.into(), initial_alpha1.into());
-        mock::setup_reserves(netuid2, initial_tao.into(), initial_alpha2.into());
+//         // Setup prices 0.1 and 0.2
+//         let initial_tao: u64 = 100_000_u64;
+//         let initial_alpha1: u64 = initial_tao * 10;
+//         let initial_alpha2: u64 = initial_tao * 5;
+//         mock::setup_reserves(netuid1, initial_tao.into(), initial_alpha1.into());
+//         mock::setup_reserves(netuid2, initial_tao.into(), initial_alpha2.into());
 
-        // Force the swap to initialize
-        SubtensorModule::swap_tao_for_alpha(
-            netuid1,
-            TaoCurrency::ZERO,
-            1_000_000_000_000.into(),
-            false,
-        )
-        .unwrap();
-        SubtensorModule::swap_tao_for_alpha(
-            netuid2,
-            TaoCurrency::ZERO,
-            1_000_000_000_000.into(),
-            false,
-        )
-        .unwrap();
+//         // Force the swap to initialize
+//         SubtensorModule::swap_tao_for_alpha(
+//             netuid1,
+//             TaoCurrency::ZERO,
+//             1_000_000_000_000.into(),
+//             false,
+//         )
+//         .unwrap();
+//         SubtensorModule::swap_tao_for_alpha(
+//             netuid2,
+//             TaoCurrency::ZERO,
+//             1_000_000_000_000.into(),
+//             false,
+//         )
+//         .unwrap();
 
-        // Set subnet prices to reversed proportion to ensure they don't affect emissions.
-        SubnetMovingPrice::<Test>::insert(netuid1, I96F32::from_num(2));
-        SubnetMovingPrice::<Test>::insert(netuid2, I96F32::from_num(1));
+//         // Set subnet prices to reversed proportion to ensure they don't affect emissions.
+//         SubnetMovingPrice::<Test>::insert(netuid1, I96F32::from_num(2));
+//         SubnetMovingPrice::<Test>::insert(netuid2, I96F32::from_num(1));
 
-        // Set subnet tao flow ema.
-        let block_num = FlowHalfLife::<Test>::get();
-        SubnetEmaTaoFlow::<Test>::insert(netuid1, (block_num, I64F64::from_num(1)));
-        SubnetEmaTaoFlow::<Test>::insert(netuid2, (block_num, I64F64::from_num(2)));
-        System::set_block_number(block_num);
+//         // Set subnet tao flow ema.
+//         let block_num = FlowHalfLife::<Test>::get();
+//         SubnetEmaTaoFlow::<Test>::insert(netuid1, (block_num, I64F64::from_num(1)));
+//         SubnetEmaTaoFlow::<Test>::insert(netuid2, (block_num, I64F64::from_num(2)));
+//         System::set_block_number(block_num);
 
-        // Set normalization exponent to 1 for simplicity
-        FlowNormExponent::<Test>::set(U64F64::from(1_u64));
+//         // Set normalization exponent to 1 for simplicity
+//         FlowNormExponent::<Test>::set(U64F64::from(1_u64));
 
-        // Assert initial TAO reserves.
-        assert_eq!(SubnetTAO::<Test>::get(netuid1), initial_tao.into());
-        assert_eq!(SubnetTAO::<Test>::get(netuid2), initial_tao.into());
-        let total_stake_before = TotalStake::<Test>::get();
+//         // Assert initial TAO reserves.
+//         assert_eq!(SubnetTAO::<Test>::get(netuid1), initial_tao.into());
+//         assert_eq!(SubnetTAO::<Test>::get(netuid2), initial_tao.into());
+//         let total_stake_before = TotalStake::<Test>::get();
 
-        // Run the coinbase with the emission amount.
-        SubtensorModule::run_coinbase(U96F32::from_num(emission));
+//         // Run the coinbase with the emission amount.
+//         SubtensorModule::run_coinbase(U96F32::from_num(emission));
 
-        // Assert tao emission is split evenly.
-        assert_abs_diff_eq!(
-            SubnetTAO::<Test>::get(netuid1),
-            TaoCurrency::from(initial_tao + emission / 3),
-            epsilon = 10.into(),
-        );
-        assert_abs_diff_eq!(
-            SubnetTAO::<Test>::get(netuid2),
-            TaoCurrency::from(initial_tao + 2 * emission / 3),
-            epsilon = 10.into(),
-        );
+//         // Assert tao emission is split evenly.
+//         assert_abs_diff_eq!(
+//             SubnetTAO::<Test>::get(netuid1),
+//             TaoCurrency::from(initial_tao + emission / 3),
+//             epsilon = 10.into(),
+//         );
+//         assert_abs_diff_eq!(
+//             SubnetTAO::<Test>::get(netuid2),
+//             TaoCurrency::from(initial_tao + 2 * emission / 3),
+//             epsilon = 10.into(),
+//         );
 
-        // Prices are low => we limit tao issued (buy alpha with it)
-        let tao_issued = TaoCurrency::from(((0.1 + 0.2) * emission as f64) as u64);
-        assert_abs_diff_eq!(
-            TotalIssuance::<Test>::get(),
-            tao_issued,
-            epsilon = 10.into()
-        );
-        assert_abs_diff_eq!(
-            TotalStake::<Test>::get(),
-            total_stake_before + emission.into(),
-            epsilon = 10.into()
-        );
-    });
-}
+//         // Prices are low => we limit tao issued (buy alpha with it)
+//         let tao_issued = TaoCurrency::from(((0.1 + 0.2) * emission as f64) as u64);
+//         assert_abs_diff_eq!(
+//             TotalIssuance::<Test>::get(),
+//             tao_issued,
+//             epsilon = 10.into()
+//         );
+//         assert_abs_diff_eq!(
+//             TotalStake::<Test>::get(),
+//             total_stake_before + emission.into(),
+//             epsilon = 10.into()
+//         );
+//     });
+// }
 
 // Test moving price updates with different alpha values.
 // This test verifies that:

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 334,
+    spec_version: 335,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Temporarily disable tao flow and go back to ema prices emission algorithm.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

