### PR TITLE
fix: add missing RootClaim to ProxyType TryFrom<u8>

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -184,6 +184,7 @@ impl TryFrom<u8> for ProxyType {
             14 => Ok(Self::SudoUncheckedSetCode),
             15 => Ok(Self::SwapHotkey),
             16 => Ok(Self::SubnetLeaseBeneficiary),
+            17 => Ok(Self::RootClaim),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
The `RootClaim` variant was missing from the `TryFrom<u8>` implementation for `ProxyType`.

This adds `17 => Ok(Self::RootClaim)` to match the enum definition.