### PR TITLE
fix: ensure burn/recycle at most amount

### DIFF
--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -266,5 +266,7 @@ mod errors {
         InvalidRootClaimThreshold,
         /// Exceeded subnet limit number or zero.
         InvalidSubnetNumber,
+        /// Unintended precision loss when unstaking alpha
+        PrecisionLoss,
     }
 }

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -55,8 +55,10 @@ impl<T: Config> Pallet<T> {
             &hotkey, &coldkey, netuid, amount,
         );
 
+        ensure!(actual_alpha_decrease <= amount, Error::<T>::PrecisionLoss);
+
         // Recycle means we should decrease the alpha issuance tracker.
-        Self::recycle_subnet_alpha(netuid, amount);
+        Self::recycle_subnet_alpha(netuid, actual_alpha_decrease);
 
         Self::deposit_event(Event::AlphaRecycled(
             coldkey,
@@ -120,7 +122,9 @@ impl<T: Config> Pallet<T> {
             &hotkey, &coldkey, netuid, amount,
         );
 
-        Self::burn_subnet_alpha(netuid, amount);
+        ensure!(actual_alpha_decrease <= amount, Error::<T>::PrecisionLoss);
+
+        Self::burn_subnet_alpha(netuid, actual_alpha_decrease);
 
         // Deposit event
         Self::deposit_event(Event::AlphaBurned(

--- a/pallets/subtensor/src/tests/recycle_alpha.rs
+++ b/pallets/subtensor/src/tests/recycle_alpha.rs
@@ -1,6 +1,7 @@
 use approx::assert_abs_diff_eq;
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use sp_core::U256;
+use substrate_fixed::types::U64F64;
 use subtensor_runtime_common::{AlphaCurrency, Currency as CurrencyT};
 
 use super::mock;
@@ -540,6 +541,88 @@ fn test_burn_errors() {
                 netuid
             ),
             Error::<Test>::InsufficientLiquidity
+        );
+    });
+}
+
+#[test]
+fn test_recycle_precision_loss() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+
+        let netuid = add_dynamic_network(&hotkey, &coldkey);
+
+        Balances::make_free_balance_be(&coldkey, 1_000_000_000);
+        // sanity check
+        assert!(SubtensorModule::if_subnet_exist(netuid));
+
+        // add stake to coldkey-hotkey pair so we can recycle it
+        let stake = 200_000;
+        increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
+
+        // get initial total issuance and alpha out
+        let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
+        let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
+
+        // amount to recycle
+        let recycle_amount = AlphaCurrency::from(stake);
+
+        // Modify the alpha pool denominator so it's low-precision
+        let denominator = U64F64::from_num(0.0000001);
+        TotalHotkeyShares::<Test>::insert(hotkey, netuid, denominator);
+        Alpha::<Test>::insert((&hotkey, &coldkey, netuid), denominator);
+
+        // recycle, expect error due to precision loss
+        assert_noop!(
+            SubtensorModule::recycle_alpha(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                recycle_amount,
+                netuid
+            ),
+            Error::<Test>::PrecisionLoss
+        );
+    });
+}
+
+#[test]
+fn test_burn_precision_loss() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+
+        let netuid = add_dynamic_network(&hotkey, &coldkey);
+
+        Balances::make_free_balance_be(&coldkey, 1_000_000_000);
+        // sanity check
+        assert!(SubtensorModule::if_subnet_exist(netuid));
+
+        // add stake to coldkey-hotkey pair so we can recycle it
+        let stake = 200_000;
+        increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
+
+        // get initial total issuance and alpha out
+        let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
+        let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
+
+        // amount to recycle
+        let burn_amount = AlphaCurrency::from(stake);
+
+        // Modify the alpha pool denominator so it's low-precision
+        let denominator = U64F64::from_num(0.0000001);
+        TotalHotkeyShares::<Test>::insert(hotkey, netuid, denominator);
+        Alpha::<Test>::insert((&hotkey, &coldkey, netuid), denominator);
+
+        // burn, expect error due to precision loss
+        assert_noop!(
+            SubtensorModule::burn_alpha(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                burn_amount,
+                netuid
+            ),
+            Error::<Test>::PrecisionLoss
         );
     });
 }

--- a/pallets/subtensor/src/tests/recycle_alpha.rs
+++ b/pallets/subtensor/src/tests/recycle_alpha.rs
@@ -561,10 +561,6 @@ fn test_recycle_precision_loss() {
         let stake = 200_000;
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
 
-        // get initial total issuance and alpha out
-        let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
-        let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
-
         // amount to recycle
         let recycle_amount = AlphaCurrency::from(stake);
 
@@ -601,10 +597,6 @@ fn test_burn_precision_loss() {
         // add stake to coldkey-hotkey pair so we can recycle it
         let stake = 200_000;
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
-
-        // get initial total issuance and alpha out
-        let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
-        let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
 
         // amount to recycle
         let burn_amount = AlphaCurrency::from(stake);

--- a/pallets/subtensor/src/tests/recycle_alpha.rs
+++ b/pallets/subtensor/src/tests/recycle_alpha.rs
@@ -562,10 +562,10 @@ fn test_recycle_precision_loss() {
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
 
         // amount to recycle
-        let recycle_amount = AlphaCurrency::from(stake);
+        let recycle_amount = AlphaCurrency::from(stake / 2);
 
         // Modify the alpha pool denominator so it's low-precision
-        let denominator = U64F64::from_num(0.0000001);
+        let denominator = U64F64::from_num(0.00000001);
         TotalHotkeyShares::<Test>::insert(hotkey, netuid, denominator);
         Alpha::<Test>::insert((&hotkey, &coldkey, netuid), denominator);
 
@@ -599,10 +599,10 @@ fn test_burn_precision_loss() {
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
 
         // amount to recycle
-        let burn_amount = AlphaCurrency::from(stake);
+        let burn_amount = AlphaCurrency::from(stake / 2);
 
         // Modify the alpha pool denominator so it's low-precision
-        let denominator = U64F64::from_num(0.0000001);
+        let denominator = U64F64::from_num(0.00000001);
         TotalHotkeyShares::<Test>::insert(hotkey, netuid, denominator);
         Alpha::<Test>::insert((&hotkey, &coldkey, netuid), denominator);
 


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Fixes and issue in the `recycle_alpha` and `burn_alpha` calls where we may recycle/burn more than the intended amount.  
We add an `ensure` and `Error::<T>::PrecisionLoss` for the `decrease_stake_*` call.  

Also adds tests for this.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Contribution by Gittensor, learn more at https://gittensor.io/