### PR TITLE
fix: DefaultPendingChildKeyCooldown should use prod_or_fast value

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2359,10 +2359,11 @@ pub mod pallet {
     #[pallet::storage]
     pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, Vec<u8>, bool, ValueQuery>;
 
-    /// Default value for pending childkey cooldown (settable by root, default 0)
+    /// Default value for pending childkey cooldown (settable by root).
+    /// Uses the same value as DefaultPendingCooldown for consistency.
     #[pallet::type_value]
     pub fn DefaultPendingChildKeyCooldown<T: Config>() -> u64 {
-        0
+        DefaultPendingCooldown::<T>::get()
     }
 
     /// Storage value for pending childkey cooldown, settable by root.


### PR DESCRIPTION
## Summary
`DefaultPendingChildKeyCooldown` was returning `0` instead of using the same value as `DefaultPendingCooldown`. This causes `PendingChildKeyCooldown` to be `0` on fresh chains (like localnet) instead of the expected `7200` (prod) or `15` (fast/test).

## Changes
- Changed `DefaultPendingChildKeyCooldown` to call `DefaultPendingCooldown::<T>::get()` for consistency

## Before
```rust
pub fn DefaultPendingChildKeyCooldown<T: Config>() -> u64 {
    0
}
```

## After
```rust
pub fn DefaultPendingChildKeyCooldown<T: Config>() -> u64 {
    DefaultPendingCooldown::<T>::get()
}
```

Fixes #2107