### PR TITLE
hotfix: taoflow calc to use original methodology with user LPs now re…

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -692,9 +692,6 @@ impl<T: Config> Pallet<T> {
         price_limit: TaoCurrency,
         drop_fees: bool,
     ) -> Result<TaoCurrency, DispatchError> {
-        // Record the protocol TAO before the swap.
-        let protocol_tao = Self::get_protocol_tao(netuid);
-
         //  Decrease alpha on subnet
         let actual_alpha_decrease =
             Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
@@ -702,13 +699,6 @@ impl<T: Config> Pallet<T> {
         // Swap the alpha for TAO.
         let swap_result =
             Self::swap_alpha_for_tao(netuid, actual_alpha_decrease, price_limit, drop_fees)?;
-
-        // Record the protocol TAO after the swap.
-        let protocol_tao_after = Self::get_protocol_tao(netuid);
-        // This should decrease as we are removing TAO from the protocol.
-        let protocol_tao_delta: TaoCurrency = protocol_tao.saturating_sub(protocol_tao_after);
-        // Use max to overstate the TAO flow from the protocol.
-        let tao_flow = protocol_tao_delta.max(swap_result.amount_paid_out.into());
 
         // Refund the unused alpha (in case if limit price is hit)
         let refund = actual_alpha_decrease.saturating_sub(
@@ -736,7 +726,7 @@ impl<T: Config> Pallet<T> {
         // }
 
         // Record TAO outflow
-        Self::record_tao_outflow(netuid, tao_flow);
+        Self::record_tao_outflow(netuid, swap_result.amount_paid_out.into());
 
         LastColdkeyHotkeyStakeBlock::<T>::insert(coldkey, hotkey, Self::get_current_block_as_u64());
 
@@ -775,19 +765,8 @@ impl<T: Config> Pallet<T> {
         set_limit: bool,
         drop_fees: bool,
     ) -> Result<AlphaCurrency, DispatchError> {
-        // Record the protocol TAO before the swap.
-        let protocol_tao = Self::get_protocol_tao(netuid);
-
         // Swap the tao to alpha.
         let swap_result = Self::swap_tao_for_alpha(netuid, tao, price_limit, drop_fees)?;
-
-        // Record the protocol TAO after the swap.
-        let protocol_tao_after = Self::get_protocol_tao(netuid);
-
-        // This should increase as we are adding TAO to the protocol.
-        let protocol_tao_delta: TaoCurrency = protocol_tao_after.saturating_sub(protocol_tao);
-        // Use min to understate the TAO flow into the protocol.
-        let tao_flow = protocol_tao_delta.min(tao);
 
         ensure!(
             !swap_result.amount_paid_out.is_zero(),
@@ -824,7 +803,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // Record TAO inflow
-        Self::record_tao_inflow(netuid, tao_flow);
+        Self::record_tao_inflow(netuid, swap_result.amount_paid_in.into());
 
         LastColdkeyHotkeyStakeBlock::<T>::insert(coldkey, hotkey, Self::get_current_block_as_u64());
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 351,
+    spec_version: 352,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
…solved

## Description
Revert taoflow's flow calculation to use the original `swap_result.amount_paid_in` and `swap_result.amount_paid_out` rather than measuring protocol position delta.  


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.