### PR TITLE
fix: prevent lock cost drop after subnet registration

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -511,7 +511,12 @@ impl<T: Config> Pallet<T> {
         let last_lock_block = Self::get_network_last_lock_block();
         let current_block = Self::get_current_block_as_u64();
         let lock_reduction_interval = Self::get_lock_reduction_interval();
-        let mult: TaoCurrency = if last_lock_block == 0 { 1 } else { 2 }.into();
+        let mult: TaoCurrency = if last_lock_block == 0 && last_lock <= min_lock {
+            1
+        } else {
+            2
+        }
+        .into();
 
         let mut lock_cost = last_lock.saturating_mul(mult).saturating_sub(
             last_lock


### PR DESCRIPTION
- treat missing last_lock_block as post-registration when last_lock > min_lock
- add regression test for lock cost multiplier

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.