### PR TITLE
chore(deps): upgrade ed25519-dalek from 2.1.0 to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ subtensor-swap-interface = { default-features = false, path = "pallets/swap-inte
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
 
-ed25519-dalek = { version = "2.1.0", default-features = false }
+ed25519-dalek = { version = "2.2.0", default-features = false }
 async-trait = "0.1"
 cargo-husky = { version = "1", default-features = false }
 clap = "4.5.4"


### PR DESCRIPTION
Bumps `ed25519-dalek` from 2.1.0 to 2.2.0 (minor version update). No breaking changes are expected for this minor release.