### PR TITLE
chore(deps): upgrade jsonrpsee from 0.24.9 to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ enumflags2 = "0.7.9"
 futures = "0.3.30"
 hex = { version = "0.4", default-features = false }
 hex-literal = "0.4.1"
-jsonrpsee = { version = "0.24.9", default-features = false }
+jsonrpsee = { version = "0.26.0", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }
 memmap2 = "0.9.8"


### PR DESCRIPTION
Upgrades `jsonrpsee` from version `0.24.9` to `0.26.0` (minor version bump).

No changelog was available, but as a minor release it should be backwards compatible. The version string in `Cargo.toml` has been updated; no code changes were required in the consuming files as the public API used (`RpcResult`, `proc_macros::rpc`, `ErrorObjectOwned`, `ErrorObject`, `RpcModule`, `Methods`) remains stable across this version range.