### PR TITLE
refactor: replace RocksDbWeight with ParityDbWeight

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -17,7 +17,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `{{pallet}}`.
@@ -102,16 +102,16 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
-			.saturating_add(RocksDbWeight::get().reads({{benchmark.base_reads}}_u64))
+			.saturating_add(ParityDbWeight::get().reads({{benchmark.base_reads}}_u64))
 			{{/if}}
 			{{#each benchmark.component_reads as |cr|}}
-			.saturating_add(RocksDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
+			.saturating_add(ParityDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
 			{{/each}}
 			{{#if (ne benchmark.base_writes "0")}}
-			.saturating_add(RocksDbWeight::get().writes({{benchmark.base_writes}}_u64))
+			.saturating_add(ParityDbWeight::get().writes({{benchmark.base_writes}}_u64))
 			{{/if}}
 			{{#each benchmark.component_writes as |cw|}}
-			.saturating_add(RocksDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			.saturating_add(ParityDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
 			{{/each}}
 			{{#each benchmark.component_calculated_proof_size as |cp|}}
 			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))

--- a/chain-extensions/src/mock.rs
+++ b/chain-extensions/src/mock.rs
@@ -9,7 +9,7 @@ use core::num::NonZeroU64;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Contains, Everything, InherentBuilder, InsideBoth};
 use frame_support::weights::Weight;
-use frame_support::weights::constants::RocksDbWeight;
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::{PalletId, derive_impl};
 use frame_support::{assert_ok, parameter_types, traits::PrivilegeCmp};
 use frame_system as system;
@@ -212,7 +212,7 @@ impl system::Config for Test {
     type BaseCallFilter = InsideBoth<Everything, NoNestingCallFilter>;
     type BlockWeights = BlockWeights;
     type BlockLength = ();
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type Hash = H256;

--- a/pallets/commitments/src/weights.rs
+++ b/pallets/commitments/src/weights.rs
@@ -24,7 +24,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_commitments`.
@@ -52,7 +52,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Sudo setting rate limit for commitments
 	fn set_rate_limit() -> Weight {
 		Weight::from_parts(10_000_000, 2000)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 }
 
@@ -68,13 +68,13 @@ impl WeightInfo for () {
 		//  Estimated: `6344`
 		// Minimum execution time: 28_000_000 picoseconds.
 		Weight::from_parts(28_000_000, 6344)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 
 	/// Sudo setting rate limit for commitments
 	fn set_rate_limit() -> Weight {
 		Weight::from_parts(10_000_000, 2000)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 }

--- a/pallets/crowdloan/src/weights.rs
+++ b/pallets/crowdloan/src/weights.rs
@@ -26,7 +26,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_crowdloan`.
@@ -195,8 +195,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 42_128_000 picoseconds.
 		Weight::from_parts(42_930_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(5_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -210,8 +210,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 43_161_000 picoseconds.
 		Weight::from_parts(44_192_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -225,8 +225,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 40_235_000 picoseconds.
 		Weight::from_parts(40_907_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -242,8 +242,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 40_986_000 picoseconds.
 		Weight::from_parts(41_858_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -260,9 +260,9 @@ impl WeightInfo for () {
 		Weight::from_parts(2_729_302, 3743)
 			// Standard Error: 351_422
 			.saturating_add(Weight::from_parts(31_033_274, 0).saturating_mul(k.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().reads((2_u64).saturating_mul(k.into())))
-			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().writes((2_u64).saturating_mul(k.into())))
 			.saturating_add(Weight::from_parts(0, 2579).saturating_mul(k.into()))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
@@ -277,8 +277,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 43_341_000 picoseconds.
 		Weight::from_parts(44_402_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -288,8 +288,8 @@ impl WeightInfo for () {
 		//  Estimated: `3743`
 		// Minimum execution time: 8_876_000 picoseconds.
 		Weight::from_parts(9_137_000, 3743)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -299,8 +299,8 @@ impl WeightInfo for () {
 		//  Estimated: `3743`
 		// Minimum execution time: 9_117_000 picoseconds.
 		Weight::from_parts(9_438_000, 3743)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(278), added: 2753, mode: `MaxEncodedLen`)
@@ -310,7 +310,7 @@ impl WeightInfo for () {
 		//  Estimated: `3743`
 		// Minimum execution time: 8_766_000 picoseconds.
 		Weight::from_parts(9_087_000, 3743)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/proxy/src/weights.rs
+++ b/pallets/proxy/src/weights.rs
@@ -51,6 +51,7 @@
 
 use crate as pallet_proxy;
 use frame::weights_prelude::*;
+use frame_support::weights::constants::ParityDbWeight;
 
 /// Weight functions needed for `pallet_proxy`.
 pub trait WeightInfo {
@@ -275,7 +276,7 @@ impl WeightInfo for () {
 		Weight::from_parts(25_084_085, 4706)
 			// Standard Error: 2_569
 			.saturating_add(Weight::from_parts(33_574, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:0)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -299,8 +300,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(171_107, 0).saturating_mul(a.into()))
 			// Standard Error: 3_834
 			.saturating_add(Weight::from_parts(34_523, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Announcements` (r:1 w:1)
 	/// Proof: `Proxy::Announcements` (`max_values`: None, `max_size`: Some(2233), added: 4708, mode: `MaxEncodedLen`)
@@ -318,8 +319,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(158_572, 0).saturating_mul(a.into()))
 			// Standard Error: 1_881
 			.saturating_add(Weight::from_parts(8_433, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Announcements` (r:1 w:1)
 	/// Proof: `Proxy::Announcements` (`max_values`: None, `max_size`: Some(2233), added: 4708, mode: `MaxEncodedLen`)
@@ -337,8 +338,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(176_827, 0).saturating_mul(a.into()))
 			// Standard Error: 1_901
 			.saturating_add(Weight::from_parts(9_607, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:0)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -358,8 +359,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(157_335, 0).saturating_mul(a.into()))
 			// Standard Error: 2_730
 			.saturating_add(Weight::from_parts(28_872, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -372,8 +373,8 @@ impl WeightInfo for () {
 		Weight::from_parts(28_296_216, 4706)
 			// Standard Error: 1_643
 			.saturating_add(Weight::from_parts(50_271, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -386,8 +387,8 @@ impl WeightInfo for () {
 		Weight::from_parts(28_379_566, 4706)
 			// Standard Error: 1_547
 			.saturating_add(Weight::from_parts(45_784, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -400,8 +401,8 @@ impl WeightInfo for () {
 		Weight::from_parts(25_821_878, 4706)
 			// Standard Error: 2_300
 			.saturating_add(Weight::from_parts(33_972, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -414,8 +415,8 @@ impl WeightInfo for () {
 		Weight::from_parts(29_662_728, 4706)
 			// Standard Error: 1_851
 			.saturating_add(Weight::from_parts(29_928, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -428,8 +429,8 @@ impl WeightInfo for () {
 		Weight::from_parts(26_780_627, 4706)
 			// Standard Error: 1_581
 			.saturating_add(Weight::from_parts(33_085, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(1241), added: 3716, mode: `MaxEncodedLen`)
@@ -443,7 +444,7 @@ impl WeightInfo for () {
 		//  Estimated: `5698`
 		// Minimum execution time: 46_733_000 picoseconds.
 		Weight::from_parts(47_972_000, 5698)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 }

--- a/pallets/registry/src/weights.rs
+++ b/pallets/registry/src/weights.rs
@@ -24,7 +24,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_registry`.
@@ -70,8 +70,8 @@ impl WeightInfo for () {
 		//  Estimated: `3499`
 		// Minimum execution time: 41_000_000 picoseconds.
 		Weight::from_parts(41_000_000, 3499)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: Registry IdentityOf (r:1 w:1)
 	/// Proof Skipped: Registry IdentityOf (max_values: None, max_size: None, mode: Measured)
@@ -81,7 +81,7 @@ impl WeightInfo for () {
 		//  Estimated: `3860`
 		// Minimum execution time: 36_000_000 picoseconds.
 		Weight::from_parts(36_000_000, 3860)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -10,7 +10,7 @@ use crate::utils::rate_limiting::TransactionType;
 use crate::*;
 use frame_support::traits::{Contains, Everything, InherentBuilder, InsideBoth, InstanceFilter};
 use frame_support::weights::Weight;
-use frame_support::weights::constants::RocksDbWeight;
+use frame_support::weights::constants::ParityDbWeight;
 use frame_support::{PalletId, derive_impl};
 use frame_support::{
     assert_ok, parameter_types,
@@ -122,7 +122,7 @@ impl system::Config for Test {
     type BaseCallFilter = InsideBoth<Everything, NoNestingCallFilter>;
     type BlockWeights = BlockWeights;
     type BlockLength = ();
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type Hash = H256;

--- a/pallets/swap/src/weights.rs
+++ b/pallets/swap/src/weights.rs
@@ -8,7 +8,7 @@
 
 use frame_support::{
     traits::Get,
-    weights::{Weight, constants::RocksDbWeight},
+    weights::{Weight, constants::ParityDbWeight},
 };
 use sp_std::marker::PhantomData;
 
@@ -64,31 +64,31 @@ impl<T: frame_system::Config> WeightInfo for DefaultWeight<T> {
 impl WeightInfo for () {
     fn set_fee_rate() -> Weight {
         Weight::from_parts(10_000_000, 0)
-            .saturating_add(RocksDbWeight::get().reads(1))
-            .saturating_add(RocksDbWeight::get().writes(1))
+            .saturating_add(ParityDbWeight::get().reads(1))
+            .saturating_add(ParityDbWeight::get().writes(1))
     }
 
     fn add_liquidity() -> Weight {
         Weight::from_parts(50_000_000, 0)
-            .saturating_add(RocksDbWeight::get().reads(5))
-            .saturating_add(RocksDbWeight::get().writes(4))
+            .saturating_add(ParityDbWeight::get().reads(5))
+            .saturating_add(ParityDbWeight::get().writes(4))
     }
 
     fn remove_liquidity() -> Weight {
         Weight::from_parts(50_000_000, 0)
-            .saturating_add(RocksDbWeight::get().reads(4))
-            .saturating_add(RocksDbWeight::get().writes(4))
+            .saturating_add(ParityDbWeight::get().reads(4))
+            .saturating_add(ParityDbWeight::get().writes(4))
     }
 
     fn modify_position() -> Weight {
         Weight::from_parts(50_000_000, 0)
-            .saturating_add(RocksDbWeight::get().reads(4))
-            .saturating_add(RocksDbWeight::get().writes(4))
+            .saturating_add(ParityDbWeight::get().reads(4))
+            .saturating_add(ParityDbWeight::get().writes(4))
     }
 
     fn toggle_user_liquidity() -> Weight {
         Weight::from_parts(10_000_000, 0)
-            .saturating_add(RocksDbWeight::get().reads(1))
-            .saturating_add(RocksDbWeight::get().writes(1))
+            .saturating_add(ParityDbWeight::get().reads(1))
+            .saturating_add(ParityDbWeight::get().writes(1))
     }
 }

--- a/pallets/utility/src/weights.rs
+++ b/pallets/utility/src/weights.rs
@@ -50,7 +50,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_utility`.
@@ -167,7 +167,7 @@ impl WeightInfo for () {
 		Weight::from_parts(4_034_000, 3997)
 			// Standard Error: 2_323
 			.saturating_add(Weight::from_parts(4_914_560, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	/// Storage: `SafeMode::EnteredUntil` (r:1 w:0)
 	/// Proof: `SafeMode::EnteredUntil` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -179,7 +179,7 @@ impl WeightInfo for () {
 		//  Estimated: `3997`
 		// Minimum execution time: 5_866_000 picoseconds.
 		Weight::from_parts(6_097_000, 3997)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	/// Storage: `SafeMode::EnteredUntil` (r:1 w:0)
 	/// Proof: `SafeMode::EnteredUntil` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -194,7 +194,7 @@ impl WeightInfo for () {
 		Weight::from_parts(4_075_000, 3997)
 			// Standard Error: 2_176
 			.saturating_add(Weight::from_parts(5_127_263, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
@@ -216,7 +216,7 @@ impl WeightInfo for () {
 		Weight::from_parts(4_035_000, 3997)
 			// Standard Error: 1_682
 			.saturating_add(Weight::from_parts(4_902_729, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	fn dispatch_as_fallible() -> Weight {
 		// Proof Size summary in bytes:
@@ -235,6 +235,6 @@ impl WeightInfo for () {
 		//  Estimated: `7004`
 		// Minimum execution time: 11_273_000 picoseconds.
 		Weight::from_parts(11_571_000, 7004)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -85,7 +85,7 @@ pub use frame_support::{
         IdentityFee, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
         WeightToFeePolynomial,
         constants::{
-            BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND,
+            BlockExecutionWeight, ExtrinsicBaseWeight, ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND,
         },
     },
 };
@@ -326,7 +326,7 @@ impl frame_system::Config for Runtime {
     // Maximum number of block number to block hash mappings to keep (oldest pruned first).
     type BlockHashCount = BlockHashCount;
     // The weight of database operations that the runtime can invoke.
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     // Version of the runtime.
     type Version = Version;
     // Converts a module to the index of the module in `construct_runtime!`.


### PR DESCRIPTION
## Summary
- Since subtensor uses ParityDB as the database backend, this change updates all weight references from `RocksDbWeight` to `ParityDbWeight` for consistency
- Updated runtime, pallets, test mocks, and the benchmark weight template

## Changes
- `runtime/src/lib.rs`: Changed `DbWeight` type from `RocksDbWeight` to `ParityDbWeight`
- `.maintain/frame-weight-template.hbs`: Updated benchmark template to generate `ParityDbWeight` references
- `pallets/*/src/weights.rs`: Updated all pallet weight implementations
- `*/mock.rs`: Updated test mocks

Closes #2131

## Test plan
- [x] `cargo check --lib` passes
- [ ] Full test suite validation