### PR TITLE
chore(deps): upgrade ed25519-dalek from 2.1.0 to 3.0.0-pre.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ subtensor-swap-interface = { default-features = false, path = "pallets/swap-inte
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
 
-ed25519-dalek = { version = "2.1.0", default-features = false }
+ed25519-dalek = { version = "3.0.0-pre.6", default-features = false }
 async-trait = "0.1"
 cargo-husky = { version = "1", default-features = false }
 clap = "4.5.4"


### PR DESCRIPTION
Upgrades `ed25519-dalek` from version `2.1.0` to `3.0.0-pre.6` (major pre-release version bump).

This is a major version upgrade. Please verify that any code using `ed25519-dalek` APIs still compiles and behaves correctly, as breaking changes may have been introduced between 2.x and 3.0.0-pre.6. Review the ed25519-dalek changelog or migration guide for details on API changes before merging.