### PR TITLE
fix: remove duplicate safe_exp function, use exp_safe instead

### DIFF
--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -1592,8 +1592,3 @@ pub fn mat_ema_alpha(
 pub fn safe_ln(value: I32F32) -> I32F32 {
     ln(value).unwrap_or(I32F32::saturating_from_num(0.0))
 }
-
-/// Safe exp function, returns 0 if value is 0.
-pub fn safe_exp(value: I32F32) -> I32F32 {
-    exp(value).unwrap_or(I32F32::saturating_from_num(0.0))
-}

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1477,7 +1477,7 @@ impl<T: Config> Pallet<T> {
 
         // sigmoid = 1. / (1. + e^(-steepness * (combined_diff - 0.5)))
         let sigmoid = one.saturating_div(
-            one.saturating_add(safe_exp(
+            one.saturating_add(exp_safe(
                 alpha_sigmoid_steepness
                     .saturating_div(I32F32::from_num(-100))
                     .saturating_mul(combined_diff.saturating_sub(I32F32::from_num(0.5))),


### PR DESCRIPTION
## Summary
Resolves #2149

## Problem
The codebase has two similar exponentiation functions in `math.rs`:

1. **`exp_safe`** (line 172): Robust implementation with:
   - Input clamping to [-20, 20] range
   - Smart error handling (returns `max_value` for positive overflow, 0 for negative)
   - Existing test coverage in `tests/math.rs`

2. **`safe_exp`** (line 1597): Simple wrapper that:
   - Has no input clamping
   - Always returns 0 on any error

## Solution
- Remove the duplicate `safe_exp` function from `math.rs`
- Update `run_epoch.rs` to use `exp_safe` instead

## Why `exp_safe` is better
1. Clamps input to prevent overflow in the first place
2. Returns `max_value` (not 0) when large positive inputs would overflow - more mathematically correct
3. Has existing test coverage

## Testing
- `cargo check -p pallet-subtensor` passes
- Existing `exp_safe` tests in `tests/math.rs` provide coverage

Contribution by Gittensor, learn more at https://gittensor.io/