### PR TITLE
Fix: clear taoflow and EMA for new subnet

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -298,6 +298,8 @@ impl<T: Config> Pallet<T> {
         SubnetTaoInEmission::<T>::remove(netuid);
         SubnetVolume::<T>::remove(netuid);
         SubnetMovingPrice::<T>::remove(netuid);
+        SubnetTaoFlow::<T>::remove(netuid);
+        SubnetEmaTaoFlow::<T>::remove(netuid);
         SubnetTaoProvided::<T>::remove(netuid);
 
         // --- 13. Token / mechanism / registration toggles.

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -368,6 +368,10 @@ fn dissolve_clears_all_per_subnet_storages() {
         SubnetTaoProvided::<Test>::insert(net, TaoCurrency::from(1));
         SubnetAlphaInProvided::<Test>::insert(net, AlphaCurrency::from(1));
 
+        // TAO Flow
+        SubnetTaoFlow::<Test>::insert(net, 0i64);
+        SubnetEmaTaoFlow::<Test>::insert(net, (0u64, substrate_fixed::types::I64F64::from_num(0)));
+
         // Subnet locks
         TransferToggle::<Test>::insert(net, true);
         SubnetLocked::<Test>::insert(net, TaoCurrency::from(1));
@@ -499,6 +503,10 @@ fn dissolve_clears_all_per_subnet_storages() {
         assert!(!SubnetAlphaOutEmission::<Test>::contains_key(net));
         assert!(!SubnetTaoInEmission::<Test>::contains_key(net));
         assert!(!SubnetVolume::<Test>::contains_key(net));
+
+        // TAO Flow
+        assert!(!SubnetTaoFlow::<Test>::contains_key(net));
+        assert!(!SubnetEmaTaoFlow::<Test>::contains_key(net));
 
         // These are now REMOVED
         assert!(!SubnetAlphaIn::<Test>::contains_key(net));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 364,
+    spec_version: 365,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Clear the TAOFlow and TAOFlow EMA values for subnets that are removed.  

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Contribution by Gittensor, learn more at https://gittensor.io/