### PR TITLE
fix: alpha accounting precision and add repair mechanism

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2612,12 +2612,15 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
             Error::<T>::HotKeyAccountNotExists
         );
 
+        // Apply share-pool math first because the actual credited amount can differ due to
+        // rounding/precision.
+        let actual_alpha =
+            Self::increase_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
+
         // Increse alpha out counter
         SubnetAlphaOut::<T>::mutate(netuid, |total| {
-            *total = total.saturating_add(alpha);
+            *total = total.saturating_add(actual_alpha);
         });
-
-        Self::increase_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
 
         Ok(())
     }
@@ -2633,14 +2636,17 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
             Error::<T>::HotKeyAccountNotExists
         );
 
+        // Apply share-pool math first because the actual debited amount can differ due to
+        // rounding/precision.
+        let actual_alpha =
+            Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
+
         // Decrese alpha out counter
         SubnetAlphaOut::<T>::mutate(netuid, |total| {
-            *total = total.saturating_sub(alpha);
+            *total = total.saturating_sub(actual_alpha);
         });
 
-        Ok(Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(
-            hotkey, coldkey, netuid, alpha,
-        ))
+        Ok(actual_alpha)
     }
 }
 

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2432,5 +2432,26 @@ mod dispatches {
 
             Ok(())
         }
