### PR TITLE
refactor: standardize MechId naming convention

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2491,9 +2491,9 @@ fn test_trim_to_max_allowed_uids() {
         ValidatorPermit::<Test>::insert(netuid, bool_values.clone());
         Active::<Test>::insert(netuid, bool_values);
 
-        for mecid in 0..mechanism_count.into() {
+        for mechid in 0..mechanism_count.into() {
             let netuid_index =
-                SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
+                SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mechid));
             Incentive::<Test>::insert(netuid_index, values.clone());
             LastUpdate::<Test>::insert(netuid_index, u64_values.clone());
         }
@@ -2548,9 +2548,9 @@ fn test_trim_to_max_allowed_uids() {
                 }
             }
 
-            for mecid in 0..mechanism_count.into() {
+            for mechid in 0..mechanism_count.into() {
                 let netuid_index =
-                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
+                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mechid));
                 Weights::<Test>::insert(netuid_index, uid, weights.clone());
                 Bonds::<Test>::insert(netuid_index, uid, bonds.clone());
             }
@@ -2596,9 +2596,9 @@ fn test_trim_to_max_allowed_uids() {
         assert_eq!(ValidatorPermit::<Test>::get(netuid), expected_bools);
         assert_eq!(StakeWeight::<Test>::get(netuid), expected_values);
 
-        for mecid in 0..mechanism_count.into() {
+        for mechid in 0..mechanism_count.into() {
             let netuid_index =
-                SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
+                SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mechid));
             assert_eq!(Incentive::<Test>::get(netuid_index), expected_values);
             assert_eq!(LastUpdate::<Test>::get(netuid_index), expected_u64_values);
         }
@@ -2608,9 +2608,9 @@ fn test_trim_to_max_allowed_uids() {
             assert!(!Keys::<Test>::contains_key(netuid, uid));
             assert!(!BlockAtRegistration::<Test>::contains_key(netuid, uid));
             assert!(!AssociatedEvmAddress::<Test>::contains_key(netuid, uid));
-            for mecid in 0..mechanism_count.into() {
+            for mechid in 0..mechanism_count.into() {
                 let netuid_index =
-                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
+                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mechid));
                 assert!(!Weights::<Test>::contains_key(netuid_index, uid));
                 assert!(!Bonds::<Test>::contains_key(netuid_index, uid));
             }
