### PR TITLE
chore(deps): upgrade ndarray from 0.16.1 to 0.17.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ jsonrpsee = { version = "0.24.9", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }
 memmap2 = "0.9.8"
-ndarray = { version = "0.16.1", default-features = false }
+ndarray = { version = "0.17.2", default-features = false }
 rand = "0.8.5"
 scale-info = { version = "2.11.2", default-features = false }
 serde = { version = "1.0.214", default-features = false }


### PR DESCRIPTION
Upgrades `ndarray` from version `0.16.1` to `0.17.2` (minor version bump).

This is a minor version upgrade that should be backwards compatible. Please verify that any ndarray usage in the codebase compiles and behaves correctly with the new version, as minor releases may include new APIs or deprecations.