### PR TITLE
fix voting power ema alpha check

### DIFF
--- a/contract-tests/src/subtensor.ts
+++ b/contract-tests/src/subtensor.ts
@@ -1,11 +1,12 @@
 import * as assert from "assert";
 import { devnet, MultiAddress } from '@polkadot-api/descriptors';
-import { TypedApi, TxCallData, Binary, Enum } from 'polkadot-api';
+import { TypedApi, TxCallData, Binary, Enum, getTypedCodecs } from 'polkadot-api';
 import { KeyPair } from "@polkadot-labs/hdkd-helpers"
 import { getAliceSigner, waitForTransactionCompletion, getSignerFromKeypair, waitForTransactionWithRetry } from './substrate'
 import { convertH160ToSS58, convertPublicKeyToSs58, ethAddressToH160 } from './address-utils'
 import { tao } from './balance-math'
 import internal from "stream";
+import { createCodec } from "scale-ts";
 
 // create a new subnet and return netuid
 export async function addNewSubnetwork(api: TypedApi<typeof devnet>, hotkey: KeyPair, coldkey: KeyPair) {
@@ -26,6 +27,9 @@ export async function addNewSubnetwork(api: TypedApi<typeof devnet>, hotkey: Key
     const newTotalNetworks = await api.query.SubtensorModule.TotalNetworks.getValue()
     // could create multiple subnetworks during retry, just return the first created one
     assert.ok(newTotalNetworks > totalNetworks)
+
+    // rewrite network last lock cost to 0, to avoid the lock cost calculation error
+    await setNetworkLastLockCost(api)
     return totalNetworks
 }
 
@@ -398,4 +402,19 @@ export async function sendWasmContractExtrinsic(api: TypedApi<typeof devnet>, co
         storage_deposit_limit: BigInt(1000000000)
     })
     await waitForTransactionWithRetry(api, tx, signer)
-}   
+}
+
+export async function setNetworkLastLockCost(api: TypedApi<typeof devnet>) {
+    const alice = getAliceSigner()
+    const key = await api.query.SubtensorModule.NetworkLastLockCost.getKey()
+    const codec = await getTypedCodecs(devnet);
+    const value = codec.query.SubtensorModule.NetworkLastLockCost.value.enc(BigInt(0))
+    const internalCall = api.tx.System.set_storage({
+        items: [[Binary.fromHex(key), Binary.fromBytes(value)]]
+    })
+    const tx = api.tx.Sudo.sudo({ call: internalCall.decodedCall })
+    await waitForTransactionWithRetry(api, tx, alice)
+
+    const valueOnChain = await api.query.SubtensorModule.NetworkLastLockCost.getValue()
+    assert.equal(BigInt(0), valueOnChain)
+}

--- a/contract-tests/src/subtensor.ts
+++ b/contract-tests/src/subtensor.ts
@@ -418,5 +418,5 @@ export async function setNetworkLastLockCost(api: TypedApi<typeof devnet>, defau
     await waitForTransactionWithRetry(api, tx, alice)
 
     const valueOnChain = await api.query.SubtensorModule.NetworkLastLockCost.getValue()
-    assert.equal(BigInt(0), valueOnChain)
+    assert.equal(defaultNetworkLastLockCost, valueOnChain)
 }

--- a/contract-tests/test/votingPower.precompile.test.ts
+++ b/contract-tests/test/votingPower.precompile.test.ts
@@ -76,8 +76,8 @@ describe("Test VotingPower Precompile", () => {
 
             assert.ok(alpha !== undefined, "getVotingPowerEmaAlpha should return a value");
             assert.strictEqual(typeof alpha, 'bigint', "getVotingPowerEmaAlpha should return a bigint");
-            // Default alpha is 0.1 * 10^18 = 100_000_000_000_000_000
-            assert.strictEqual(alpha, BigInt("100000000000000000"), "Default alpha should be 0.1 (100_000_000_000_000_000)");
+            // Default alpha is  0_003_570_000_000_000_000 // 0.00357 * 10^18 = 2 weeks e-folding (time-constant) @ 361
+            assert.strictEqual(alpha, BigInt("3570000000000000"), "Default alpha should be 0.00357 * 10^18 (3570000000000000)");
         });
     });
 


### PR DESCRIPTION
## Description

Fix an e2e test case for getVotingPowerEmaAlpha method, the value in test is different with one defined in rust.
Fix the accumulated network registration cost, set the value to default after registration is done.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.