### PR TITLE
chore(deps): upgrade hex-literal from 0.4.1 to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ codec = { package = "parity-scale-codec", version = "3.7.5", default-features = 
 enumflags2 = "0.7.9"
 futures = "0.3.30"
 hex = { version = "0.4", default-features = false }
-hex-literal = "0.4.1"
+hex-literal = "1.1.0"
 jsonrpsee = { version = "0.24.9", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }


### PR DESCRIPTION
Upgrades `hex-literal` from version 0.4.1 to 1.1.0 (major version bump). This updates the version constraint in `Cargo.toml`. Please verify that any usages of the `hex!` macro remain compatible with the new version, as this is a major release and may include breaking changes.