### PR TITLE
chore(deps): upgrade alloy-primitives from 0.8.23 to 1.5.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 walkdir = "2"
 approx = "0.5"
-alloy-primitives = { version = "0.8.23", default-features = false }
+alloy-primitives = { version = "1.5.6", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }
 semver = "1.0"
 toml_edit = "0.22"


### PR DESCRIPTION
Upgrades `alloy-primitives` from `0.8.23` to `1.5.6` (major version bump). This updates the version constraint in the workspace `Cargo.toml`. Please verify that any code using `alloy-primitives` APIs remains compatible with the new major version, as breaking changes may have been introduced.