### PR TITLE
chore(deps): upgrade codec (parity-scale-codec) from 3.7.5 to 0.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
 cargo-husky = { version = "1", default-features = false }
 clap = "4.5.4"
-codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
+codec = { package = "parity-scale-codec", version = "0.0.7", default-features = false }
 enumflags2 = "0.7.9"
 futures = "0.3.30"
 hex = { version = "0.4", default-features = false }


### PR DESCRIPTION
Upgrades the `codec` dependency (parity-scale-codec) from version 3.7.5 to 0.0.7 in the workspace `Cargo.toml`.

Note: This is a major version downgrade (3.x → 0.0.7). No changelog was available for this release. The `codec` crate is used extensively throughout the pallets for encoding/decoding (e.g., `Encode`, `Decode`, `Compact`). If this target version introduces breaking API changes relative to 3.7.5, additional code changes may be required after testing.