+
+        /// Set SubnetAlphaOut for a subnet (root only).
+        ///
+        /// This is an administrative escape hatch to repair alpha issuance / burn accounting
+        /// when historical drift is detected.
+        #[pallet::call_index(125)]
+        #[pallet::weight((\n            Weight::from_parts(6_000, 0)\n            .saturating_add(T::DbWeight::get().reads(1_u64))\n            .saturating_add(T::DbWeight::get().writes(1_u64)),\n            DispatchClass::Operational,\n            Pays::Yes\n        ))]
+        pub fn sudo_set_subnet_alpha_out(
+            origin: OriginFor<T>,
+            netuid: NetUid,
+            alpha_out: AlphaCurrency,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+
+            ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
+
+            SubnetAlphaOut::<T>::insert(netuid, alpha_out);
+            Self::deposit_event(Event::SubnetAlphaOutSet(netuid, alpha_out));
+
+            Ok(())
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2438,7 +2438,13 @@ mod dispatches {
         /// This is an administrative escape hatch to repair alpha issuance / burn accounting
         /// when historical drift is detected.
         #[pallet::call_index(125)]
-        #[pallet::weight((\n            Weight::from_parts(6_000, 0)\n            .saturating_add(T::DbWeight::get().reads(1_u64))\n            .saturating_add(T::DbWeight::get().writes(1_u64)),\n            DispatchClass::Operational,\n            Pays::Yes\n        ))]
+        #[pallet::weight((
+            Weight::from_parts(6_000, 0)
+            .saturating_add(T::DbWeight::get().reads(1_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64)),
+            DispatchClass::Operational,
+            Pays::Yes
+        ))]
         pub fn sudo_set_subnet_alpha_out(
             origin: OriginFor<T>,
             netuid: NetUid,

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -322,6 +322,12 @@ mod events {
         /// (coldkey, hotkey, amount, subnet_id)
         AlphaBurned(T::AccountId, T::AccountId, AlphaCurrency, NetUid),
 
+        /// Subnet alpha-out tracker has been updated via sudo.
+        ///
+        /// Parameters:
+        /// (netuid, alpha_out)
+        SubnetAlphaOutSet(NetUid, AlphaCurrency),
+
         /// An EVM key has been associated with a hotkey.
         EvmKeyAssociated {
             /// The subnet that the hotkey belongs to.

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -45,18 +45,18 @@ impl<T: Config> Pallet<T> {
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
         let amount = amount.min(alpha_available);
 
-        ensure!(
-            SubnetAlphaOut::<T>::get(netuid) >= amount,
-            Error::<T>::InsufficientLiquidity
-        );
-
         // Deduct from the coldkey's stake.
         let actual_alpha_decrease = Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey, &coldkey, netuid, amount,
         );
 
+        ensure!(
+            SubnetAlphaOut::<T>::get(netuid) >= actual_alpha_decrease,
+            Error::<T>::NotEnoughAlphaOutToRecycle
+        );
+
         // Recycle means we should decrease the alpha issuance tracker.
-        Self::recycle_subnet_alpha(netuid, amount);
+        Self::recycle_subnet_alpha(netuid, actual_alpha_decrease);
 
         Self::deposit_event(Event::AlphaRecycled(
             coldkey,

--- a/pallets/subtensor/src/tests/recycle_alpha.rs
+++ b/pallets/subtensor/src/tests/recycle_alpha.rs
@@ -45,8 +45,19 @@ fn test_recycle_success() {
             netuid
         ));
 
-        assert!(TotalHotkeyAlpha::<Test>::get(hotkey, netuid) < initial_alpha);
-        assert!(SubnetAlphaOut::<Test>::get(netuid) < initial_net_alpha);
+        let new_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
+        let new_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
+
+        assert!(new_alpha < initial_alpha);
+        assert!(new_net_alpha < initial_net_alpha);
+
+        // Accounting invariant: recycle should reduce SubnetAlphaOut by the *same* amount of alpha
+        // that was actually removed from the hotkey's total.
+        assert_eq!(
+            initial_net_alpha.saturating_sub(new_net_alpha),
+            initial_alpha.saturating_sub(new_alpha)
+        );
+
         assert!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid)
                 < initial_alpha


### PR DESCRIPTION
## Summary

This PR fixes critical precision and accounting issues in the alpha staking system that were causing double deductions, negative burns, and accounting drift between `SubnetAlphaOut` and `TotalHotkeyAlpha`. It also adds a sudo repair function to correct historical drift.

Closes #2274

## Problem Statement

The alpha staking system was experiencing several accounting issues:

1. **Double Deduction**: The `do_recycle_alpha` function was checking `SubnetAlphaOut` against the requested amount before executing the stake decrease, but the share pool logic could return a different actual amount due to rounding/precision. This caused a mismatch between what was checked and what was actually recycled.

2. **Negative Burn / Accounting Drift**: The `increase_stake` and `decrease_stake` functions in the `BalanceOps` implementation (used by swaps/liquidity) were updating `SubnetAlphaOut` using the requested amount rather than the actual amount returned by the share pool logic. This precision gap caused `SubnetAlphaOut` to drift from `TotalHotkeyAlpha` over time, leading to potential negative burn scenarios.

3. **No Repair Mechanism**: There was no way to correct historical accounting drift once it occurred.

## Solution

### 1. Double Deduction & Precision Fix

**File**: `pallets/subtensor/src/staking/recycle_alpha.rs`

Modified `do_recycle_alpha` to:
- First execute the stake decrease to get the exact `actual_alpha_decrease` from the share pool
- Use this actual amount in the validation check: `ensure!(SubnetAlphaOut >= actual_alpha_decrease)`
- Pass `actual_alpha_decrease` to `recycle_subnet_alpha` instead of the requested amount

This ensures that `SubnetAlphaOut` and `TotalHotkeyAlpha` stay in perfect lockstep during recycle operations.

```rust
// Before: Checked requested amount, but used different actual amount
ensure!(SubnetAlphaOut::<T>::get(netuid) >= amount, ...);
let actual_alpha_decrease = Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(...);
Self::recycle_subnet_alpha(netuid, amount); // Used requested amount

// After: Check and use the same actual amount
let actual_alpha_decrease = Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(...);
ensure!(SubnetAlphaOut::<T>::get(netuid) >= actual_alpha_decrease, ...);
Self::recycle_subnet_alpha(netuid, actual_alpha_decrease); // Use actual amount
```

### 2. Negative Burn / Accounting Drift Fix

**File**: `pallets/subtensor/src/lib.rs`

Updated the `BalanceOps` implementation for `increase_stake` and `decrease_stake` to:
- Use the actual amount returned by the share pool logic (`increase_stake_for_hotkey_and_coldkey_on_subnet` / `decrease_stake_for_hotkey_and_coldkey_on_subnet`) when updating `SubnetAlphaOut`
- This closes the precision gap that was causing accounting drift

```rust
// Before: Used requested amount
let actual_alpha = Self::increase_stake_for_hotkey_and_coldkey_on_subnet(...);
SubnetAlphaOut::<T>::mutate(netuid, |total| {
    *total = total.saturating_add(alpha); // Used requested amount
});

// After: Use actual amount returned by share pool
let actual_alpha = Self::increase_stake_for_hotkey_and_coldkey_on_subnet(...);
SubnetAlphaOut::<T>::mutate(netuid, |total| {
    *total = total.saturating_add(actual_alpha); // Use actual amount
});
```

### 3. Burning vs Recycling

**File**: `pallets/subtensor/src/staking/recycle_alpha.rs`

Confirmed that `do_burn_alpha` remains untouched and continues to function correctly:
- It reduces `TotalHotkeyAlpha` without reducing `SubnetAlphaOut`
- This is the intended behavior for burn operations

### 4. Sudo Repair Function

**File**: `pallets/subtensor/src/macros/dispatches.rs`

Added `sudo_set_subnet_alpha_out` (Call Index 125) to allow the root authority to manually set the `SubnetAlphaOut` value to correct historical drift:

```rust
#[pallet::call_index(125)]
pub fn sudo_set_subnet_alpha_out(
    origin: OriginFor<T>,
    netuid: NetUid,
    alpha_out: AlphaCurrency,
) -> DispatchResult {
    ensure_root(origin)?;
    ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
    SubnetAlphaOut::<T>::insert(netuid, alpha_out);
    Self::deposit_event(Event::SubnetAlphaOutSet(netuid, alpha_out));
    Ok(())
}
```

This provides an administrative escape hatch to repair alpha issuance/burn accounting when historical drift is detected.

### 5. Test Updates

**File**: `pallets/subtensor/src/tests/recycle_alpha.rs`

Updated tests to verify the accounting invariant:
- Added assertion that the delta in `SubnetAlphaOut` exactly matches the delta in `TotalHotkeyAlpha` after a recycle operation
- This ensures the precision fix is working correctly

```rust
// Accounting invariant: recycle should reduce SubnetAlphaOut by the *same* amount of alpha
// that was actually removed from the hotkey's total.
assert_eq!(
    initial_net_alpha.saturating_sub(new_net_alpha),
    initial_alpha.saturating_sub(new_alpha)
);
```

## Files Changed

1. `pallets/subtensor/src/staking/recycle_alpha.rs` - Fixed precision in `do_recycle_alpha`
2. `pallets/subtensor/src/lib.rs` - Fixed precision in `increase_stake` and `decrease_stake` (BalanceOps)
3. `pallets/subtensor/src/macros/dispatches.rs` - Added `sudo_set_subnet_alpha_out` function
4. `pallets/subtensor/src/tests/recycle_alpha.rs` - Added accounting invariant test

Contribution by Gittensor, learn more at https://gittensor.io/