### PR TITLE
Enable `metadata-hash` feature in localnet builds  

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -268,7 +268,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 392,
+    spec_version: 393,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -35,14 +35,14 @@ if [ "$fast_runtime" == "False" ]; then
   echo "fast_runtime is Off"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet"}"
+  : "${FEATURES:="pow-faucet metadata-hash"}"
   BUILD_DIR="$BASE_DIR/target/non-fast-runtime"
 else
   # Block of code to execute if fast_runtime is not False
   echo "fast_runtime is On"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet fast-runtime"}"
+  : "${FEATURES:="pow-faucet metadata-hash fast-runtime"}"
   BUILD_DIR="$BASE_DIR/target/fast-runtime"
 fi
 


### PR DESCRIPTION
Localnet builds were missing the `metadata-hash` compile feature.
Without it, the node rejects any transaction signed with `mode=1`
(`CheckMetadataHash -> CannotLookup`), which makes Ledger hardware wallets unusable - the `Generic Polkadot Ledger app` requires `mode=1` and cannot sign without it.

Production builds (Dockerfile) already include `metadata-hash`. This adds it to localnet so Ledger works consistently across all environments.