### PR TITLE
feat: add sudo call to disable emissions for a subnet

### DIFF
--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -645,5 +645,17 @@ mod benchmarks {
         ); /* sudo_set_min_non_immune_uids() */
     }
 
+    #[benchmark]
+    fn sudo_set_emissions_disabled() {
+        pallet_subtensor::Pallet::<T>::set_admin_freeze_window(0);
+        pallet_subtensor::Pallet::<T>::init_new_network(
+            1u16.into(), /*netuid*/
+            1u16,        /*tempo*/
+        );
+
+        #[extrinsic_call]
+        _(RawOrigin::Root, 1u16.into()/*netuid*/, true/*disabled*/)/*sudo_set_emissions_disabled*/;
+    }
+
     //impl_benchmark_test_suite!(AdminUtils, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2246,7 +2246,7 @@ pub mod pallet {
         /// When emissions are disabled, the subnet will not receive any TAO emissions.
         #[pallet::call_index(85)]
         #[pallet::weight((
-            Weight::from_parts(7_343_000, 0)
+            Weight::from_parts(17_230_000, 0)
                 .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(2))
                 .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
             DispatchClass::Operational,

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2247,7 +2247,7 @@ pub mod pallet {
         #[pallet::call_index(85)]
         #[pallet::weight((
             Weight::from_parts(7_343_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(1))
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(2))
                 .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
             DispatchClass::Operational,
             Pays::Yes
@@ -2262,6 +2262,12 @@ pub mod pallet {
                 pallet_subtensor::Pallet::<T>::if_subnet_exist(netuid),
                 Error::<T>::SubnetDoesNotExist
             );
+
+            let current_value = pallet_subtensor::Pallet::<T>::get_emissions_disabled(netuid);
+            if current_value == disabled {
+                return Ok(());
+            }
+
             pallet_subtensor::Pallet::<T>::set_emissions_disabled(netuid, disabled);
             log::debug!(
                 "sudo_set_emissions_disabled( netuid: {netuid:?}, disabled: {disabled:?} ) "

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2240,6 +2240,34 @@ pub mod pallet {
             pallet_subtensor::Pallet::<T>::set_min_non_immune_uids(netuid, min);
             Ok(())
         }
+
+        /// Enables or disables emissions for a specific subnet.
+        /// It is only callable by the root account (sudo).
+        /// When emissions are disabled, the subnet will not receive any TAO emissions.
+        #[pallet::call_index(85)]
+        #[pallet::weight((
+            Weight::from_parts(7_343_000, 0)
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(1))
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
+            DispatchClass::Operational,
+            Pays::Yes
+        ))]
+        pub fn sudo_set_emissions_disabled(
+            origin: OriginFor<T>,
+            netuid: NetUid,
+            disabled: bool,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            ensure!(
+                pallet_subtensor::Pallet::<T>::if_subnet_exist(netuid),
+                Error::<T>::SubnetDoesNotExist
+            );
+            pallet_subtensor::Pallet::<T>::set_emissions_disabled(netuid, disabled);
+            log::debug!(
+                "sudo_set_emissions_disabled( netuid: {netuid:?}, disabled: {disabled:?} ) "
+            );
+            Ok(())
+        }
     }
 }
 

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2943,3 +2943,38 @@ fn test_sudo_set_emissions_disabled_subnet_not_exist() {
         );
     });
 }
+
+#[test]
+fn test_sudo_set_emissions_disabled_same_value() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        add_network(netuid, 10);
+
+        // Default value is false
+        assert!(!SubtensorModule::get_emissions_disabled(netuid));
+
+        // Setting to same value (false) should succeed without changing anything
+        assert_ok!(AdminUtils::sudo_set_emissions_disabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            false
+        ));
+        assert!(!SubtensorModule::get_emissions_disabled(netuid));
+
+        // Now disable emissions
+        assert_ok!(AdminUtils::sudo_set_emissions_disabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            true
+        ));
+        assert!(SubtensorModule::get_emissions_disabled(netuid));
+
+        // Setting to same value (true) should succeed without changing anything
+        assert_ok!(AdminUtils::sudo_set_emissions_disabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            true
+        ));
+        assert!(SubtensorModule::get_emissions_disabled(netuid));
+    });
+}

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -314,6 +314,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 15. Mechanism step / emissions bookkeeping.
         FirstEmissionBlockNumber::<T>::remove(netuid);
