### PR TITLE
feat: implement subnet EMA reset mechanism

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1493,6 +1493,16 @@ pub mod pallet {
     pub type FlowEmaSmoothingFactor<T: Config> =
         StorageValue<_, u64, ValueQuery, DefaultFlowEmaSmoothingFactor<T>>;
 
+    #[pallet::type_value]
+    /// Default maximum cost for resetting subnet EMA (100 TAO in RAO).
+    pub fn DefaultMaxEmaResetCost<T: Config>() -> TaoCurrency {
+        TaoCurrency::from(100_000_000_000u64) // 100 TAO
+    }
+    #[pallet::storage]
+    /// --- ITEM --> Maximum cost for resetting subnet EMA
+    pub type MaxEmaResetCost<T: Config> =
+        StorageValue<_, TaoCurrency, ValueQuery, DefaultMaxEmaResetCost<T>>;
+
     /// ============================
     /// ==== Global Parameters =====
     /// ============================

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2432,5 +2432,35 @@ mod dispatches {
 
             Ok(())
         }
+
+        /// --- Resets the subnet EMA to zero by burning TAO.
+        ///
+        /// This extrinsic allows subnet owners to reset negative EMA values that
+        /// prevent their subnet from receiving emissions. The cost is proportional
+        /// to |EMA| × (1/α), capped at MaxEmaResetCost.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, must be the subnet owner.
+        /// * `netuid` - The network identifier of the subnet to reset.
+        ///
+        /// # Errors
+        /// * `SubnetNotExists` - The subnet does not exist.
+        /// * `EmaNotInitialized` - The subnet EMA has not been initialized.
+        /// * `SubnetEmaNotNegative` - The subnet EMA is not negative, reset not needed.
+        /// * `NotEnoughBalanceToPayEmaResetCost` - Insufficient balance to pay reset cost.
+        ///
+        /// # Events
+        /// Emits a `SubnetEmaReset` event on success.
+        #[pallet::call_index(125)]
+        #[pallet::weight((
+            Weight::from_parts(35_000_000, 0)
+                .saturating_add(T::DbWeight::get().reads(5_u64))
+                .saturating_add(T::DbWeight::get().writes(3_u64)),
+            DispatchClass::Normal,
+            Pays::Yes
+        ))]
+        pub fn reset_subnet_ema(origin: OriginFor<T>, netuid: NetUid) -> DispatchResult {
+            Self::do_reset_subnet_ema(origin, netuid)
+        }
     }
 }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -268,5 +268,11 @@ mod errors {
         InvalidSubnetNumber,
         /// Unintended precision loss when unstaking alpha
         PrecisionLoss,
+        /// EMA has not been initialized for this subnet.
+        EmaNotInitialized,
+        /// Subnet EMA is not negative, reset not needed.
+        SubnetEmaNotNegative,
+        /// Not enough balance to pay the EMA reset cost.
+        NotEnoughBalanceToPayEmaResetCost,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -479,5 +479,17 @@ mod events {
             /// The amount of alpha distributed
             alpha: AlphaCurrency,
         },
+
+        /// Subnet EMA has been reset by the owner.
+        SubnetEmaReset {
+            /// The subnet ID
+            netuid: NetUid,
+            /// The account that executed the reset
+            who: T::AccountId,
+            /// The cost paid for the reset in TAO
+            cost: TaoCurrency,
+            /// The previous EMA value before reset (as i128 bits representation of I64F64)
+            previous_ema: i128,
+        },
     }
 }


### PR DESCRIPTION
This PR implements a mechanism for subnet owners to reset negative EMA values that prevent their subnet from receiving emissions.

Changes:
- Add MaxEmaResetCost storage item (default: 100 TAO)
- Add reset_subnet_ema extrinsic (call_index: 125)
- Add get_ema_reset_cost helper function
- Add EmaNotInitialized, SubnetEmaNotNegative, NotEnoughBalanceToPayEmaResetCost errors
- Add SubnetEmaReset event with netuid, who, cost, previous_ema
- Add comprehensive tests for the new functionality

The reset cost is calculated as |EMA| × (1/α), capped at MaxEmaResetCost. The burned TAO is recycled to reduce total issuance.

Related Issue(s)

- Closes #2228

Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Other (please describe):

Breaking Change

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

---

Contribution by Gittensor, learn more at https://gittensor.io/