@@ -2643,9 +2643,9 @@ fn test_trim_to_max_allowed_uids() {
 
         // Ensure trimmed uids weights and bonds connections have been trimmed correctly
         for uid in 0..new_max_n {
-            for mecid in 0..mechanism_count.into() {
+            for mechid in 0..mechanism_count.into() {
                 let netuid_index =
-                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
+                    SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mechid));
                 assert!(
                     Weights::<Test>::get(netuid_index, uid)
                         .iter()

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -78,7 +78,7 @@ pub trait SubtensorCustomApi<BlockHash> {
     fn get_mechagraph(
         &self,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         at: Option<BlockHash>,
     ) -> RpcResult<Vec<u8>>;
     #[method(name = "subnetInfo_getSubnetState")]
@@ -103,7 +103,7 @@ pub trait SubtensorCustomApi<BlockHash> {
     fn get_selective_mechagraph(
         &self,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         metagraph_index: Vec<u16>,
         at: Option<BlockHash>,
     ) -> RpcResult<Vec<u8>>;
@@ -391,12 +391,12 @@ where
     fn get_mechagraph(
         &self,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Vec<u8>> {
         let api = self.client.runtime_api();
         let at = at.unwrap_or_else(|| self.client.info().best_hash);
-        match api.get_mechagraph(at, netuid, mecid) {
+        match api.get_mechagraph(at, netuid, mechid) {
             Ok(result) => Ok(result.encode()),
             Err(e) => Err(Error::RuntimeError(format!(
                 "Unable to get dynamic subnets info: {e:?}"
@@ -502,14 +502,14 @@ where
     fn get_selective_mechagraph(
         &self,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         metagraph_index: Vec<u16>,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Vec<u8>> {
         let api = self.client.runtime_api();
         let at = at.unwrap_or_else(|| self.client.info().best_hash);
 
-        match api.get_selective_mechagraph(at, netuid, mecid, metagraph_index) {
+        match api.get_selective_mechagraph(at, netuid, mechid, metagraph_index) {
             Ok(result) => Ok(result.encode()),
             Err(e) => {
                 Err(Error::RuntimeError(format!("Unable to get selective metagraph: {e:?}")).into())

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -41,7 +41,7 @@ sp_api::decl_runtime_apis! {
         fn get_all_metagraphs() -> Vec<Option<Metagraph<AccountId32>>>;
         fn get_metagraph(netuid: NetUid) -> Option<Metagraph<AccountId32>>;
         fn get_all_mechagraphs() -> Vec<Option<Metagraph<AccountId32>>>;
-        fn get_mechagraph(netuid: NetUid, mecid: MechId) -> Option<Metagraph<AccountId32>>;
+        fn get_mechagraph(netuid: NetUid, mechid: MechId) -> Option<Metagraph<AccountId32>>;
         fn get_dynamic_info(netuid: NetUid) -> Option<DynamicInfo<AccountId32>>;
         fn get_subnet_state(netuid: NetUid) -> Option<SubnetState<AccountId32>>;
         fn get_selective_metagraph(netuid: NetUid, metagraph_indexes: Vec<u16>) -> Option<SelectiveMetagraph<AccountId32>>;

--- a/pallets/subtensor/src/coinbase/reveal_commits.rs
+++ b/pallets/subtensor/src/coinbase/reveal_commits.rs
@@ -46,8 +46,8 @@ impl<T: Config> Pallet<T> {
 
         // All mechanisms share the same epoch, so the reveal_period/reveal_epoch are also the same
         // Reveal for all mechanisms
-        for mecid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
-            let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+        for mechid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
+            let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
 
             // Clean expired commits
             for (epoch, _) in TimelockedWeightCommits::<T>::iter_prefix(netuid_index) {
@@ -180,7 +180,7 @@ impl<T: Config> Pallet<T> {
                 if let Err(e) = Self::do_set_mechanism_weights(
                     T::RuntimeOrigin::signed(who.clone()),
                     netuid,
-                    MechId::from(mecid),
+                    MechId::from(mechid),
                     uids,
                     values,
                     version_key,

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -87,10 +87,10 @@ impl<T: Config> Pallet<T> {
     /// Persists per-mechanism epoch output in state
     pub fn persist_mechanism_epoch_terms(
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         output: &BTreeMap<T::AccountId, EpochTerms>,
     ) {
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
         let mut terms_sorted: sp_std::vec::Vec<&EpochTerms> = output.values().collect();
         terms_sorted.sort_unstable_by_key(|t| t.uid);
 
@@ -145,11 +145,11 @@ impl<T: Config> Pallet<T> {
     #[allow(clippy::indexing_slicing)]
     pub fn epoch_dense_mechanism(
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         rao_emission: AlphaCurrency,
     ) -> Vec<(T::AccountId, AlphaCurrency, AlphaCurrency)> {
         // Calculate netuid storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // Get subnetwork size.
         let n: u16 = Self::get_subnetwork_n(netuid);
@@ -558,11 +558,11 @@ impl<T: Config> Pallet<T> {
     ///
     pub fn epoch_mechanism(
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         rao_emission: AlphaCurrency,
     ) -> EpochOutput<T> {
         // Calculate netuid storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // Initialize output keys (neuron hotkeys) and UIDs
         let mut terms_map: BTreeMap<T::AccountId, EpochTerms> = Keys::<T>::iter_prefix(netuid)
@@ -1061,7 +1061,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
     pub fn get_weights_sparse(netuid_index: NetUidStorageIndex) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
         for (uid_i, weights_i) in
@@ -1080,7 +1080,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized weights in [n, n] matrix, input weights are assumed to be row max-upscaled in u16.
     pub fn get_weights(netuid_index: NetUidStorageIndex) -> Vec<Vec<I32F32>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut weights: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, weights_vec) in
@@ -1103,7 +1103,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
     pub fn get_bonds_sparse(netuid_index: NetUidStorageIndex) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
         for (uid_i, bonds_vec) in
@@ -1126,7 +1126,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized bonds in [n, n] matrix, input bonds are assumed to be column max-upscaled in u16.
     pub fn get_bonds(netuid_index: NetUidStorageIndex) -> Vec<Vec<I32F32>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, bonds_vec) in
@@ -1188,7 +1188,7 @@ impl<T: Config> Pallet<T> {
         bonds: &[Vec<(u16, I32F32)>],
         netuid_index: NetUidStorageIndex,
     ) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
 
         // Retrieve the bonds moving average for the given network ID and scale it down.
         let bonds_moving_average: I64F64 =
@@ -1301,7 +1301,7 @@ impl<T: Config> Pallet<T> {
         bonds: &[Vec<(u16, I32F32)>],
         consensus: &[I32F32],
     ) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
 
         // Check if Liquid Alpha is enabled, consensus is not empty, and contains non-zero values.
         if LiquidAlphaOn::<T>::get(netuid)
@@ -1537,7 +1537,7 @@ impl<T: Config> Pallet<T> {
         netuid_index: NetUidStorageIndex,
         account_id: &T::AccountId,
     ) -> Result<(), DispatchError> {
-        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mechid(netuid_index).unwrap_or_default();
 
         // check bonds reset enabled for this subnet
         let bonds_reset_enabled: bool = Self::get_bonds_reset(netuid);

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1061,7 +1061,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
     pub fn get_weights_sparse(netuid_index: NetUidStorageIndex) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
         for (uid_i, weights_i) in
@@ -1080,7 +1080,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized weights in [n, n] matrix, input weights are assumed to be row max-upscaled in u16.
     pub fn get_weights(netuid_index: NetUidStorageIndex) -> Vec<Vec<I32F32>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut weights: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, weights_vec) in
@@ -1103,7 +1103,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
     pub fn get_bonds_sparse(netuid_index: NetUidStorageIndex) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
         let n = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
         for (uid_i, bonds_vec) in
@@ -1126,7 +1126,7 @@ impl<T: Config> Pallet<T> {
 
     /// Output unnormalized bonds in [n, n] matrix, input bonds are assumed to be column max-upscaled in u16.
     pub fn get_bonds(netuid_index: NetUidStorageIndex) -> Vec<Vec<I32F32>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, bonds_vec) in
@@ -1188,7 +1188,7 @@ impl<T: Config> Pallet<T> {
         bonds: &[Vec<(u16, I32F32)>],
         netuid_index: NetUidStorageIndex,
     ) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
 
         // Retrieve the bonds moving average for the given network ID and scale it down.
         let bonds_moving_average: I64F64 =
@@ -1301,7 +1301,7 @@ impl<T: Config> Pallet<T> {
         bonds: &[Vec<(u16, I32F32)>],
         consensus: &[I32F32],
     ) -> Vec<Vec<(u16, I32F32)>> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
 
         // Check if Liquid Alpha is enabled, consensus is not empty, and contains non-zero values.
         if LiquidAlphaOn::<T>::get(netuid)
@@ -1537,7 +1537,7 @@ impl<T: Config> Pallet<T> {
         netuid_index: NetUidStorageIndex,
         account_id: &T::AccountId,
     ) -> Result<(), DispatchError> {
-        let (netuid, _) = Self::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Self::get_netuid_and_mecid(netuid_index).unwrap_or_default();
 
         // check bonds reset enabled for this subnet
         let bonds_reset_enabled: bool = Self::get_bonds_reset(netuid);

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -120,7 +120,7 @@ mod dispatches {
         /// * `netuid` (u16):
         /// 	- The network uid we are setting these weights on.
         ///
-        /// * `mecid` (`u8`):
+        /// * `mechid` (`u8`):
         ///   - The u8 mechnism identifier.
         ///
         /// * `dests` (Vec<u16>):
@@ -168,7 +168,7 @@ mod dispatches {
         pub fn set_mechanism_weights(
             origin: OriginFor<T>,
             netuid: NetUid,
-            mecid: MechId,
+            mechid: MechId,
             dests: Vec<u16>,
             weights: Vec<u16>,
             version_key: u64,
@@ -176,7 +176,7 @@ mod dispatches {
             if Self::get_commit_reveal_weights_enabled(netuid) {
                 Err(Error::<T>::CommitRevealEnabled.into())
             } else {
-                Self::do_set_mechanism_weights(origin, netuid, mecid, dests, weights, version_key)
+                Self::do_set_mechanism_weights(origin, netuid, mechid, dests, weights, version_key)
             }
         }
 
@@ -258,7 +258,7 @@ mod dispatches {
         /// * `netuid` (`u16`):
         ///   - The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
+        /// * `mechid` (`u8`):
         ///   - The u8 mechanism identifier.
         ///
         /// * `commit_hash` (`H256`):
@@ -278,10 +278,10 @@ mod dispatches {
         pub fn commit_mechanism_weights(
             origin: T::RuntimeOrigin,
             netuid: NetUid,
-            mecid: MechId,
+            mechid: MechId,
             commit_hash: H256,
         ) -> DispatchResult {
-            Self::do_commit_mechanism_weights(origin, netuid, mecid, commit_hash)
+            Self::do_commit_mechanism_weights(origin, netuid, mechid, commit_hash)
         }
 
         /// --- Allows a hotkey to commit weight hashes for multiple netuids as a batch.
@@ -379,7 +379,7 @@ mod dispatches {
         /// * `netuid` (`u16`):
         ///   - The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
+        /// * `mechid` (`u8`):
         ///   - The u8 mechanism identifier.
         ///
         /// * `uids` (`Vec<u16>`):
@@ -417,7 +417,7 @@ mod dispatches {
         pub fn reveal_mechanism_weights(
             origin: T::RuntimeOrigin,
             netuid: NetUid,
-            mecid: MechId,
+            mechid: MechId,
             uids: Vec<u16>,
             values: Vec<u16>,
             salt: Vec<u16>,
@@ -426,7 +426,7 @@ mod dispatches {
             Self::do_reveal_mechanism_weights(
                 origin,
                 netuid,
-                mecid,
+                mechid,
                 uids,
                 values,
                 salt,
@@ -485,7 +485,7 @@ mod dispatches {
         /// * `netuid` (`u16`):
         ///   - The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
+        /// * `mechid` (`u8`):
         ///   - The u8 mechanism identifier.
         ///
         /// * `commit` (`Vec<u8>`):
@@ -515,14 +515,14 @@ mod dispatches {
         pub fn commit_crv3_mechanism_weights(
             origin: T::RuntimeOrigin,
             netuid: NetUid,
-            mecid: MechId,
+            mechid: MechId,
             commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
             reveal_round: u64,
         ) -> DispatchResult {
             Self::do_commit_timelocked_mechanism_weights(
                 origin,
                 netuid,
-                mecid,
+                mechid,
                 commit,
                 reveal_round,
                 4,
@@ -2264,7 +2264,7 @@ mod dispatches {
         /// * `netuid` (`u16`):
         ///   - The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
+        /// * `mechid` (`u8`):
         ///   - The u8 mechanism identifier.
         ///
         /// * `commit` (`Vec<u8>`):
@@ -2289,7 +2289,7 @@ mod dispatches {
         pub fn commit_timelocked_mechanism_weights(
             origin: T::RuntimeOrigin,
             netuid: NetUid,
-            mecid: MechId,
+            mechid: MechId,
             commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
             reveal_round: u64,
             commit_reveal_version: u16,
@@ -2297,7 +2297,7 @@ mod dispatches {
             Self::do_commit_timelocked_mechanism_weights(
                 origin,
                 netuid,
-                mecid,
+                mechid,
                 commit,
                 reveal_round,
                 commit_reveal_version,

--- a/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
+++ b/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
@@ -25,7 +25,7 @@ pub fn migrate_crv3_commits_add_block<T: Config>() -> Weight {
     for (netuid_index, epoch, old_q) in CRV3WeightCommits::<T>::drain() {
         total_weight = total_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
-        let (netuid, _) = Pallet::<T>::get_netuid_and_subid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Pallet::<T>::get_netuid_and_mecid(netuid_index).unwrap_or_default();
         let commit_block = Pallet::<T>::get_first_block_of_epoch(netuid, epoch);
 
         // convert VecDeque<(who,cipher,rnd)> → VecDeque<(who,cb,cipher,rnd)>

--- a/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
+++ b/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
@@ -25,7 +25,7 @@ pub fn migrate_crv3_commits_add_block<T: Config>() -> Weight {
     for (netuid_index, epoch, old_q) in CRV3WeightCommits::<T>::drain() {
         total_weight = total_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
-        let (netuid, _) = Pallet::<T>::get_netuid_and_mecid(netuid_index).unwrap_or_default();
+        let (netuid, _) = Pallet::<T>::get_netuid_and_mechid(netuid_index).unwrap_or_default();
         let commit_block = Pallet::<T>::get_first_block_of_epoch(netuid, epoch);
 
         // convert VecDeque<(who,cipher,rnd)> → VecDeque<(who,cb,cipher,rnd)>

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -808,15 +808,15 @@ impl<T: Config> Pallet<T> {
         metagraphs
     }
 
-    pub fn get_mechagraph(netuid: NetUid, mecid: MechId) -> Option<Metagraph<T::AccountId>> {
-        if Self::ensure_mechanism_exists(netuid, mecid).is_err() {
+    pub fn get_mechagraph(netuid: NetUid, mechid: MechId) -> Option<Metagraph<T::AccountId>> {
+        if Self::ensure_mechanism_exists(netuid, mechid).is_err() {
             return None;
         }
 
         // Get netuid metagraph
         let maybe_meta = Self::get_metagraph(netuid);
         if let Some(mut meta) = maybe_meta {
-            let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+            let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
             // Update with mechanism information
             meta.netuid = NetUid::from(u16::from(netuid_index)).into();
@@ -840,8 +840,8 @@ impl<T: Config> Pallet<T> {
         let mut metagraphs = Vec::<Option<Metagraph<T::AccountId>>>::new();
         for netuid in netuids.clone().iter() {
             let mechanism_count = u8::from(MechanismCountCurrent::<T>::get(netuid));
-            for mecid in 0..mechanism_count {
-                metagraphs.push(Self::get_mechagraph(*netuid, MechId::from(mecid)));
+            for mechid in 0..mechanism_count {
+                metagraphs.push(Self::get_mechagraph(*netuid, MechId::from(mechid)));
             }
         }
         metagraphs
@@ -865,7 +865,7 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_selective_mechagraph(
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         metagraph_indexes: Vec<u16>,
     ) -> Option<SelectiveMetagraph<T::AccountId>> {
         if !Self::if_subnet_exist(netuid) {
@@ -874,7 +874,7 @@ impl<T: Config> Pallet<T> {
             let mut result = SelectiveMetagraph::default();
 
             for index in metagraph_indexes.iter() {
-                let value = Self::get_single_selective_mechagraph(netuid, mecid, *index);
+                let value = Self::get_single_selective_mechagraph(netuid, mechid, *index);
                 result.merge_value(&value, *index as usize);
             }
             // always include netuid even the metagraph_indexes doesn't contain it
@@ -1455,12 +1455,12 @@ impl<T: Config> Pallet<T> {
 
     fn get_single_selective_mechagraph(
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         metagraph_index: u16,
     ) -> SelectiveMetagraph<T::AccountId> {
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
-        // Default to netuid, replace as needed for mecid
+        // Default to netuid, replace as needed for mechid
         match SelectiveMetagraphIndex::from_index(metagraph_index as usize) {
             Some(SelectiveMetagraphIndex::Incentives) => SelectiveMetagraph {
                 netuid: netuid.into(),

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -24,8 +24,8 @@ impl<T: Config> Pallet<T> {
         let neuron_index: usize = neuron_uid.into();
         Emission::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0.into()));
         Consensus::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
-        for mecid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
-            let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+        for mechid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
+            let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
             Incentive::<T>::mutate(netuid_index, |v| Self::set_element_at(v, neuron_index, 0));
             Bonds::<T>::remove(netuid_index, neuron_uid); // Remove bonds for Validator.
 
@@ -111,8 +111,8 @@ impl<T: Config> Pallet<T> {
         Active::<T>::mutate(netuid, |v| v.push(true));
         Emission::<T>::mutate(netuid, |v| v.push(0.into()));
         Consensus::<T>::mutate(netuid, |v| v.push(0));
-        for mecid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
-            let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+        for mechid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
+            let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
             Incentive::<T>::mutate(netuid_index, |v| v.push(0));
             Self::set_last_update_for_uid(netuid_index, next_uid, block_number);
         }
@@ -205,8 +205,8 @@ impl<T: Config> Pallet<T> {
                     Keys::<T>::remove(netuid, neuron_uid);
                     BlockAtRegistration::<T>::remove(netuid, neuron_uid);
                     AssociatedEvmAddress::<T>::remove(netuid, neuron_uid);
-                    for mecid in 0..mechanisms_count {
-                        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+                    for mechid in 0..mechanisms_count {
+                        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
                         Weights::<T>::remove(netuid_index, neuron_uid);
                         Bonds::<T>::remove(netuid_index, neuron_uid);
                     }
@@ -264,8 +264,8 @@ impl<T: Config> Pallet<T> {
             StakeWeight::<T>::insert(netuid, trimmed_stake_weight);
 
             // Update incentives/lastupdates for mechanisms
-            for mecid in 0..mechanisms_count {
-                let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+            for mechid in 0..mechanisms_count {
+                let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
                 let incentive = Incentive::<T>::get(netuid_index);
                 let lastupdate = LastUpdate::<T>::get(netuid_index);
                 let mut trimmed_incentive = Vec::with_capacity(trimmed_uids.len());
@@ -302,8 +302,8 @@ impl<T: Config> Pallet<T> {
                 AssociatedEvmAddress::<T>::swap(netuid, old_neuron_uid, netuid, new_neuron_uid);
                 BlockAtRegistration::<T>::swap(netuid, old_neuron_uid, netuid, new_neuron_uid);
 
-                for mecid in 0..mechanisms_count {
-                    let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
+                for mechid in 0..mechanisms_count {
+                    let netuid_index = Self::get_mechanism_storage_index(netuid, mechid.into());
 
                     // Swap to new position and remap all target uids
                     Weights::<T>::swap(netuid_index, old_neuron_uid, netuid_index, new_neuron_uid);

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -52,23 +52,23 @@ impl<T: Config> Pallet<T> {
     pub fn do_commit_mechanism_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         commit_hash: H256,
     ) -> DispatchResult {
-        Self::internal_commit_weights(origin, netuid, mecid, commit_hash)
+        Self::internal_commit_weights(origin, netuid, mechid, commit_hash)
     }
 
     fn internal_commit_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         commit_hash: H256,
     ) -> DispatchResult {
-        // Ensure netuid and mecid exist
-        Self::ensure_mechanism_exists(netuid, mecid)?;
+        // Ensure netuid and mechid exist
+        Self::ensure_mechanism_exists(netuid, mechid)?;
 
         // Calculate subnet storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // 1. Verify the caller's signature (hotkey).
         let who = ensure_signed(origin)?;
@@ -277,7 +277,7 @@ impl<T: Config> Pallet<T> {
     pub fn do_commit_timelocked_mechanism_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
         reveal_round: u64,
         commit_reveal_version: u16,
@@ -285,7 +285,7 @@ impl<T: Config> Pallet<T> {
         Self::internal_commit_timelocked_weights(
             origin,
             netuid,
-            mecid,
+            mechid,
             commit,
             reveal_round,
             commit_reveal_version,
@@ -295,16 +295,16 @@ impl<T: Config> Pallet<T> {
     pub fn internal_commit_timelocked_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
         reveal_round: u64,
         commit_reveal_version: u16,
     ) -> DispatchResult {
-        // Ensure netuid and mecid exist
-        Self::ensure_mechanism_exists(netuid, mecid)?;
+        // Ensure netuid and mechid exist
+        Self::ensure_mechanism_exists(netuid, mechid)?;
 
         // Calculate netuid storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // 1. Verify the caller's signature (hotkey).
         let who = ensure_signed(origin)?;
@@ -439,26 +439,26 @@ impl<T: Config> Pallet<T> {
     pub fn do_reveal_mechanism_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         uids: Vec<u16>,
         values: Vec<u16>,
         salt: Vec<u16>,
         version_key: u64,
     ) -> DispatchResult {
-        Self::internal_reveal_weights(origin, netuid, mecid, uids, values, salt, version_key)
+        Self::internal_reveal_weights(origin, netuid, mechid, uids, values, salt, version_key)
     }
 
     fn internal_reveal_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         uids: Vec<u16>,
         values: Vec<u16>,
         salt: Vec<u16>,
         version_key: u64,
     ) -> DispatchResult {
         // Calculate netuid storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // --- 1. Check the caller's signature (hotkey).
         let who = ensure_signed(origin.clone())?;
@@ -536,7 +536,7 @@ impl<T: Config> Pallet<T> {
                     Self::do_set_mechanism_weights(
                         origin,
                         netuid,
-                        mecid,
+                        mechid,
                         uids.clone(),
                         values.clone(),
                         version_key,
@@ -748,13 +748,13 @@ impl<T: Config> Pallet<T> {
     fn internal_set_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         uids: Vec<u16>,
         values: Vec<u16>,
         version_key: u64,
     ) -> dispatch::DispatchResult {
         // Calculate subnet storage index
-        let netuid_index = Self::get_mechanism_storage_index(netuid, mecid);
+        let netuid_index = Self::get_mechanism_storage_index(netuid, mechid);
 
         // --- 1. Check the caller's signature. This is the hotkey of a registered account.
         let hotkey = ensure_signed(origin)?;
@@ -772,7 +772,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 3. Check to see if this is a valid network and sub-subnet.
-        Self::ensure_mechanism_exists(netuid, mecid)?;
+        Self::ensure_mechanism_exists(netuid, mechid)?;
 
         // --- 4. Check to see if the number of uids is within the max allowed uids for this network.
         ensure!(
@@ -935,7 +935,7 @@ impl<T: Config> Pallet<T> {
     ///  * 'netuid' (u16):
     ///    - The u16 network identifier.
     ///
-    ///  * 'mecid' (u8):
+    ///  * 'mechid' (u8):
     ///    - The u8 identifier of sub-subnet.
     ///
     ///  * 'uids' ( Vec<u16> ):
@@ -988,12 +988,12 @@ impl<T: Config> Pallet<T> {
     pub fn do_set_mechanism_weights(
         origin: T::RuntimeOrigin,
         netuid: NetUid,
-        mecid: MechId,
+        mechid: MechId,
         uids: Vec<u16>,
         values: Vec<u16>,
         version_key: u64,
     ) -> dispatch::DispatchResult {
-        Self::internal_set_weights(origin, netuid, mecid, uids, values, version_key)
+        Self::internal_set_weights(origin, netuid, mechid, uids, values, version_key)
     }
 
     /// ---- The implementation for the extrinsic batch_set_weights.
@@ -1108,8 +1108,8 @@ impl<T: Config> Pallet<T> {
         neuron_uid: u16,
         current_block: u64,
     ) -> bool {
-        let maybe_netuid_and_mecid = Self::get_netuid_and_mecid(netuid_index);
-        if let Ok((netuid, _)) = maybe_netuid_and_mecid
+        let maybe_netuid_and_mechid = Self::get_netuid_and_mechid(netuid_index);
+        if let Ok((netuid, _)) = maybe_netuid_and_mechid
             && Self::is_uid_exist_on_network(netuid, neuron_uid)
         {
             // --- 1. Ensure that the diff between current and last_set weights is greater than limit.
@@ -1121,7 +1121,7 @@ impl<T: Config> Pallet<T> {
                 >= Self::get_weights_set_rate_limit(netuid);
         }
 
-        // --- 3. Non registered peers cant pass. Neither can non-existing mecid
+        // --- 3. Non registered peers cant pass. Neither can non-existing mechid
         false
     }
 

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -1108,8 +1108,8 @@ impl<T: Config> Pallet<T> {
         neuron_uid: u16,
         current_block: u64,
     ) -> bool {
-        let maybe_netuid_and_subid = Self::get_netuid_and_subid(netuid_index);
-        if let Ok((netuid, _)) = maybe_netuid_and_subid
+        let maybe_netuid_and_mecid = Self::get_netuid_and_mecid(netuid_index);
+        if let Ok((netuid, _)) = maybe_netuid_and_mecid
             && Self::is_uid_exist_on_network(netuid, neuron_uid)
         {
             // --- 1. Ensure that the diff between current and last_set weights is greater than limit.

--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -388,8 +388,8 @@ impl<T: Config> Pallet<T> {
         // 3.5 Swap WeightCommits
         // WeightCommits( hotkey ) --> Vec<u64> -- the weight commits for the hotkey.
         if is_network_member {
-            for mecid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
-                let netuid_index = Self::get_mechanism_storage_index(netuid, MechId::from(mecid));
+            for mechid in 0..MechanismCountCurrent::<T>::get(netuid).into() {
+                let netuid_index = Self::get_mechanism_storage_index(netuid, MechId::from(mechid));
                 if let Ok(old_weight_commits) =
                     WeightCommits::<T>::try_get(netuid_index, old_hotkey)
                 {

--- a/pallets/subtensor/src/tests/epoch_logs.rs
+++ b/pallets/subtensor/src/tests/epoch_logs.rs
@@ -108,8 +108,8 @@ fn set_weights(netuid: NetUid, weights: Vec<Vec<u16>>, indices: Vec<u16>) {
 
 /// Write sparse weight rows **for a specific mechanism**.
 /// `rows` is a list of `(validator_uid, row)` where `row` is `[(dest_uid, weight_u16)]`.
-fn set_weights_for_mech(netuid: NetUid, mecid: MechId, rows: Vec<(u16, Vec<(u16, u16)>)>) {
-    let netuid_index = SubtensorModule::get_mechanism_storage_index(netuid, mecid);
+fn set_weights_for_mech(netuid: NetUid, mechid: MechId, rows: Vec<(u16, Vec<(u16, u16)>)>) {
+    let netuid_index = SubtensorModule::get_mechanism_storage_index(netuid, mechid);
     for (uid, sparse_row) in rows {
         Weights::<Test>::insert(netuid_index, uid, sparse_row);
     }

--- a/pallets/subtensor/src/tests/mechanism.rs
+++ b/pallets/subtensor/src/tests/mechanism.rs
@@ -116,7 +116,7 @@ fn test_netuid_and_subnet_from_index() {
             );
 
             let (netuid, mecid) =
-                SubtensorModule::get_netuid_and_subid(NetUidStorageIndex::from(*netuid_index))
+                SubtensorModule::get_netuid_and_mecid(NetUidStorageIndex::from(*netuid_index))
                     .unwrap();
             assert_eq!(netuid, NetUid::from(expected_netuid));
             assert_eq!(mecid, MechId::from(expected_subid));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -946,8 +946,8 @@ impl OnMetadataCommitment<AccountId> for ResetBondsOnCommit {
     fn on_metadata_commitment(netuid: NetUid, address: &AccountId) {
         // Reset bonds for each mechanism of this subnet
         let mechanism_count = SubtensorModule::get_current_mechanism_count(netuid);
-        for mecid in 0..u8::from(mechanism_count) {
-            let netuid_index = SubtensorModule::get_mechanism_storage_index(netuid, mecid.into());
+        for mechid in 0..u8::from(mechanism_count) {
+            let netuid_index = SubtensorModule::get_mechanism_storage_index(netuid, mechid.into());
             let _ = SubtensorModule::do_reset_bonds(netuid_index, address);
         }
     }
@@ -2427,8 +2427,8 @@ impl_runtime_apis! {
             SubtensorModule::get_metagraph(netuid)
         }
 
-        fn get_mechagraph(netuid: NetUid, mecid: MechId) -> Option<Metagraph<AccountId32>> {
-            SubtensorModule::get_mechagraph(netuid, mecid)
+        fn get_mechagraph(netuid: NetUid, mechid: MechId) -> Option<Metagraph<AccountId32>> {
+            SubtensorModule::get_mechagraph(netuid, mechid)
         }
 
         fn get_subnet_state(netuid: NetUid) -> Option<SubnetState<AccountId32>> {
@@ -2458,8 +2458,8 @@ impl_runtime_apis! {
             SubtensorModule::get_coldkey_auto_stake_hotkey(coldkey, netuid)
         }
 
-        fn get_selective_mechagraph(netuid: NetUid, mecid: MechId, metagraph_indexes: Vec<u16>) -> Option<SelectiveMetagraph<AccountId32>> {
-            SubtensorModule::get_selective_mechagraph(netuid, mecid, metagraph_indexes)
+        fn get_selective_mechagraph(netuid: NetUid, mechid: MechId, metagraph_indexes: Vec<u16>) -> Option<SelectiveMetagraph<AccountId32>> {
+            SubtensorModule::get_selective_mechagraph(netuid, mechid, metagraph_indexes)
         }
     }
 


### PR DESCRIPTION
## Summary
- Standardizes mechanism identifier naming across the codebase
- Renames `sub_id` parameter to `mecid` in public API functions to match the `MechId` type
- Renames `get_netuid_and_subid` function to `get_netuid_and_mecid`
- Updates internal variable names from `sub_id_*` to `mecid_*`
- Updates comments to use `mecid` terminology

## Changes
Files modified:
- `pallets/subtensor/src/subnets/mechanism.rs` - Core naming changes
- `pallets/subtensor/src/epoch/run_epoch.rs` - Updated function calls
- `pallets/subtensor/src/subnets/weights.rs` - Updated function calls
- `pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs` - Updated function calls
- `pallets/subtensor/src/tests/mechanism.rs` - Updated test calls

## Test plan
- [x] Verified `cargo check --lib` passes
- [x] Verified `cargo check --tests` passes
- All changes are internal naming refactors with no behavioral changes

Fixes #2101

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297