+        EmissionsDisabled::<T>::remove(netuid);
         PendingValidatorEmission::<T>::remove(netuid);
         PendingServerEmission::<T>::remove(netuid);
         PendingRootAlphaDivs::<T>::remove(netuid);

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -8,11 +8,13 @@ impl<T: Config> Pallet<T> {
     pub fn get_subnets_to_emit_to(subnets: &[NetUid]) -> Vec<NetUid> {
         // Filter out root subnet.
         // Filter out subnets with no first emission block number.
+        // Filter out subnets with emissions disabled.
         subnets
             .iter()
             .filter(|netuid| !netuid.is_root())
             .filter(|netuid| FirstEmissionBlockNumber::<T>::get(*netuid).is_some())
             .filter(|netuid| SubtokenEnabled::<T>::get(*netuid))
+            .filter(|netuid| !EmissionsDisabled::<T>::get(*netuid))
             .filter(|&netuid| {
                 // Only emit TAO if the subnetwork allows registration.
                 Self::get_network_registration_allowed(*netuid)

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1587,6 +1587,11 @@ pub mod pallet {
     pub type FirstEmissionBlockNumber<T: Config> =
         StorageMap<_, Identity, NetUid, u64, OptionQuery>;
 
+    /// --- MAP ( netuid ) --> emissions_disabled | Whether emissions are disabled for this subnet
+    #[pallet::storage]
+    pub type EmissionsDisabled<T: Config> =
+        StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultFalse<T>>;
+
     /// --- MAP ( netuid ) --> subnet mechanism
     #[pallet::storage]
     pub type SubnetMechanism<T: Config> =

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -131,6 +131,8 @@ mod events {
         RegistrationAllowed(NetUid, bool),
         /// POW registration is allowed/disallowed for a subnet.
         PowRegistrationAllowed(NetUid, bool),
+        /// emissions are enabled/disabled for a subnet.
+        EmissionsDisabledSet(NetUid, bool),
         /// setting tempo on a network
         TempoSet(NetUid, u16),
         /// setting the RAO recycled for registration.

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -4016,3 +4016,35 @@ fn test_get_subnet_terms_alpha_emissions_cap() {
         assert_eq!(alpha_in.get(&netuid).copied().unwrap(), tao_block_emission);
     });
 }
+
+#[test]
+fn test_get_subnets_to_emit_to_filters_emissions_disabled() {
+    new_test_ext(1).execute_with(|| {
+        let netuid0 = add_dynamic_network(&U256::from(1), &U256::from(2));
+        let netuid1 = add_dynamic_network(&U256::from(3), &U256::from(4));
+
+        // Both subnets should be in the list initially
+        let subnets_to_emit_to_0 = SubtensorModule::get_subnets_to_emit_to(&[netuid0, netuid1]);
+        assert_eq!(subnets_to_emit_to_0.len(), 2);
+        assert!(subnets_to_emit_to_0.contains(&netuid0));
+        assert!(subnets_to_emit_to_0.contains(&netuid1));
+
+        // Disable emissions for netuid0
+        EmissionsDisabled::<Test>::insert(netuid0, true);
+
+        // Check that netuid0 is not in the list
+        let subnets_to_emit_to_1 = SubtensorModule::get_subnets_to_emit_to(&[netuid0, netuid1]);
+        assert_eq!(subnets_to_emit_to_1.len(), 1);
+        assert!(!subnets_to_emit_to_1.contains(&netuid0));
+        assert!(subnets_to_emit_to_1.contains(&netuid1));
+
+        // Re-enable emissions for netuid0
+        EmissionsDisabled::<Test>::insert(netuid0, false);
+
+        // Check that netuid0 is back in the list
+        let subnets_to_emit_to_2 = SubtensorModule::get_subnets_to_emit_to(&[netuid0, netuid1]);
+        assert_eq!(subnets_to_emit_to_2.len(), 2);
+        assert!(subnets_to_emit_to_2.contains(&netuid0));
+        assert!(subnets_to_emit_to_2.contains(&netuid1));
+    });
+}

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -596,6 +596,15 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::PowRegistrationAllowed(netuid, registration_allowed));
     }
 
+    // Emissions Disabled utils
+    pub fn get_emissions_disabled(netuid: NetUid) -> bool {
+        EmissionsDisabled::<T>::get(netuid)
+    }
+    pub fn set_emissions_disabled(netuid: NetUid, disabled: bool) {
+        EmissionsDisabled::<T>::insert(netuid, disabled);
+        Self::deposit_event(Event::EmissionsDisabledSet(netuid, disabled));
+    }
+
     pub fn get_target_registrations_per_interval(netuid: NetUid) -> u16 {
         TargetRegistrationsPerInterval::<T>::get(netuid)
     }


### PR DESCRIPTION
## Description

This PR implements a new sudo call `sudo_set_emissions_disabled` that allows root to disable or enable TAO emissions for a specific subnet. When emissions are disabled for a subnet, it will be filtered out from the list of subnets that receive emissions during the coinbase process.

Closes #2287

### Implementation Details

#### Storage
- **`EmissionsDisabled`**: New storage map in subtensor pallet (`MAP ( netuid ) --> bool`)
  - Default value: `false` (emissions enabled)
  - Location: `pallets/subtensor/src/lib.rs`

#### Events
- **`EmissionsDisabledSet(NetUid, bool)`**: Emitted when emissions are enabled/disabled for a subnet
  - Location: `pallets/subtensor/src/macros/events.rs`

#### Extrinsics
- **`sudo_set_emissions_disabled(origin, netuid, disabled)`**: New sudo call in admin-utils pallet
  - Call index: 84
  - Access: Root only (`ensure_root`)
  - Validation: Checks subnet exists before modifying
  - Location: `pallets/admin-utils/src/lib.rs`

#### Core Logic Changes
- **`get_subnets_to_emit_to`**: Updated to filter out subnets where `EmissionsDisabled` is `true`
  - Location: `pallets/subtensor/src/coinbase/subnet_emissions.rs`

- **`remove_network`**: Added cleanup for `EmissionsDisabled` storage when subnet is dissolved
  - Location: `pallets/subtensor/src/coinbase/root.rs`

#### Utility Functions
- **`get_emissions_disabled(netuid)`**: Getter for `EmissionsDisabled` storage
- **`set_emissions_disabled(netuid, disabled)`**: Setter that also emits the event
  - Location: `pallets/subtensor/src/utils/misc.rs`

## Related Issue(s)

- Closes #2287

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Breaking Change

This PR does not introduce a breaking change. The new storage item defaults to `false` (emissions enabled), so existing subnets will continue to receive emissions as before. The new functionality is opt-in via the sudo call.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Testing

### Unit Tests Added

1. **`test_sudo_set_emissions_disabled`** (`pallets/admin-utils/src/tests/mod.rs`)
   - Verifies default value is `false`
   - Verifies non-root cannot call the extrinsic (returns `BadOrigin`)
   - Verifies root can disable emissions
   - Verifies root can re-enable emissions

2. **`test_sudo_set_emissions_disabled_subnet_not_exist`** (`pallets/admin-utils/src/tests/mod.rs`)
   - Verifies error when subnet doesn't exist

3. **`test_get_subnets_to_emit_to_filters_emissions_disabled`** (`pallets/subtensor/src/tests/coinbase.rs`)
   - Verifies subnets with emissions disabled are filtered out
   - Verifies re-enabling emissions adds subnet back to emission list

### Benchmarking

- Added benchmark for `sudo_set_emissions_disabled` in `pallets/admin-utils/src/benchmarking.rs`

### Commands to Run Tests

```bash
# Run admin-utils tests
cargo test -p pallet-admin-utils test_sudo_set_emissions_disabled

# Run subtensor coinbase tests
cargo test -p pallet-subtensor test_get_subnets_to_emit_to_filters_emissions_disabled

# Run clippy
cargo clippy -p pallet-subtensor -p pallet-admin-utils -- -D warnings

# Check formatting
cargo fmt --check -p pallet-subtensor -p pallet-admin-utils
```

## Screenshots (if applicable)

N/A - This is a backend/runtime change with no UI components.

## Additional Notes

### Files Modified

| File | Changes |
|------|---------|
| `pallets/subtensor/src/lib.rs` | Added `EmissionsDisabled` storage map |
| `pallets/subtensor/src/macros/events.rs` | Added `EmissionsDisabledSet` event |
| `pallets/subtensor/src/utils/misc.rs` | Added getter/setter functions |
| `pallets/subtensor/src/coinbase/subnet_emissions.rs` | Added filter for disabled subnets |
| `pallets/subtensor/src/coinbase/root.rs` | Added cleanup in `remove_network` |
| `pallets/admin-utils/src/lib.rs` | Added `sudo_set_emissions_disabled` extrinsic |
| `pallets/admin-utils/src/benchmarking.rs` | Added benchmark |
| `pallets/subtensor/src/tests/coinbase.rs` | Added emission filtering test |
| `pallets/admin-utils/src/tests/mod.rs` | Added sudo call tests |

### Usage Example

```rust
// Disable emissions for subnet 1
AdminUtils::sudo_set_emissions_disabled(
    RuntimeOrigin::root(),
    NetUid::from(1),
    true  // disabled = true
)?;

// Re-enable emissions for subnet 1
AdminUtils::sudo_set_emissions_disabled(
    RuntimeOrigin::root(),
    NetUid::from(1),
    false  // disabled = false
)?;
```