### PR TITLE
Feat/transfer stake destination hotkey

### DIFF
--- a/chain-extensions/src/lib.rs
+++ b/chain-extensions/src/lib.rs
@@ -226,12 +226,13 @@ where
             }
             FunctionId::TransferStakeV1 => {
                 let weight = Weight::from_parts(160_300_000, 0)
-                    .saturating_add(T::DbWeight::get().reads(13_u64))
+                    .saturating_add(T::DbWeight::get().reads(14_u64))
                     .saturating_add(T::DbWeight::get().writes(6_u64));
 
                 env.charge_weight(weight)?;
 
-                let (destination_coldkey, hotkey, origin_netuid, destination_netuid, alpha_amount): (
+                let (destination_coldkey, origin_hotkey, destination_hotkey, origin_netuid, destination_netuid, alpha_amount): (
+                    T::AccountId,
                     T::AccountId,
                     T::AccountId,
                     NetUid,
@@ -244,7 +245,8 @@ where
                 let call_result = pallet_subtensor::Pallet::<T>::transfer_stake(
                     RawOrigin::Signed(env.caller()).into(),
                     destination_coldkey,
-                    hotkey,
+                    origin_hotkey,
+                    destination_hotkey,
                     origin_netuid,
                     destination_netuid,
                     alpha_amount,

--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -487,7 +487,6 @@ fn transfer_stake_success_moves_between_coldkeys() {
             (
                 destination_coldkey,
                 hotkey,
-                hotkey,
                 netuid,
                 netuid,
                 alpha_to_transfer,

--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -478,7 +478,7 @@ fn transfer_stake_success_moves_between_coldkeys() {
         let alpha_to_transfer: AlphaCurrency = (alpha_before.to_u64() / 3).into();
 
         let expected_weight = Weight::from_parts(160_300_000, 0)
-            .saturating_add(<mock::Test as frame_system::Config>::DbWeight::get().reads(13))
+            .saturating_add(<mock::Test as frame_system::Config>::DbWeight::get().reads(14))
             .saturating_add(<mock::Test as frame_system::Config>::DbWeight::get().writes(6));
 
         let mut env = MockEnv::new(
@@ -486,6 +486,7 @@ fn transfer_stake_success_moves_between_coldkeys() {
             origin_coldkey,
             (
                 destination_coldkey,
+                hotkey,
                 hotkey,
                 netuid,
                 netuid,

--- a/chain-extensions/src/types.rs
+++ b/chain-extensions/src/types.rs
@@ -21,6 +21,7 @@ pub enum FunctionId {
     AddProxyV1 = 13,
     RemoveProxyV1 = 14,
     GetAlphaPriceV1 = 15,
+    TransferStakeV2 = 16,
 }
 
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]

--- a/contract-tests/bittensor/lib.rs
+++ b/contract-tests/bittensor/lib.rs
@@ -68,7 +68,8 @@ pub trait RuntimeReadWrite {
     #[ink(function = 6)]
     fn transfer_stake(
         destination_coldkey: <CustomEnvironment as ink::env::Environment>::AccountId,
-        hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        origin_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        destination_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
         origin_netuid: NetUid,
         destination_netuid: NetUid,
         amount: AlphaCurrency,
@@ -278,7 +279,8 @@ mod bittensor {
         pub fn transfer_stake(
             &self,
             destination_coldkey: [u8; 32],
-            hotkey: [u8; 32],
+            origin_hotkey: [u8; 32],
+            destination_hotkey: [u8; 32],
             origin_netuid: u16,
             destination_netuid: u16,
             amount: u64,
@@ -287,7 +289,8 @@ mod bittensor {
                 .extension()
                 .transfer_stake(
                     destination_coldkey.into(),
-                    hotkey.into(),
+                    origin_hotkey.into(),
+                    destination_hotkey.into(),
                     origin_netuid.into(),
                     destination_netuid.into(),
                     amount.into(),

--- a/docs/wasm-contracts.md
+++ b/docs/wasm-contracts.md
@@ -34,7 +34,8 @@ Subtensor provides a custom chain extension that allows smart contracts to inter
 | 3 | `unstake_all` | Unstake all TAO from a hotkey | `(AccountId)` | Error code |
 | 4 | `unstake_all_alpha` | Unstake all Alpha from a hotkey | `(AccountId)` | Error code |
 | 5 | `move_stake` | Move stake between hotkeys | `(AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
-| 6 | `transfer_stake` | Transfer stake between coldkeys and hotkeys | `(AccountId, AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
+| 6 | `transfer_stake` | Transfer stake between coldkeys (same hotkey) | `(AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
+| 16 | `transfer_stake_v2` | Transfer stake between coldkeys and hotkeys | `(AccountId, AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
 | 7 | `swap_stake` | Swap stake allocations between subnets | `(AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
 | 8 | `add_stake_limit` | Delegate stake with a price limit | `(AccountId, NetUid, TaoCurrency, TaoCurrency, bool)` | Error code |
 | 9 | `remove_stake_limit` | Withdraw stake with a price limit | `(AccountId, NetUid, AlphaCurrency, TaoCurrency, bool)` | Error code |

--- a/docs/wasm-contracts.md
+++ b/docs/wasm-contracts.md
@@ -34,7 +34,7 @@ Subtensor provides a custom chain extension that allows smart contracts to inter
 | 3 | `unstake_all` | Unstake all TAO from a hotkey | `(AccountId)` | Error code |
 | 4 | `unstake_all_alpha` | Unstake all Alpha from a hotkey | `(AccountId)` | Error code |
 | 5 | `move_stake` | Move stake between hotkeys | `(AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
-| 6 | `transfer_stake` | Transfer stake between coldkeys | `(AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
+| 6 | `transfer_stake` | Transfer stake between coldkeys and hotkeys | `(AccountId, AccountId, AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
 | 7 | `swap_stake` | Swap stake allocations between subnets | `(AccountId, NetUid, NetUid, AlphaCurrency)` | Error code |
 | 8 | `add_stake_limit` | Delegate stake with a price limit | `(AccountId, NetUid, TaoCurrency, TaoCurrency, bool)` | Error code |
 | 9 | `remove_stake_limit` | Withdraw stake with a price limit | `(AccountId, NetUid, AlphaCurrency, TaoCurrency, bool)` | Error code |

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1636,13 +1636,14 @@ mod dispatches {
             )
         }
 
-        /// Transfers a specified amount of stake from one coldkey to another, optionally across subnets,
-        /// while keeping the same hotkey.
+        /// Transfers a specified amount of stake from one coldkey to another, optionally across subnets
+        /// and hotkeys.
         ///
         /// # Arguments
         /// * `origin` - The origin of the transaction, which must be signed by the `origin_coldkey`.
         /// * `destination_coldkey` - The coldkey to which the stake is transferred.
-        /// * `hotkey` - The hotkey associated with the stake.
+        /// * `origin_hotkey` - The hotkey from which the stake is being transferred.
+        /// * `destination_hotkey` - The hotkey to which the stake is being transferred.
         /// * `origin_netuid` - The network/subnet ID to move stake from.
         /// * `destination_netuid` - The network/subnet ID to move stake to (for cross-subnet transfer).
         /// * `alpha_amount` - The amount of stake to transfer.
@@ -1651,20 +1652,21 @@ mod dispatches {
         /// Returns an error if:
         /// * The origin is not signed by the correct coldkey.
         /// * Either subnet does not exist.
-        /// * The hotkey does not exist.
-        /// * There is insufficient stake on `(origin_coldkey, hotkey, origin_netuid)`.
+        /// * Either hotkey does not exist.
+        /// * There is insufficient stake on `(origin_coldkey, origin_hotkey, origin_netuid)`.
         /// * The transfer amount is below the minimum stake requirement.
         ///
         /// # Events
         /// May emit a `StakeTransferred` event on success.
         #[pallet::call_index(86)]
         #[pallet::weight((Weight::from_parts(160_300_000, 0)
-        .saturating_add(T::DbWeight::get().reads(13_u64))
+        .saturating_add(T::DbWeight::get().reads(14_u64))
         .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn transfer_stake(
             origin: T::RuntimeOrigin,
             destination_coldkey: T::AccountId,
-            hotkey: T::AccountId,
+            origin_hotkey: T::AccountId,
+            destination_hotkey: T::AccountId,
             origin_netuid: NetUid,
             destination_netuid: NetUid,
             alpha_amount: AlphaCurrency,
@@ -1672,7 +1674,8 @@ mod dispatches {
             Self::do_transfer_stake(
                 origin,
                 destination_coldkey,
-                hotkey,
+                origin_hotkey,
+                destination_hotkey,
                 origin_netuid,
                 destination_netuid,
                 alpha_amount,

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -274,10 +274,11 @@ mod events {
         /// - **error**: The dispatch error emitted by the failed item.
         BatchWeightItemFailed(sp_runtime::DispatchError),
 
-        /// Stake has been transferred from one coldkey to another on the same subnet.
+        /// Stake has been transferred from one coldkey to another, optionally across hotkeys and subnets.
         /// Parameters:
-        /// (origin_coldkey, destination_coldkey, hotkey, origin_netuid, destination_netuid, amount)
+        /// (origin_coldkey, destination_coldkey, origin_hotkey, destination_hotkey, origin_netuid, destination_netuid, amount)
         StakeTransferred(
+            T::AccountId,
             T::AccountId,
             T::AccountId,
             T::AccountId,

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -93,13 +93,14 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Transfers stake from one coldkey to another, optionally moving from one subnet to another,
-    /// while keeping the same hotkey.
+    /// Transfers stake from one coldkey to another, optionally moving from one subnet to another
+    /// and from one hotkey to another.
     ///
     /// # Arguments
     /// * `origin` - The origin of the transaction, which must be signed by the `origin_coldkey`.
     /// * `destination_coldkey` - The account ID of the coldkey to which the stake is being transferred.
-    /// * `hotkey` - The account ID of the hotkey associated with this stake.
+    /// * `origin_hotkey` - The account ID of the hotkey from which the stake is being transferred.
+    /// * `destination_hotkey` - The account ID of the hotkey to which the stake is being transferred.
     /// * `origin_netuid` - The network ID (subnet) from which the stake is being transferred.
     /// * `destination_netuid` - The network ID (subnet) to which the stake is being transferred.
     /// * `alpha_amount` - The amount of stake to transfer.
@@ -111,8 +112,8 @@ impl<T: Config> Pallet<T> {
     /// This function will return an error if:
     /// * The transaction is not signed by the `origin_coldkey`.
     /// * The subnet (`origin_netuid` or `destination_netuid`) does not exist.
-    /// * The `hotkey` does not exist.
-    /// * The `(origin_coldkey, hotkey, origin_netuid)` does not have enough stake for `alpha_amount`.
+    /// * Either `origin_hotkey` or `destination_hotkey` does not exist.
+    /// * The `(origin_coldkey, origin_hotkey, origin_netuid)` does not have enough stake for `alpha_amount`.
     /// * The amount to be transferred is below the minimum stake requirement.
     /// * There is a failure in staking or unstaking logic.
     ///
@@ -121,7 +122,8 @@ impl<T: Config> Pallet<T> {
     pub fn do_transfer_stake(
         origin: T::RuntimeOrigin,
         destination_coldkey: T::AccountId,
-        hotkey: T::AccountId,
+        origin_hotkey: T::AccountId,
+        destination_hotkey: T::AccountId,
         origin_netuid: NetUid,
         destination_netuid: NetUid,
         alpha_amount: AlphaCurrency,
@@ -133,8 +135,8 @@ impl<T: Config> Pallet<T> {
         let tao_moved = Self::transition_stake_internal(
             &coldkey,
             &destination_coldkey,
-            &hotkey,
-            &hotkey,
+            &origin_hotkey,
+            &destination_hotkey,
             origin_netuid,
             destination_netuid,
             alpha_amount,
@@ -144,20 +146,21 @@ impl<T: Config> Pallet<T> {
             false,
         )?;
 
-        // 9. Emit an event for logging/monitoring.
+        // Emit an event for logging/monitoring.
         log::debug!(
-            "StakeTransferred(origin_coldkey: {coldkey:?}, destination_coldkey: {destination_coldkey:?}, hotkey: {hotkey:?}, origin_netuid: {origin_netuid:?}, destination_netuid: {destination_netuid:?}, amount: {tao_moved:?})"
+            "StakeTransferred(origin_coldkey: {coldkey:?}, destination_coldkey: {destination_coldkey:?}, origin_hotkey: {origin_hotkey:?}, destination_hotkey: {destination_hotkey:?}, origin_netuid: {origin_netuid:?}, destination_netuid: {destination_netuid:?}, amount: {tao_moved:?})"
         );
         Self::deposit_event(Event::StakeTransferred(
             coldkey,
             destination_coldkey,
-            hotkey,
+            origin_hotkey,
+            destination_hotkey,
             origin_netuid,
             destination_netuid,
             tao_moved,
         ));
 
-        // 10. Return success.
+        // Return success.
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -538,6 +538,7 @@ fn test_subtoken_enable_reject_trading_before_enable() {
                 RuntimeOrigin::signed(coldkey_account_id),
                 hotkey_account_id,
                 hotkey_account_2_id,
+                hotkey_account_2_id,
                 netuid,
                 netuid2,
                 amount.into(),
@@ -658,6 +659,7 @@ fn test_subtoken_enable_trading_ok_with_enable() {
         assert_ok!(SubtensorModule::transfer_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
+            hotkey_account_2_id,
             hotkey_account_2_id,
             netuid,
             netuid2,

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -2335,7 +2335,8 @@ fn test_coldkey_in_swap_schedule_prevents_funds_usage() {
         // Transfer stake
         let call = RuntimeCall::SubtensorModule(SubtensorCall::transfer_stake {
             destination_coldkey: new_coldkey,
-            hotkey,
+            origin_hotkey: hotkey,
+            destination_hotkey: hotkey,
             origin_netuid: netuid,
             destination_netuid: netuid,
             alpha_amount: stake.into(),

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -264,10 +264,11 @@ impl<F, OU> SubtensorTxFeeHandler<F, OU> {
             }) => alpha_vec.push((origin_hotkey.clone(), *origin_netuid)),
             Some(SubtensorCall::transfer_stake {
                 destination_coldkey: _,
-                hotkey,
+                origin_hotkey,
+                destination_hotkey: _,
                 origin_netuid,
                 ..
-            }) => alpha_vec.push((hotkey.clone(), *origin_netuid)),
+            }) => alpha_vec.push((origin_hotkey.clone(), *origin_netuid)),
             Some(SubtensorCall::swap_stake {
                 hotkey,
                 origin_netuid,

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -901,7 +901,8 @@ fn test_transfer_stake_fees_alpha() {
         );
         let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::transfer_stake {
             destination_coldkey,
-            hotkey: sn.hotkeys[0],
+            origin_hotkey: sn.hotkeys[0],
+            destination_hotkey: sn.hotkeys[0],
             origin_netuid: sn.subnets[0].netuid,
             destination_netuid: sn.subnets[1].netuid,
             alpha_amount: unstake_amount,

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -80,16 +80,17 @@ interface IStaking {
 
     /**
      * @dev Transfer a subtensor stake `amount` associated with the transaction signer to a different coldkey
-     * `destination_coldkey`.
+     * `destination_coldkey` and optionally a different hotkey `destination_hotkey`.
      *
-     * This function allows external accounts and contracts to transfer staked TAO to another coldkey,
+     * This function allows external accounts and contracts to transfer staked TAO to another coldkey and hotkey,
      * which effectively calls `transfer_stake` on the subtensor pallet with specified destination
-     * coldkey as a parameter being the hashed address mapping of H160 sender address to Substrate ss58
+     * coldkey and hotkey as parameters being the hashed address mapping of H160 sender address to Substrate ss58
      * address as implemented in Frontier HashedAddressMapping:
      * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
      *
      * @param destination_coldkey The destination coldkey public key (32 bytes).
-     * @param hotkey The hotkey public key (32 bytes).
+     * @param origin_hotkey The origin hotkey public key (32 bytes).
+     * @param destination_hotkey The destination hotkey public key (32 bytes).
      * @param origin_netuid The subnet to move stake from (uint256).
      * @param destination_netuid The subnet to move stake to (uint256).
      * @param amount The amount to move in rao.
@@ -100,7 +101,8 @@ interface IStaking {
      */
     function transferStake(
         bytes32 destination_coldkey,
-        bytes32 hotkey,
+        bytes32 origin_hotkey,
+        bytes32 destination_hotkey,
         uint256 origin_netuid,
         uint256 destination_netuid,
         uint256 amount

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -80,6 +80,34 @@ interface IStaking {
 
     /**
      * @dev Transfer a subtensor stake `amount` associated with the transaction signer to a different coldkey
+     * `destination_coldkey` while keeping the same hotkey.
+     *
+     * This function allows external accounts and contracts to transfer staked TAO to another coldkey,
+     * which effectively calls `transfer_stake` on the subtensor pallet with specified destination
+     * coldkey as a parameter being the hashed address mapping of H160 sender address to Substrate ss58
+     * address as implemented in Frontier HashedAddressMapping:
+     * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
+     *
+     * @param destination_coldkey The destination coldkey public key (32 bytes).
+     * @param hotkey The hotkey public key (32 bytes).
+     * @param origin_netuid The subnet to move stake from (uint256).
+     * @param destination_netuid The subnet to move stake to (uint256).
+     * @param amount The amount to move in rao.
+     *
+     * Requirements:
+     * - `hotkey` must be a valid hotkey registered on the network, ensuring
+     * that the stake is correctly attributed.
+     */
+    function transferStake(
+        bytes32 destination_coldkey,
+        bytes32 hotkey,
+        uint256 origin_netuid,
+        uint256 destination_netuid,
+        uint256 amount
+    ) external payable;
+
+    /**
+     * @dev Transfer a subtensor stake `amount` associated with the transaction signer to a different coldkey
      * `destination_coldkey` and optionally a different hotkey `destination_hotkey`.
      *
      * This function allows external accounts and contracts to transfer staked TAO to another coldkey and hotkey,
@@ -99,7 +127,7 @@ interface IStaking {
      * - `origin_hotkey` and `destination_hotkey` must be valid hotkeys registered on the network, ensuring
      * that the stake is correctly attributed.
      */
-    function transferStake(
+    function transferStakeV2(
         bytes32 destination_coldkey,
         bytes32 origin_hotkey,
         bytes32 destination_hotkey,

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -190,25 +190,28 @@ where
         handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
     }
 
-    #[precompile::public("transferStake(bytes32,bytes32,uint256,uint256,uint256)")]
+    #[precompile::public("transferStake(bytes32,bytes32,bytes32,uint256,uint256,uint256)")]
     #[precompile::payable]
     fn transfer_stake(
         handle: &mut impl PrecompileHandle,
         destination_coldkey: H256,
-        hotkey: H256,
+        origin_hotkey: H256,
+        destination_hotkey: H256,
         origin_netuid: U256,
         destination_netuid: U256,
         amount_alpha: U256,
     ) -> EvmResult<()> {
         let account_id = handle.caller_account_id::<R>();
         let destination_coldkey = R::AccountId::from(destination_coldkey.0);
-        let hotkey = R::AccountId::from(hotkey.0);
+        let origin_hotkey = R::AccountId::from(origin_hotkey.0);
+        let destination_hotkey = R::AccountId::from(destination_hotkey.0);
         let origin_netuid = try_u16_from_u256(origin_netuid)?;
         let destination_netuid = try_u16_from_u256(destination_netuid)?;
         let alpha_amount: u64 = amount_alpha.unique_saturated_into();
         let call = pallet_subtensor::Call::<R>::transfer_stake {
             destination_coldkey,
-            hotkey,
+            origin_hotkey,
+            destination_hotkey,
             origin_netuid: origin_netuid.into(),
             destination_netuid: destination_netuid.into(),
             alpha_amount: alpha_amount.into(),

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -190,9 +190,39 @@ where
         handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
     }
 
-    #[precompile::public("transferStake(bytes32,bytes32,bytes32,uint256,uint256,uint256)")]
+    /// Backward-compatible transferStake with 5 parameters (same hotkey for origin and destination)
+    #[precompile::public("transferStake(bytes32,bytes32,uint256,uint256,uint256)")]
     #[precompile::payable]
     fn transfer_stake(
+        handle: &mut impl PrecompileHandle,
+        destination_coldkey: H256,
+        hotkey: H256,
+        origin_netuid: U256,
+        destination_netuid: U256,
+        amount_alpha: U256,
+    ) -> EvmResult<()> {
+        let account_id = handle.caller_account_id::<R>();
+        let destination_coldkey = R::AccountId::from(destination_coldkey.0);
+        let hotkey = R::AccountId::from(hotkey.0);
+        let origin_netuid = try_u16_from_u256(origin_netuid)?;
+        let destination_netuid = try_u16_from_u256(destination_netuid)?;
+        let alpha_amount: u64 = amount_alpha.unique_saturated_into();
+        let call = pallet_subtensor::Call::<R>::transfer_stake {
+            destination_coldkey,
+            origin_hotkey: hotkey.clone(),
+            destination_hotkey: hotkey,
+            origin_netuid: origin_netuid.into(),
+            destination_netuid: destination_netuid.into(),
+            alpha_amount: alpha_amount.into(),
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+    }
+
+    /// New transferStakeV2 with 6 parameters (allows different origin and destination hotkeys)
+    #[precompile::public("transferStakeV2(bytes32,bytes32,bytes32,uint256,uint256,uint256)")]
+    #[precompile::payable]
+    fn transfer_stake_v2(
         handle: &mut impl PrecompileHandle,
         destination_coldkey: H256,
         origin_hotkey: H256,


### PR DESCRIPTION
## Description

When using `transfer_stake`, users previously couldn't specify a destination hotkey - the stake would transfer to a new coldkey but remain on the original hotkey. This was problematic because the new coldkey doesn't own that hotkey, so the stake wouldn't show up in btcli commands for the recipient.

This PR adds a `destination_hotkey` parameter to `transfer_stake`, allowing users to transfer stake to both a different coldkey AND a different hotkey in a single operation. This makes the transfer actually useful - recipients can now receive stake on their own hotkey.

### What changed

The `transfer_stake` extrinsic now accepts:
- `destination_coldkey` - who receives the stake
- `origin_hotkey` - the hotkey to take stake from
- `destination_hotkey` - the hotkey to put stake on (NEW)
- `origin_netuid` / `destination_netuid` - subnet IDs
- `alpha_amount` - amount to transfer

Previously, the single `hotkey` parameter was used for both origin and destination.

## Related Issue(s)

- Closes #1377

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

This is a breaking change for existing callers of `transfer_stake`:

**Before:**
```rust
transfer_stake(destination_coldkey, hotkey, origin_netuid, destination_netuid, alpha_amount)
```

**After:**
```rust
transfer_stake(destination_coldkey, origin_hotkey, destination_hotkey, origin_netuid, destination_netuid, alpha_amount)
```

**Migration:** Existing callers should pass the same hotkey for both `origin_hotkey` and `destination_hotkey` to maintain the previous behavior.

**Affected interfaces:**
- Substrate extrinsic (call_index 86)
- EVM precompile: `transferStake(bytes32,bytes32,bytes32,uint256,uint256,uint256)`
- Chain extension (function ID 6)
- ink! contract interface

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<img width="798" height="313" alt="Screenshot 2025-12-16 095544" src="https://github.com/user-attachments/assets/0a17bb02-db46-416d-8b59-13bdf70ff020" />

## Additional Notes

### Files changed

| File | Change |
|------|--------|
| `pallets/subtensor/src/macros/dispatches.rs` | Added `destination_hotkey` parameter to dispatch |
| `pallets/subtensor/src/staking/move_stake.rs` | Updated `do_transfer_stake` to use both hotkeys |
| `pallets/subtensor/src/macros/events.rs` | Updated `StakeTransferred` event to include both hotkeys |
| `precompiles/src/staking.rs` | Updated EVM precompile signature |
| `precompiles/src/solidity/stakingV2.sol` | Updated Solidity interface |
| `chain-extensions/src/lib.rs` | Updated chain extension |
| `contract-tests/bittensor/lib.rs` | Updated ink! contract interface |
| `pallets/transaction-fee/src/lib.rs` | Updated pattern matching |
| `docs/wasm-contracts.md` | Updated documentation |
| Test files | Updated all tests + added new test |

### Why this matters

Before this change, if Alice transferred stake to Bob, the stake would end up on Alice's hotkey but owned by Bob's coldkey. Bob couldn't see or manage this stake easily because his btcli commands filter by his own hotkeys.

Now, Alice can transfer stake directly to Bob's hotkey, making the transfer actually useful for the recipient.
