### PR TITLE
chore(deps): upgrade cargo-husky from 1 to 1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ subtensor-chain-extensions = { default-features = false, path = "chain-extension
 
 ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
-cargo-husky = { version = "1", default-features = false }
+cargo-husky = { version = "1.5.0", default-features = false }
 clap = "4.5.4"
 codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false }
 enumflags2 = "0.7.9"


### PR DESCRIPTION
Bumps `cargo-husky` from version `1` to `1.5.0`.

This is a minor version bump. No changelog was available, but as a minor update it should be backwards compatible. The version constraint in `Cargo.toml` has been updated to pin to `1.5.0`.