### PR TITLE
chore(deps): upgrade rayon from 1.10 to 1.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ syn = { workspace = true, features = [
 quote.workspace = true
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 walkdir.workspace = true
-rayon = "1.10"
+rayon = "1.11.0"
 
 [workspace]
 members = [


### PR DESCRIPTION
Upgrades rayon from version 1.10 to 1.11.0 (minor version bump). No breaking changes expected. Only the version constraint in Cargo.toml needs to be updated.