### PR TITLE
hotfix: migrate fix bad hk swap

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -166,7 +166,9 @@ mod hooks {
                 // Fix staking hot keys
                 .saturating_add(migrations::migrate_fix_staking_hot_keys::migrate_fix_staking_hot_keys::<T>())
                 // Migrate coldkey swap scheduled to announcements
-                .saturating_add(migrations::migrate_coldkey_swap_scheduled_to_announcements::migrate_coldkey_swap_scheduled_to_announcements::<T>());
+                .saturating_add(migrations::migrate_coldkey_swap_scheduled_to_announcements::migrate_coldkey_swap_scheduled_to_announcements::<T>())
+                // Migrate fix bad hk swap
+                .saturating_add(migrations::migrate_fix_bad_hk_swap::migrate_fix_bad_hk_swap::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
@@ -1,0 +1,295 @@
+use super::*;
+use codec::EncodeLike;
+use frame_support::{traits::Get, weights::Weight};
+use frame_system::pallet_prelude::BlockNumberFor;
+use log;
+use safe_math::FixedExt;
+use scale_info::prelude::string::String;
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::{AccountId32, MultiAddress};
+use substrate_fixed::types::U64F64;
+
+pub fn try_restore_shares<T: Config>() -> Weight
+{
+    let mut weight = T::DbWeight::get().reads(1);
+
+    let effected_hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+    let hk_as_acctid32: AccountId32 = AccountId32::from_string(effected_hotkey).unwrap();
+	let hk_as_multiaddr = MultiAddress::Address32(hk_as_acctid32.into());
+	let hk_as_acctid: T::AccountId = T::AccountId::decode(hk_as_acctid32.as_mut()).unwrap();
+
+    let effected_netuid = 59.into();
+
+	let diffs = [
+		("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981),
+		("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
+		("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
+		("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
+		("5F7BkPL3EVjKTYMbBkEmPAtTZQSGeyNzFPaf1DtebPFmJsJ7", -4016510),
+		("5EefisctzgWdVGFQaL4LjFFacTE7dM4YJVNy3ogGBQoapTU1", -13106893093),
+		("5CwkvpBxHCaRK9xBC2n6WdhpF5zg9t5WLkGorASaoErdynFQ", 439139249152),
+		("5FU7ErUtmi22xuqeeCYVpNZp6WVSSL98hqDi5iyeZbkXtkbe", -35958768555),
+		("5D7HL8T95qkHQTPFjgSFCjRoeM7oE3vQBYjiR1kAPbPxcMKu", -201914811997),
+		("5HL3pPdDFY94Qdf8VnbfT4W6LXFkpd68Y5GSGzNJfntMdGZX", -235660917467),
+		("5EcYAz8SBKWsogA6meJmVXcwVp4tjCvw3ZnJE6UXTyWNUdF2", -500070769668),
+		("5EoE3c7XMf8TN3yudAaFjv4yvjtWYRviHcXi73EXkLHmWTCB", -86442928436),
+		("5CMDjL7t2biHGREBwrmd8renD74FLEhjCVqfJG2MXckWBwDu", 1039317),
+		("5CVGKimL4cLgyTqvYKQbPKYFZfiztsdczU7HrwNdSFKbbn5D", 4224201),
+		("5HmZnEcW4eHbXmUEFWJbc4GHnBBYEK8ZPsFa25PuEmP5iuwM", -13156128),
+		("5FNa4J4fTKh555CEyXHgR29RicSm8nTEHx36utTa4MJepJyX", -9519954),
+		("5Gun93uQgffYpxqMKSmfG18AHiQW7Z2GR2dfPPR8W188vJYc", -1127662),
+		("5HW1C4js4RyjQqNwALSUZC8NJ2WinD5Si2X2XkstXrMW2uYo", -34457336758),
+		("5EqMhjdLY9h64ui2mizRZyBp1mEPJ7s4TsfAxQSQkAFmMfzE", -9346443829744),
+		("5H3XwzydgE2XUGoJCR4dSj7tkd7uxZDJqik69hux2DBcruom", -1215347774),
+		("5DjkmYpCUX6dBTvGoyN9j4QZhtMPhdcywDE8cJ8Qq1vg4X6e", -3603984447),
+		("5E7Z7Btjz74XpZLH5fRzfZqiHCo4j9PXKfqi88kQ5MFrds34", -823907380854),
+		("5DSBWN4hN9413C6o6A2hR9tYUbHjWsQqPRV74GrnCrMkCGJx", -309708781),
+		("5FMLRmKPqsTsMbakpVUwoYro1P64QXVNTWyzNDugaNwSKRzF", -137525398263),
+		("5EFZf5pnTqLegv6gxCrb6TKBQBGz9xLJNK8x9eR273cSons6", -1521760918),
+		("5CGAGEuMLaidBDk8bDZKJb23dxRSP1wLenLALGLw8BTG1E3W", -544739696),
+		("5HSzRtcQjD5KP6Nh2GVSS16aLDe6q9R33Wpu6s2eEeeo3AYS", -2309184790),
+		("5DALvFDcfANQJcWz6AXMfDqabnoZhdDMoH6FxqYUibug1ja7", -369405632507),
+		("5Fy8iWkpcbsskmEN1nYZDdS9zKh167Em9RRYisoss7jaYXxi", 15257429),
+		("5CQCVTRyqJgZKBDmtHzpoF8su6BScLcNGbX8t3WMm5qYbbJH", -10721968),
+		("5DXZByh2NS4MU61a1aaLrcLYpyzpJgHe95TEBdcEN2cF1SA5", -655946136),
+		("5EX5yAYiABFzKDQJDe1kRVwFm3XRRY4HyLMe4Vu9A5U2VEVT", -325581360246),
+		("5FvabwjtyW887gtc7vUnUc47KVhy17UeaNLRjzTg5nkVACMP", -77588524213),
+		("5HTbYi5cmgWJxvyTy9JeYdtnjoDzjXnEXTGFsPEVx9iRPmVF", -53542953784),
+		("5CWzmvA17MAMQ9mnAecLxFXS2N8846rz6T7m4QNHyVtJVq4j", 2672295922502),
+		("5DSYntgHZY4krYUtkkQZyyoffVtu5e8rYWhXuhs832zY6YKy", -2680205688),
+		("5EYyTFyLDqXscaa5VtXTvUc3x2ow2TeT8G12ZDMZwE6uFWPQ", -39165843935),
+		("5CohfM1qdyNwdeJEex1Zyht3S2WS48rV993DmVbyKs2mEEd6", -4004685632),
+		("5Gx6Y7UQD39Latgxigr6mHbnh1herpwNPau2PjvzwLWEjXL3", -559504),
+		("5Hh4Efq5WDwe8URjjUqUNX8KxtMwLHLViwoRvXfEpXQCZakh", -32541090531),
+		("5GWRHC7Nd8njqTPsdJkp6ngniCCBu9UjGhLfxp2jF1fPrfZ4", -5394093031),
+		("5GNAB64UN32krzr3Xxu5LW6naeu2P3XULcdBCR9VZ5Libyit", -24884230),
+		("5EEz25th1nYNM5xR1UsyFFAUaXMjdHqLxZ3wUjyHokYbXHku", -12525171),
+		("5HKJq4JCS9xoKdYhcRnsRp1bodovba7ncd5KTYVwfReKaxHT", -408133990236),
+		("5DXs7x664RL5NdSW77DTseLiu84unstuHGuqvmY61UtJwzRN", -3095078614148),
+		("5CDfdDaA2p9sK1ia5yMVYfzgtFs2e1TrSAxuQqXoS28Lcrxf", -1032856892),
+		("5Ecg4vD2zKXHDFhQqogWq1dZdijPsDty8rGsZu3raeoJSiXb", -995678),
+		("5C5Yg63TNLb68Tu819qXd3Bt4giG8mAPzLmAFSqa2HC1R5Rm", -40818739830910),
+		("5HHH25Wuf9rmVuk9cMKU1hCCPJ1qbHBd1SyHj91R3fMT36yb", -391416057906),
+		("5GKGGE5YLHoDciYJ6Ec2YnUP3SykSQPA47hqmwBP63EtVrd9", -413944553000),
+		("5CSi9ZLyiXfLeYtEFaZSBuTofNMRnXEJEJE9CS4gGaT6CkWt", -17811605275),
+		("5CSoA7QVdFHHBZz53bbRV2mC5vhL64ehhWa8ibtLppmt2n3J", -65701320107),
+		("5GpA5BtfMMX52rXztrha79YqfwR4YaSfTuAcb48Yt73U4h71", -2194562),
+		("5Euz5wpb4xiDWfV1A6AKK6i6ca3WoZQD5hCVyf1fws8GXh4z", -6143407839874),
+		("5DZzmhCG7SMK3LwrkmHZ8ZBwaAByMjfBpEid14nNQdxHipCE", -386645),
+		("5Fc9Vo3hkbr6bPxJpjQo5sQ43L5Hc2G8R5BdqRYF8psvB5pw", 55668553),
+		("5GuSHC3iowySHLDW4pEyEZE6PKxKP62YpJYJyBy5tijzAnYz", -159317636526),
+		("5HVVZrUBPvjYHiwaSvtvaN9GZogoznM49m2AEmVW6RXnYCka", -1995572213),
+		("5EcGpeV2wjkCVsBjsBifSWbdcqH98b6oEY8beDY59c4fXkhw", -177096614584),
+		("5GnCjvWJEESwVNFZzy85zbBzw26etuEt87WiqsE3ee2Ws1wm", -1961445),
+		("5GWuPUpTuChAqKxvU22TRLvRkBFiyWWZnq9cLpJN6SSvkho1", -94157569391),
+		("5FXHf7q5rvBXnzQgmsa31Db9rjcRy6ZHKMiyDSb8Vs5p2msN", -688433531658),
+		("5GbxkzytnvbRuNQ7qxPpfPuWMoeitS8V4KDY9jSshE5fDegD", -19085313),
+		("5Gus1B7c9uWkky7Yawh2tKR1V6AMh5DbqUBPq881JHqeqVqY", -16101671818),
+		("5DLhRdbvWkYYScDmwx4QgJfieSN4apBWbZ2yno3MfgbR8hBP", -21062025),
+		("5Cg5kVyNEs7MWWRHU8X5MHwX5cN3aegvC4RBt2JK19w2GiR8", -2593737050),
+		("5Dkushsxtc8AdCf287MtTYHQv9DoZeBRpttUpBtmyFhGy3uR", -48672832345630),
+		("5EqNqVsHj9bQVyEujcm62zjMYUFhTLY7rTP854txSrJzyoco", -3828526),
+		("5Dea6d6nKErEbRQ4MBGuCALn8NZ2xo4kaa51hB5KMriPBkEM", -1560192853875),
+		("5DNt2XDWdeMd4H92FLnfUvkqyXzmavezHvzLboP3VgT1xLZV", -831964576998),
+		("5FKtFoTeK8aaG6HZTrDgvoYHVQ5NY4S9VyV7W5K74cWcwLYA", -60823501166),
+		("5GEBanZKUU7Hrf8K2VNi33HxyJRstgQ3WD3odHgvMj2nPbhi", -98946626902),
+		("5CUtw7LYB2n2bzgXt6YnmKDHt6PsB3kKAyD9azYJNcRG8TNg", -9779588557490),
+		("5EynbF72b12fbgMvEeL1vJSY342rCryNbuwxFivU1Xevtmv3", -17314385200455),
+		("5CapiZRuULed8ConS1gbjMVgnwcT5JnQah7tx6sZnK7sJJuJ", -5810972),
+		("5DnaxLaNduf41WM6WWZ4fkzcGzWNWx6eLJyQpSaMueUGCsaU", -12668760),
+		("5Cqz9SChYPxTFZ2623rE2aQQ5ttQoLwZ8yfwYgiZyQDANqZn", -683549),
+		("5C8ZcLzF23GrXKdH4Pg3ZXC3vKQsF5PM8VvhzzxzTQksgj8e", -44720570590),
+		("5GuNsmoswrP6hTKZkKcpTpZftTMKrmnCHvTL2V3NHJy2fpen", -5042891812715),
+		("5F1TYDkLnP36HHY5btigxyKUPzBraxdrU1aX1bqFfPfcfnzU", -1189104279832),
+		("5Dc384z9HuTGF6oratZs1fLciCHtPZaLhrHfCVw82a5AikWZ", -616163196988),
+		("5DhcaEUsRKhZQ31qRffJqjtLmFkbVaCebn8nVjYhvB4KJtX5", -17746006723),
+		("5HYE7z3xTcrN1rqz54NyZRAkehFfRMcaEcdoMq5g5ATET5wQ", 212509751245),
+		("5F97DdEVTy9gPCtN6jkJJENDJuQiRGiwbMVSL74qRq8FCq5W", 2225287736222),
+		("5FUVN133rSvuKXgsXKMR2ZEaysxZjkRUFUWS1UMyNGre9xFV", -73216740161),
+		("5CZeimtfpRqQgPxVwr1MzfG2Sok8E1AMERHo6vUmEdRS5JiU", -3937802),
+		("5Eqq2JwGh7qbtnjPiFEPmmnHxs3S4J4Ahg8fr4sybZV1tPdY", -173406860562),
+		("5ERfDw6K3GmQqwqsEG6foFtu7VsYGifPi556UJKQsBnfbHKN", 96022588728),
+		("5Ek8RkU6KMv5Fx7yivRVoQkuJYAKhULWiLWDpbGG4hvR9HFD", 968139369093),
+		("5HpCpGALzqgnDTP1HXFiuhzD5MFaDTRHjXBCvaMY9LNNRkT9", 104943979521),
+		("5FYqS77gxW9gHG8id1YYPS7Cd4TQmNUMhF8h3S77Fq2VvvRQ", 729199757977),
+		("5FtBqMg13pNf1N6TwfG6BmwyaDM77mkeQ16UTHsGasrVDedX", 131457064336),
+		("5GbnWR2XhWrRMt123SdrLbR9G2a4N5dtzA3TSu3Czkzoeu7x", 2295599153),
+		("5GgiowcCG4kLpwkCTGxxQJQv8WwKFyBQ6McPRmqKtWPy8EaK", 113838605389),
+		("5FL5YtYozpUAGaiVWonpbwEYdEMij3obJHSH3ACY4vgWmDgy", 8689039),
+		("5Egq58bxRv7boM2s3rnDxx1udnkzxPQ23HuoqohVxjh9RenC", 216373234348),
+		("5FRGeeEgRNR8U33FDKvN7yUgts8zR3qRJH4yKKWoR9GswBRb", 2196574958718),
+		("5FnhSy79BPYyrmmFsbckinQw1fLiLqqPkQL2vgZwPxbRfu3k", 42319631507),
+		("5Hj8jMhqAv7cfyRh5STfbZefMhv17QxZ1RxWq9jNcLAEsRRo", 132216702183491),
+		("5EXYTGMqumAH6RLQgHwkMEMnSvHcpHc89R6U8krfNJTYWm9J", 504320264499),
+		("5EFh8ctzmytXURqrCTUBWHTs87f7TMWB6XKUzdqxKXVUtvS2", 2209599669432),
+		("5CqVqEcRBkw7Gm2reJ33cj7puR9W2Tq7qsLxSruV1BgnMqKN", 1033387458788),
+		("5D79enmLSGimsruoraGagofhaSeYJZvGUqFCCrr83ZfZs1HS", 7591184215233),
+		("5HbpyjsvyXLWtf1QT1CyNUdyut6scM5dM7ytm8hoxFvRtU1i", 129833188275),
+		("5CnxCi7CdEriWSdw4LcXdbtjodxA6uTat4gBm4wuT9QToMdo", 3132978),
+		("5G48fiQjhAd8hc4rYc6GituCuAPKznL28jyyyq1auMyZiG4t", 514913328178),
+		("5FFGjW2hJ7tQ41qghSsLP4cVmA8j9pZVSrr2CrLG7fQAsLHJ", 346794972723),
+		("5FWjnxeRMtMFxRc9kvZKCG5iJAyyz2kmXV8u3kqyiXizZtiz", 225939835005),
+		("5CUw3sB4oxd3dVSHUr3kxsB591VEjaPzr444KkfjwVFnLRfJ", 208250614494),
+		("5EaBhxNUwMRyKsaeA2BEjDCrvwE5J8FDSpfCHK9gGmnmbhCa", 278083207003),
+		("5GHJ5HxFxYQyVoNFUxR3JCqqCKRumaFCY7N5zMxwF4CpRUWr", 1381466224829),
+		("5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo", 774889),
+	];
+
+    let curr_total_alpha =
+        U64F64::from_num(TotalHotkeyAlpha::<T>::get(hk_as_acctid, effected_netuid));
+    let curr_total_hotkey_shares = TotalHotkeyShares::<T>::get(hk_as_acctid, effected_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().reads(2));
+
+    let mut total_burned: AlphaBalance = 0.into();
+    let mut total_given: U64F64 = U64F64::from_num(0);
+    let mut total_lost: U64F64 = U64F64::from_num(0);
+
+    for (ck, diff) in diffs {
+        if let Ok(ck_as_acctid) = AccountId32::from_string(ck) {
+            let curr_shares = U64F64::from_num(Alpha::<T>::get((
+                hk_as_acctid,
+                ck_as_acctid,
+                effected_netuid,
+            )));
+            let curr_bal = curr_shares
+                .safe_div(curr_total_hotkey_shares)
+                .saturating_mul(curr_total_alpha);
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            if diff < 0 {
+                // remove excess, if possible
+                let diff_fixed = U64F64::from_num(diff * -1);
+                total_given = total_given.saturating_add(diff_fixed);
+                if diff_fixed <= curr_bal {
+                    let as_alpha_balance: AlphaBalance =
+                        diff_fixed.saturating_to_num::<u64>().into();
+                    let actual_decrease =
+                        Pallet::<T>::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+                            hk_as_acctid,
+                            ck_as_acctid,
+                            effected_netuid,
+                            as_alpha_balance,
+                        );
+                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
+
+                    if actual_decrease != as_alpha_balance {
+                        log::warn!(
+                            target: "undohkswap",
+                            "Coldkey '{}' failed to burn all {:?}, instead {:?}",
+                            ck,
+                            as_alpha_balance,
+                            actual_decrease
+                        )
+                    }
+                    total_burned = total_burned.saturating_add(actual_decrease);
+                }
+            } else {
+                total_lost = total_lost.saturating_add(U64F64::from_num(diff));
+            }
+        } else {
+            log::error!(
+                target: "undohkswap",
+                "Coldkey '{}' failed to decode",
+                ck
+            )
+        }
+    }
+
+    let not_burned = total_given.saturating_sub(U64F64::from_num(total_burned.into()));
+    if not_burned > 0 {
+        log::warn!(
+            target: "undohkswap",
+            "Did not burn {:?} Alpha. Burned {:?}",
+            not_burned,
+            total_burned,
+        )
+    }
+
+    // value that can be returned per unit lost
+    let value_per_lost: U64F64 = U64F64::from_num(total_burned).safe_div(total_lost);
+    let total_returned: AlphaBalance = 0.into();
+    for (ck, diff) in diffs {
+        if let Ok(ck_as_acctid) = AccountId32::from_string(ck) {
+            if diff > 0 {
+                // lose some, return as much as we can, proportionally
+                let diff_fixed = U64F64::from_num(diff);
+                // Calculate
+                let diff_prop = diff_fixed.saturating_mul(value_per_lost);
+
+                let as_alpha_balance: AlphaBalance = diff_prop.saturating_to_num::<u64>().into();
+                let actual_increase = Pallet::<T>::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    hk_as_acctid,
+                    ck_as_acctid,
+                    effected_netuid,
+                    as_alpha_balance,
+                );
+                weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
+
+                if actual_increase != as_alpha_balance {
+                    log::warn!(
+                        target: "undohkswap",
+                        "Increase did not match expected {} {} {}",
+                        ck, as_alpha_balance, actual_increase
+                    )
+                }
+                total_returned = total_returned.saturating_add(actual_increase);
+            }
+        } else {
+            log::error!(
+                target: "undohkswap",
+                "Coldkey '{}' failed to decode",
+                ck
+            )
+        }
+    }
+
+    let not_returned = total_lost.saturating_sub(U64F64::from_num(total_returned.into()));
+    if not_returned > 0 {
+        log::warn!(
+            target: "undohkswap",
+            "Did not return {:?} of {:?} Alpha. Returned {:?}",
+            not_returned,
+            total_lost,
+            total_returned,
+        )
+    }
+
+    return weight;
+}
+
+pub fn migrate_fix_bad_hk_swap<T: Config>() -> Weight {
+    let migration_name = b"migrate_fix_bad_hk_swap".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Skip if already executed
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            target: "runtime",
+            "Migration '{}' already run - skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    // Only run on mainnet.
+    // Mainnet genesis: 0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03
+    let genesis_hash = frame_system::Pallet::<T>::block_hash(BlockNumberFor::<T>::zero());
+    weight = weight.saturating_add(T::DbWeight::get().reads(1));
+    let genesis_bytes = genesis_hash.as_ref();
+    let mainnet_genesis =
+        hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
+    if genesis_bytes == mainnet_genesis {
+        weight = weight.saturating_add(try_restore_shares::<T>());
+    }
+
+    // Mark migration done
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        target: "runtime",
+        "Migration '{}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
@@ -164,12 +164,29 @@ pub fn try_restore_shares<T: Config>() -> Weight {
                 .safe_div(curr_total_hotkey_shares)
                 .saturating_mul(curr_total_alpha);
             weight = weight.saturating_add(T::DbWeight::get().reads(1));
-            if diff > 0 && curr_bal > 0 {
+
+            if diff > 0 {
+                log::debug!(
+                    target: "undohkswap",
+                    "Coldkey '{}' has balance {:?} of {:?} diff: {}",
+                    ck,
+                    curr_bal,
+                    curr_total_alpha,
+                    diff
+                );
+
                 // remove excess, if possible
                 let diff_fixed = U64F64::from_num(diff);
                 total_given = total_given.saturating_add(diff_fixed);
 
                 let able_to_remove = diff_fixed.min(curr_bal);
+                log::debug!(
+                    target: "undohkswap",
+                    "Coldkey '{}' able to remove {:?} of {:?}",
+                    ck,
+                    able_to_remove,
+                    curr_bal
+                );
 
                 let as_alpha_balance: AlphaBalance =
                     able_to_remove.saturating_to_num::<u64>().into();
@@ -182,7 +199,7 @@ pub fn try_restore_shares<T: Config>() -> Weight {
                     );
                 weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
 
-                if actual_decrease.to_u64() != diff_fixed.saturating_to_num::<u64>() {
+                if actual_decrease.to_u64() < diff_fixed.saturating_to_num::<u64>() {
                     log::warn!(
                         target: "undohkswap",
                         "Coldkey '{}' failed to burn all {:?}, instead {:?}",
@@ -190,6 +207,26 @@ pub fn try_restore_shares<T: Config>() -> Weight {
                         diff_fixed,
                         actual_decrease
                     )
+                } else if actual_decrease.to_u64() > diff_fixed.saturating_to_num::<u64>() {
+                    log::warn!(
+                        target: "undohkswap",
+                        "Coldkey '{}' burned more than expected {:?}, instead {:?}",
+                        ck,
+                        diff_fixed,
+                        actual_decrease
+                    );
+                    // Return excess removed
+                    let excess = actual_decrease
+                        .to_u64()
+                        .saturating_sub(diff_fixed.saturating_to_num::<u64>());
+                    let excess_as_alpha_balance: AlphaBalance = excess.into();
+                    Pallet::<T>::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                        &hk_as_acctid,
+                        &ck_as_acctid,
+                        effected_netuid,
+                        excess_as_alpha_balance,
+                    );
+                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
                 }
                 total_burned = total_burned.saturating_add(actual_decrease);
             } else {

--- a/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
@@ -1,27 +1,36 @@
 use super::*;
-use codec::EncodeLike;
 use frame_support::{traits::Get, weights::Weight};
 use frame_system::pallet_prelude::BlockNumberFor;
 use log;
 use safe_math::FixedExt;
 use scale_info::prelude::string::String;
 use sp_core::crypto::Ss58Codec;
-use sp_runtime::{AccountId32, MultiAddress};
-use substrate_fixed::types::U64F64;
+use sp_runtime::AccountId32;
+use substrate_fixed::{traits::ToFixed, types::U64F64};
 
-pub fn try_restore_shares<T: Config>() -> Weight
-{
+pub fn decode_account_id32<T: Config>(ss58_string: &str) -> Option<T::AccountId> {
+    let account_id32: AccountId32 = AccountId32::from_string(ss58_string).ok()?;
+    let mut account_id32_slice: &[u8] = account_id32.as_ref();
+    T::AccountId::decode(&mut account_id32_slice).ok()
+}
+
+pub fn try_restore_shares<T: Config>() -> Weight {
     let mut weight = T::DbWeight::get().reads(1);
 
     let effected_hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
-    let hk_as_acctid32: AccountId32 = AccountId32::from_string(effected_hotkey).unwrap();
-	let hk_as_multiaddr = MultiAddress::Address32(hk_as_acctid32.into());
-	let hk_as_acctid: T::AccountId = T::AccountId::decode(hk_as_acctid32.as_mut()).unwrap();
+    let hk_as_acctid: T::AccountId =
+        if let Some(hk_as_acctid) = decode_account_id32::<T>(effected_hotkey) {
+            hk_as_acctid
+        } else {
+            log::error!("Failed to decode hotkey: {}", effected_hotkey);
+            return weight;
+        };
 
     let effected_netuid = 59.into();
 
-	let diffs = [
-		("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981),
+    #[rustfmt::skip]
+	let diffs: [(&str, i64); 112] = [ 
+		("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
 		("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
 		("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
 		("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
@@ -136,8 +145,8 @@ pub fn try_restore_shares<T: Config>() -> Weight
 	];
 
     let curr_total_alpha =
-        U64F64::from_num(TotalHotkeyAlpha::<T>::get(hk_as_acctid, effected_netuid));
-    let curr_total_hotkey_shares = TotalHotkeyShares::<T>::get(hk_as_acctid, effected_netuid);
+        U64F64::from_num(TotalHotkeyAlpha::<T>::get(&hk_as_acctid, effected_netuid));
+    let curr_total_hotkey_shares = TotalHotkeyShares::<T>::get(&hk_as_acctid, effected_netuid);
     weight = weight.saturating_add(T::DbWeight::get().reads(2));
 
     let mut total_burned: AlphaBalance = 0.into();
@@ -145,10 +154,10 @@ pub fn try_restore_shares<T: Config>() -> Weight
     let mut total_lost: U64F64 = U64F64::from_num(0);
 
     for (ck, diff) in diffs {
-        if let Ok(ck_as_acctid) = AccountId32::from_string(ck) {
+        if let Some(ck_as_acctid) = decode_account_id32::<T>(ck) {
             let curr_shares = U64F64::from_num(Alpha::<T>::get((
-                hk_as_acctid,
-                ck_as_acctid,
+                &hk_as_acctid,
+                &ck_as_acctid,
                 effected_netuid,
             )));
             let curr_bal = curr_shares
@@ -164,8 +173,8 @@ pub fn try_restore_shares<T: Config>() -> Weight
                         diff_fixed.saturating_to_num::<u64>().into();
                     let actual_decrease =
                         Pallet::<T>::decrease_stake_for_hotkey_and_coldkey_on_subnet(
-                            hk_as_acctid,
-                            ck_as_acctid,
+                            &hk_as_acctid,
+                            &ck_as_acctid,
                             effected_netuid,
                             as_alpha_balance,
                         );
@@ -194,7 +203,7 @@ pub fn try_restore_shares<T: Config>() -> Weight
         }
     }
 
-    let not_burned = total_given.saturating_sub(U64F64::from_num(total_burned.into()));
+    let not_burned = total_given.saturating_sub(total_burned.to_fixed());
     if not_burned > 0 {
         log::warn!(
             target: "undohkswap",
@@ -206,9 +215,9 @@ pub fn try_restore_shares<T: Config>() -> Weight
 
     // value that can be returned per unit lost
     let value_per_lost: U64F64 = U64F64::from_num(total_burned).safe_div(total_lost);
-    let total_returned: AlphaBalance = 0.into();
+    let mut total_returned: AlphaBalance = 0.into();
     for (ck, diff) in diffs {
-        if let Ok(ck_as_acctid) = AccountId32::from_string(ck) {
+        if let Some(ck_as_acctid) = decode_account_id32::<T>(ck) {
             if diff > 0 {
                 // lose some, return as much as we can, proportionally
                 let diff_fixed = U64F64::from_num(diff);
@@ -217,8 +226,8 @@ pub fn try_restore_shares<T: Config>() -> Weight
 
                 let as_alpha_balance: AlphaBalance = diff_prop.saturating_to_num::<u64>().into();
                 let actual_increase = Pallet::<T>::increase_stake_for_hotkey_and_coldkey_on_subnet(
-                    hk_as_acctid,
-                    ck_as_acctid,
+                    &hk_as_acctid,
+                    &ck_as_acctid,
                     effected_netuid,
                     as_alpha_balance,
                 );
@@ -242,7 +251,7 @@ pub fn try_restore_shares<T: Config>() -> Weight
         }
     }
 
-    let not_returned = total_lost.saturating_sub(U64F64::from_num(total_returned.into()));
+    let not_returned = total_lost.saturating_sub(total_returned.to_fixed());
     if not_returned > 0 {
         log::warn!(
             target: "undohkswap",

--- a/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
@@ -9,7 +9,7 @@ use sp_runtime::AccountId32;
 use substrate_fixed::{traits::ToFixed, types::U64F64};
 
 pub fn decode_account_id32<T: Config>(ss58_string: &str) -> Option<T::AccountId> {
-    let account_id32: AccountId32 = AccountId32::from_string(ss58_string).ok()?;
+    let account_id32: AccountId32 = AccountId32::from_ss58check(ss58_string).ok()?;
     let mut account_id32_slice: &[u8] = account_id32.as_ref();
     T::AccountId::decode(&mut account_id32_slice).ok()
 }
@@ -166,7 +166,7 @@ pub fn try_restore_shares<T: Config>() -> Weight {
             weight = weight.saturating_add(T::DbWeight::get().reads(1));
             if diff < 0 {
                 // remove excess, if possible
-                let diff_fixed = U64F64::from_num(diff * -1);
+                let diff_fixed = U64F64::from_num(diff.abs());
                 total_given = total_given.saturating_add(diff_fixed);
                 if diff_fixed <= curr_bal {
                     let as_alpha_balance: AlphaBalance =
@@ -262,7 +262,7 @@ pub fn try_restore_shares<T: Config>() -> Weight {
         )
     }
 
-    return weight;
+    weight
 }
 
 pub fn migrate_fix_bad_hk_swap<T: Config>() -> Weight {

--- a/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_bad_hk_swap.rs
@@ -164,35 +164,36 @@ pub fn try_restore_shares<T: Config>() -> Weight {
                 .safe_div(curr_total_hotkey_shares)
                 .saturating_mul(curr_total_alpha);
             weight = weight.saturating_add(T::DbWeight::get().reads(1));
-            if diff < 0 {
+            if diff > 0 && curr_bal > 0 {
                 // remove excess, if possible
-                let diff_fixed = U64F64::from_num(diff.abs());
+                let diff_fixed = U64F64::from_num(diff);
                 total_given = total_given.saturating_add(diff_fixed);
-                if diff_fixed <= curr_bal {
-                    let as_alpha_balance: AlphaBalance =
-                        diff_fixed.saturating_to_num::<u64>().into();
-                    let actual_decrease =
-                        Pallet::<T>::decrease_stake_for_hotkey_and_coldkey_on_subnet(
-                            &hk_as_acctid,
-                            &ck_as_acctid,
-                            effected_netuid,
-                            as_alpha_balance,
-                        );
-                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
 
-                    if actual_decrease != as_alpha_balance {
-                        log::warn!(
-                            target: "undohkswap",
-                            "Coldkey '{}' failed to burn all {:?}, instead {:?}",
-                            ck,
-                            as_alpha_balance,
-                            actual_decrease
-                        )
-                    }
-                    total_burned = total_burned.saturating_add(actual_decrease);
+                let able_to_remove = diff_fixed.min(curr_bal);
+
+                let as_alpha_balance: AlphaBalance =
+                    able_to_remove.saturating_to_num::<u64>().into();
+                let actual_decrease: AlphaBalance =
+                    Pallet::<T>::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+                        &hk_as_acctid,
+                        &ck_as_acctid,
+                        effected_netuid,
+                        as_alpha_balance,
+                    );
+                weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 3));
+
+                if actual_decrease.to_u64() != diff_fixed.saturating_to_num::<u64>() {
+                    log::warn!(
+                        target: "undohkswap",
+                        "Coldkey '{}' failed to burn all {:?}, instead {:?}",
+                        ck,
+                        diff_fixed,
+                        actual_decrease
+                    )
                 }
+                total_burned = total_burned.saturating_add(actual_decrease);
             } else {
-                total_lost = total_lost.saturating_add(U64F64::from_num(diff));
+                total_lost = total_lost.saturating_add(U64F64::from_num(diff.abs()));
             }
         } else {
             log::error!(
@@ -218,9 +219,9 @@ pub fn try_restore_shares<T: Config>() -> Weight {
     let mut total_returned: AlphaBalance = 0.into();
     for (ck, diff) in diffs {
         if let Some(ck_as_acctid) = decode_account_id32::<T>(ck) {
-            if diff > 0 {
+            if diff < 0 {
                 // lose some, return as much as we can, proportionally
-                let diff_fixed = U64F64::from_num(diff);
+                let diff_fixed = U64F64::from_num(diff.abs());
                 // Calculate
                 let diff_prop = diff_fixed.saturating_mul(value_per_lost);
 

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -60,6 +60,7 @@ pub mod migrate_to_v1_separate_emission;
 pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_transfer_ownership_to_foundation;
 pub mod migrate_upgrade_revealed_commitments;
+pub mod migrate_fix_bad_hk_swap;
 
 pub(crate) fn migrate_storage<T: Config>(
     migration_name: &'static str,

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -16,6 +16,7 @@ pub mod migrate_crv3_v2_to_timelocked;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
 pub mod migrate_disable_commit_reveal;
+pub mod migrate_fix_bad_hk_swap;
 pub mod migrate_fix_childkeys;
 pub mod migrate_fix_is_network_member;
 pub mod migrate_fix_root_subnet_tao;
@@ -60,7 +61,6 @@ pub mod migrate_to_v1_separate_emission;
 pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_transfer_ownership_to_foundation;
 pub mod migrate_upgrade_revealed_commitments;
-pub mod migrate_fix_bad_hk_swap;
 
 pub(crate) fn migrate_storage<T: Config>(
     migration_name: &'static str,

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -28,10 +28,13 @@ use pallet_scheduler::ScheduledOf;
 use scale_info::prelude::collections::VecDeque;
 use sp_core::{H256, U256, crypto::Ss58Codec};
 use sp_io::hashing::twox_128;
-use sp_runtime::{AccountId32, traits::{Hash, Zero}};
+use sp_runtime::{
+    AccountId32,
+    traits::{Hash, Zero},
+};
 use sp_std::marker::PhantomData;
-use substrate_fixed::types::extra::U2;
 use substrate_fixed::types::{I96F32, U64F64};
+use substrate_fixed::{traits::ToFixed, types::extra::U2};
 use subtensor_runtime_common::{NetUidStorageIndex, TaoBalance};
 
 #[allow(clippy::arithmetic_side_effects)]
@@ -3130,11 +3133,13 @@ fn test_migrate_fix_bad_hk_swap_only_genesis() {
         const MIGRATION_NAME: &[u8] = b"migrate_fix_bad_hk_swap";
 
         let coldkey = "5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo";
-        let account_id32: AccountId32 = AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
+        let account_id32: AccountId32 =
+            AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
         let mut account_id32_slice: &[u8] = account_id32.as_ref();
-        let coldkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
+        let coldkey_account_id: <Test as Config>::AccountId =
+            <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
         let netuid = NetUid::from(59);
-        // Setup 
+        // Setup
         // Add subnet 59
         add_network(netuid, 10, 0);
         SubtokenEnabled::<Test>::insert(netuid, true);
@@ -3142,16 +3147,22 @@ fn test_migrate_fix_bad_hk_swap_only_genesis() {
 
         // Add stake to hotkey matching
         let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
-        let account_id32: AccountId32 = AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
+        let account_id32: AccountId32 =
+            AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
         let mut account_id32_slice: &[u8] = account_id32.as_ref();
-        let hotkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
+        let hotkey_account_id: <Test as Config>::AccountId =
+            <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
 
         // Give balance to coldkey
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 100_000222.into());
         // Give stake to hotkey
         let stake_added = 222222.into();
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, stake_added);
-
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+            stake_added,
+        );
 
         // Check genesis hash
         let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
@@ -3165,10 +3176,16 @@ fn test_migrate_fix_bad_hk_swap_only_genesis() {
         assert!(!w.is_zero(), "weight must be non-zero");
 
         // Check stake did not change
-        assert_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), stake_added);
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey_account_id,
+                &coldkey_account_id,
+                netuid
+            ),
+            stake_added
+        );
     });
 }
-
 
 #[test]
 fn test_migrate_fix_bad_hk_swap_runs_on_mainnet_genesis() {
@@ -3177,11 +3194,13 @@ fn test_migrate_fix_bad_hk_swap_runs_on_mainnet_genesis() {
         const MIGRATION_NAME: &[u8] = b"migrate_fix_bad_hk_swap";
 
         let coldkey = "5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo";
-        let account_id32: AccountId32 = AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
+        let account_id32: AccountId32 =
+            AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
         let mut account_id32_slice: &[u8] = account_id32.as_ref();
-        let coldkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
+        let coldkey_account_id: <Test as Config>::AccountId =
+            <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
         let netuid = NetUid::from(59);
-        // Setup 
+        // Setup
         // Add subnet 59
         add_network(netuid, 10, 0);
         SubtokenEnabled::<Test>::insert(netuid, true);
@@ -3189,19 +3208,26 @@ fn test_migrate_fix_bad_hk_swap_runs_on_mainnet_genesis() {
 
         // Add stake to hotkey matching
         let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
-        let account_id32: AccountId32 = AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
+        let account_id32: AccountId32 =
+            AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
         let mut account_id32_slice: &[u8] = account_id32.as_ref();
-        let hotkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
+        let hotkey_account_id: <Test as Config>::AccountId =
+            <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
 
         // Give balance to coldkey
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 100_000222.into());
         // Give stake to hotkey
         let stake_added = 222222.into();
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, stake_added);
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+            stake_added,
+        );
 
         // Set genesis hash to mainnet genesis
         let mainnet_genesis =
-        hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
+            hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
         frame_system::BlockHash::<Test>::insert(0, H256::from_slice(&mainnet_genesis));
         // Check genesis hash
         let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
@@ -3213,7 +3239,14 @@ fn test_migrate_fix_bad_hk_swap_runs_on_mainnet_genesis() {
         assert!(!w.is_zero(), "weight must be non-zero");
 
         // Check stake DID change
-        assert_ne!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), stake_added);
+        assert_ne!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey_account_id,
+                &coldkey_account_id,
+                netuid
+            ),
+            stake_added
+        );
     });
 }
 
@@ -3228,7 +3261,6 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
     new_test_ext(1).execute_with(|| {
         use crate::migrations::migrate_fix_bad_hk_swap::*;
 
-        
         let netuid = NetUid::from(59);
         // Add subnet 59
         add_network(netuid, 10, 0);
@@ -3239,7 +3271,7 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
         let hotkey_account_id = decode_account_id32::<Test>(hotkey).expect("Invalid hotkey");
 
         #[rustfmt::skip]
-        let diffs: [(&str, i64); 112] = [ 
+        let diffs: [(&str, i64); 112] = [
             ("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
             ("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
             ("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
@@ -3357,7 +3389,12 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
         for (coldkey, diff) in diffs {
             let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
             if diff > 0 {
-                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, diff.unsigned_abs().into());
+                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                    diff.unsigned_abs().into(),
+                );
             }
         }
 
@@ -3367,11 +3404,41 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
         // Check stake is near 0 for all positive entires and near diff for all negative
         for (coldkey, diff) in diffs {
             let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
             if diff > 0 {
-                assert_relative_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), 0.into(), epsilon = 100_000_000.into());
+                assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
             } else {
-                assert_relative_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), diff.unsigned_abs().into(), epsilon = 100_000_000.into());
+                let diff_float: f64 =
+                    num_traits::ToPrimitive::to_f64(&diff.unsigned_abs()).expect("float conv fail");
+                assert_relative_eq!(stake_float, diff_float, max_relative = 0.001_f64);
             }
         }
     });
+}
+
+
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_mainnet_some_exits() {
+    // test with some of the gainers have exited fully or partially before the migration
+    // i.e. balance is less than they owe
+}
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_mainnet_has_more() {
+    // test with some of the gainers have a balance higher than the gain before the migration
+}
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_mainnet_some_entries() {
+    // test with some of the losers have an existing balance before the migration
 }

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -3415,6 +3415,11 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
             )
             .expect("float conv fail");
             if diff > 0 {
+                log::debug!(
+                    "diff: {} for ck: {}",
+                    diff,
+                    coldkey
+                );
                 assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
             } else {
                 let diff_float: f64 =

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -9,7 +9,7 @@
 use super::mock::*;
 use crate::*;
 use alloc::collections::BTreeMap;
-use approx::assert_abs_diff_eq;
+use approx::{assert_abs_diff_eq, assert_relative_eq};
 use codec::{Decode, Encode};
 use frame_support::{
     StorageHasher, Twox64Concat, assert_ok,
@@ -28,7 +28,7 @@ use pallet_scheduler::ScheduledOf;
 use scale_info::prelude::collections::VecDeque;
 use sp_core::{H256, U256, crypto::Ss58Codec};
 use sp_io::hashing::twox_128;
-use sp_runtime::{traits::Hash, traits::Zero};
+use sp_runtime::{AccountId32, traits::{Hash, Zero}};
 use sp_std::marker::PhantomData;
 use substrate_fixed::types::extra::U2;
 use substrate_fixed::types::{I96F32, U64F64};
@@ -3120,5 +3120,258 @@ fn test_migrate_coldkey_swap_scheduled_to_announcements() {
                 <Test as frame_system::Config>::Hashing::hash_of(&U256::from(50))
             ))
         );
+    });
+}
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_only_genesis() {
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+        const MIGRATION_NAME: &[u8] = b"migrate_fix_bad_hk_swap";
+
+        let coldkey = "5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo";
+        let account_id32: AccountId32 = AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
+        let mut account_id32_slice: &[u8] = account_id32.as_ref();
+        let coldkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
+        let netuid = NetUid::from(59);
+        // Setup 
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        // Add stake to hotkey matching
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let account_id32: AccountId32 = AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
+        let mut account_id32_slice: &[u8] = account_id32.as_ref();
+        let hotkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
+
+        // Give balance to coldkey
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 100_000222.into());
+        // Give stake to hotkey
+        let stake_added = 222222.into();
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, stake_added);
+
+
+        // Check genesis hash
+        let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
+        let genesis_bytes = genesis_hash.as_ref();
+        let mainnet_genesis =
+            hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
+        assert_ne!(genesis_bytes, mainnet_genesis);
+
+        // Run migration
+        let w = migrate_fix_bad_hk_swap::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake did not change
+        assert_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), stake_added);
+    });
+}
+
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_runs_on_mainnet_genesis() {
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+        const MIGRATION_NAME: &[u8] = b"migrate_fix_bad_hk_swap";
+
+        let coldkey = "5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo";
+        let account_id32: AccountId32 = AccountId32::from_ss58check(coldkey).expect("Invalid coldkey");
+        let mut account_id32_slice: &[u8] = account_id32.as_ref();
+        let coldkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid coldkey");
+        let netuid = NetUid::from(59);
+        // Setup 
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        // Add stake to hotkey matching
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let account_id32: AccountId32 = AccountId32::from_ss58check(hotkey).expect("Invalid hotkey");
+        let mut account_id32_slice: &[u8] = account_id32.as_ref();
+        let hotkey_account_id: <Test as Config>::AccountId = <Test as Config>::AccountId::decode(&mut account_id32_slice).expect("Invalid hotkey");
+
+        // Give balance to coldkey
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 100_000222.into());
+        // Give stake to hotkey
+        let stake_added = 222222.into();
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, stake_added);
+
+        // Set genesis hash to mainnet genesis
+        let mainnet_genesis =
+        hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
+        frame_system::BlockHash::<Test>::insert(0, H256::from_slice(&mainnet_genesis));
+        // Check genesis hash
+        let genesis_hash = frame_system::Pallet::<Test>::block_hash(0);
+        let genesis_bytes = genesis_hash.as_ref();
+        assert_eq!(genesis_bytes, mainnet_genesis);
+
+        // Run migration
+        let w = migrate_fix_bad_hk_swap::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake DID change
+        assert_ne!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), stake_added);
+    });
+}
+
+fn decode_account_id32<T: Config>(ss58_string: &str) -> Option<T::AccountId> {
+    let account_id32: AccountId32 = AccountId32::from_ss58check(ss58_string).ok()?;
+    let mut account_id32_slice: &[u8] = account_id32.as_ref();
+    T::AccountId::decode(&mut account_id32_slice).ok()
+}
+
+#[test]
+fn test_migrate_fix_bad_hk_swap_mainnet() {
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+
+        
+        let netuid = NetUid::from(59);
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let hotkey_account_id = decode_account_id32::<Test>(hotkey).expect("Invalid hotkey");
+
+        #[rustfmt::skip]
+        let diffs: [(&str, i64); 112] = [ 
+            ("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
+            ("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
+            ("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
+            ("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
+            ("5F7BkPL3EVjKTYMbBkEmPAtTZQSGeyNzFPaf1DtebPFmJsJ7", -4016510),
+            ("5EefisctzgWdVGFQaL4LjFFacTE7dM4YJVNy3ogGBQoapTU1", -13106893093),
+            ("5CwkvpBxHCaRK9xBC2n6WdhpF5zg9t5WLkGorASaoErdynFQ", 439139249152),
+            ("5FU7ErUtmi22xuqeeCYVpNZp6WVSSL98hqDi5iyeZbkXtkbe", -35958768555),
+            ("5D7HL8T95qkHQTPFjgSFCjRoeM7oE3vQBYjiR1kAPbPxcMKu", -201914811997),
+            ("5HL3pPdDFY94Qdf8VnbfT4W6LXFkpd68Y5GSGzNJfntMdGZX", -235660917467),
+            ("5EcYAz8SBKWsogA6meJmVXcwVp4tjCvw3ZnJE6UXTyWNUdF2", -500070769668),
+            ("5EoE3c7XMf8TN3yudAaFjv4yvjtWYRviHcXi73EXkLHmWTCB", -86442928436),
+            ("5CMDjL7t2biHGREBwrmd8renD74FLEhjCVqfJG2MXckWBwDu", 1039317),
+            ("5CVGKimL4cLgyTqvYKQbPKYFZfiztsdczU7HrwNdSFKbbn5D", 4224201),
+            ("5HmZnEcW4eHbXmUEFWJbc4GHnBBYEK8ZPsFa25PuEmP5iuwM", -13156128),
+            ("5FNa4J4fTKh555CEyXHgR29RicSm8nTEHx36utTa4MJepJyX", -9519954),
+            ("5Gun93uQgffYpxqMKSmfG18AHiQW7Z2GR2dfPPR8W188vJYc", -1127662),
+            ("5HW1C4js4RyjQqNwALSUZC8NJ2WinD5Si2X2XkstXrMW2uYo", -34457336758),
+            ("5EqMhjdLY9h64ui2mizRZyBp1mEPJ7s4TsfAxQSQkAFmMfzE", -9346443829744),
+            ("5H3XwzydgE2XUGoJCR4dSj7tkd7uxZDJqik69hux2DBcruom", -1215347774),
+            ("5DjkmYpCUX6dBTvGoyN9j4QZhtMPhdcywDE8cJ8Qq1vg4X6e", -3603984447),
+            ("5E7Z7Btjz74XpZLH5fRzfZqiHCo4j9PXKfqi88kQ5MFrds34", -823907380854),
+            ("5DSBWN4hN9413C6o6A2hR9tYUbHjWsQqPRV74GrnCrMkCGJx", -309708781),
+            ("5FMLRmKPqsTsMbakpVUwoYro1P64QXVNTWyzNDugaNwSKRzF", -137525398263),
+            ("5EFZf5pnTqLegv6gxCrb6TKBQBGz9xLJNK8x9eR273cSons6", -1521760918),
+            ("5CGAGEuMLaidBDk8bDZKJb23dxRSP1wLenLALGLw8BTG1E3W", -544739696),
+            ("5HSzRtcQjD5KP6Nh2GVSS16aLDe6q9R33Wpu6s2eEeeo3AYS", -2309184790),
+            ("5DALvFDcfANQJcWz6AXMfDqabnoZhdDMoH6FxqYUibug1ja7", -369405632507),
+            ("5Fy8iWkpcbsskmEN1nYZDdS9zKh167Em9RRYisoss7jaYXxi", 15257429),
+            ("5CQCVTRyqJgZKBDmtHzpoF8su6BScLcNGbX8t3WMm5qYbbJH", -10721968),
+            ("5DXZByh2NS4MU61a1aaLrcLYpyzpJgHe95TEBdcEN2cF1SA5", -655946136),
+            ("5EX5yAYiABFzKDQJDe1kRVwFm3XRRY4HyLMe4Vu9A5U2VEVT", -325581360246),
+            ("5FvabwjtyW887gtc7vUnUc47KVhy17UeaNLRjzTg5nkVACMP", -77588524213),
+            ("5HTbYi5cmgWJxvyTy9JeYdtnjoDzjXnEXTGFsPEVx9iRPmVF", -53542953784),
+            ("5CWzmvA17MAMQ9mnAecLxFXS2N8846rz6T7m4QNHyVtJVq4j", 2672295922502),
+            ("5DSYntgHZY4krYUtkkQZyyoffVtu5e8rYWhXuhs832zY6YKy", -2680205688),
+            ("5EYyTFyLDqXscaa5VtXTvUc3x2ow2TeT8G12ZDMZwE6uFWPQ", -39165843935),
+            ("5CohfM1qdyNwdeJEex1Zyht3S2WS48rV993DmVbyKs2mEEd6", -4004685632),
+            ("5Gx6Y7UQD39Latgxigr6mHbnh1herpwNPau2PjvzwLWEjXL3", -559504),
+            ("5Hh4Efq5WDwe8URjjUqUNX8KxtMwLHLViwoRvXfEpXQCZakh", -32541090531),
+            ("5GWRHC7Nd8njqTPsdJkp6ngniCCBu9UjGhLfxp2jF1fPrfZ4", -5394093031),
+            ("5GNAB64UN32krzr3Xxu5LW6naeu2P3XULcdBCR9VZ5Libyit", -24884230),
+            ("5EEz25th1nYNM5xR1UsyFFAUaXMjdHqLxZ3wUjyHokYbXHku", -12525171),
+            ("5HKJq4JCS9xoKdYhcRnsRp1bodovba7ncd5KTYVwfReKaxHT", -408133990236),
+            ("5DXs7x664RL5NdSW77DTseLiu84unstuHGuqvmY61UtJwzRN", -3095078614148),
+            ("5CDfdDaA2p9sK1ia5yMVYfzgtFs2e1TrSAxuQqXoS28Lcrxf", -1032856892),
+            ("5Ecg4vD2zKXHDFhQqogWq1dZdijPsDty8rGsZu3raeoJSiXb", -995678),
+            ("5C5Yg63TNLb68Tu819qXd3Bt4giG8mAPzLmAFSqa2HC1R5Rm", -40818739830910),
+            ("5HHH25Wuf9rmVuk9cMKU1hCCPJ1qbHBd1SyHj91R3fMT36yb", -391416057906),
+            ("5GKGGE5YLHoDciYJ6Ec2YnUP3SykSQPA47hqmwBP63EtVrd9", -413944553000),
+            ("5CSi9ZLyiXfLeYtEFaZSBuTofNMRnXEJEJE9CS4gGaT6CkWt", -17811605275),
+            ("5CSoA7QVdFHHBZz53bbRV2mC5vhL64ehhWa8ibtLppmt2n3J", -65701320107),
+            ("5GpA5BtfMMX52rXztrha79YqfwR4YaSfTuAcb48Yt73U4h71", -2194562),
+            ("5Euz5wpb4xiDWfV1A6AKK6i6ca3WoZQD5hCVyf1fws8GXh4z", -6143407839874),
+            ("5DZzmhCG7SMK3LwrkmHZ8ZBwaAByMjfBpEid14nNQdxHipCE", -386645),
+            ("5Fc9Vo3hkbr6bPxJpjQo5sQ43L5Hc2G8R5BdqRYF8psvB5pw", 55668553),
+            ("5GuSHC3iowySHLDW4pEyEZE6PKxKP62YpJYJyBy5tijzAnYz", -159317636526),
+            ("5HVVZrUBPvjYHiwaSvtvaN9GZogoznM49m2AEmVW6RXnYCka", -1995572213),
+            ("5EcGpeV2wjkCVsBjsBifSWbdcqH98b6oEY8beDY59c4fXkhw", -177096614584),
+            ("5GnCjvWJEESwVNFZzy85zbBzw26etuEt87WiqsE3ee2Ws1wm", -1961445),
+            ("5GWuPUpTuChAqKxvU22TRLvRkBFiyWWZnq9cLpJN6SSvkho1", -94157569391),
+            ("5FXHf7q5rvBXnzQgmsa31Db9rjcRy6ZHKMiyDSb8Vs5p2msN", -688433531658),
+            ("5GbxkzytnvbRuNQ7qxPpfPuWMoeitS8V4KDY9jSshE5fDegD", -19085313),
+            ("5Gus1B7c9uWkky7Yawh2tKR1V6AMh5DbqUBPq881JHqeqVqY", -16101671818),
+            ("5DLhRdbvWkYYScDmwx4QgJfieSN4apBWbZ2yno3MfgbR8hBP", -21062025),
+            ("5Cg5kVyNEs7MWWRHU8X5MHwX5cN3aegvC4RBt2JK19w2GiR8", -2593737050),
+            ("5Dkushsxtc8AdCf287MtTYHQv9DoZeBRpttUpBtmyFhGy3uR", -48672832345630),
+            ("5EqNqVsHj9bQVyEujcm62zjMYUFhTLY7rTP854txSrJzyoco", -3828526),
+            ("5Dea6d6nKErEbRQ4MBGuCALn8NZ2xo4kaa51hB5KMriPBkEM", -1560192853875),
+            ("5DNt2XDWdeMd4H92FLnfUvkqyXzmavezHvzLboP3VgT1xLZV", -831964576998),
+            ("5FKtFoTeK8aaG6HZTrDgvoYHVQ5NY4S9VyV7W5K74cWcwLYA", -60823501166),
+            ("5GEBanZKUU7Hrf8K2VNi33HxyJRstgQ3WD3odHgvMj2nPbhi", -98946626902),
+            ("5CUtw7LYB2n2bzgXt6YnmKDHt6PsB3kKAyD9azYJNcRG8TNg", -9779588557490),
+            ("5EynbF72b12fbgMvEeL1vJSY342rCryNbuwxFivU1Xevtmv3", -17314385200455),
+            ("5CapiZRuULed8ConS1gbjMVgnwcT5JnQah7tx6sZnK7sJJuJ", -5810972),
+            ("5DnaxLaNduf41WM6WWZ4fkzcGzWNWx6eLJyQpSaMueUGCsaU", -12668760),
+            ("5Cqz9SChYPxTFZ2623rE2aQQ5ttQoLwZ8yfwYgiZyQDANqZn", -683549),
+            ("5C8ZcLzF23GrXKdH4Pg3ZXC3vKQsF5PM8VvhzzxzTQksgj8e", -44720570590),
+            ("5GuNsmoswrP6hTKZkKcpTpZftTMKrmnCHvTL2V3NHJy2fpen", -5042891812715),
+            ("5F1TYDkLnP36HHY5btigxyKUPzBraxdrU1aX1bqFfPfcfnzU", -1189104279832),
+            ("5Dc384z9HuTGF6oratZs1fLciCHtPZaLhrHfCVw82a5AikWZ", -616163196988),
+            ("5DhcaEUsRKhZQ31qRffJqjtLmFkbVaCebn8nVjYhvB4KJtX5", -17746006723),
+            ("5HYE7z3xTcrN1rqz54NyZRAkehFfRMcaEcdoMq5g5ATET5wQ", 212509751245),
+            ("5F97DdEVTy9gPCtN6jkJJENDJuQiRGiwbMVSL74qRq8FCq5W", 2225287736222),
+            ("5FUVN133rSvuKXgsXKMR2ZEaysxZjkRUFUWS1UMyNGre9xFV", -73216740161),
+            ("5CZeimtfpRqQgPxVwr1MzfG2Sok8E1AMERHo6vUmEdRS5JiU", -3937802),
+            ("5Eqq2JwGh7qbtnjPiFEPmmnHxs3S4J4Ahg8fr4sybZV1tPdY", -173406860562),
+            ("5ERfDw6K3GmQqwqsEG6foFtu7VsYGifPi556UJKQsBnfbHKN", 96022588728),
+            ("5Ek8RkU6KMv5Fx7yivRVoQkuJYAKhULWiLWDpbGG4hvR9HFD", 968139369093),
+            ("5HpCpGALzqgnDTP1HXFiuhzD5MFaDTRHjXBCvaMY9LNNRkT9", 104943979521),
+            ("5FYqS77gxW9gHG8id1YYPS7Cd4TQmNUMhF8h3S77Fq2VvvRQ", 729199757977),
+            ("5FtBqMg13pNf1N6TwfG6BmwyaDM77mkeQ16UTHsGasrVDedX", 131457064336),
+            ("5GbnWR2XhWrRMt123SdrLbR9G2a4N5dtzA3TSu3Czkzoeu7x", 2295599153),
+            ("5GgiowcCG4kLpwkCTGxxQJQv8WwKFyBQ6McPRmqKtWPy8EaK", 113838605389),
+            ("5FL5YtYozpUAGaiVWonpbwEYdEMij3obJHSH3ACY4vgWmDgy", 8689039),
+            ("5Egq58bxRv7boM2s3rnDxx1udnkzxPQ23HuoqohVxjh9RenC", 216373234348),
+            ("5FRGeeEgRNR8U33FDKvN7yUgts8zR3qRJH4yKKWoR9GswBRb", 2196574958718),
+            ("5FnhSy79BPYyrmmFsbckinQw1fLiLqqPkQL2vgZwPxbRfu3k", 42319631507),
+            ("5Hj8jMhqAv7cfyRh5STfbZefMhv17QxZ1RxWq9jNcLAEsRRo", 132216702183491),
+            ("5EXYTGMqumAH6RLQgHwkMEMnSvHcpHc89R6U8krfNJTYWm9J", 504320264499),
+            ("5EFh8ctzmytXURqrCTUBWHTs87f7TMWB6XKUzdqxKXVUtvS2", 2209599669432),
+            ("5CqVqEcRBkw7Gm2reJ33cj7puR9W2Tq7qsLxSruV1BgnMqKN", 1033387458788),
+            ("5D79enmLSGimsruoraGagofhaSeYJZvGUqFCCrr83ZfZs1HS", 7591184215233),
+            ("5HbpyjsvyXLWtf1QT1CyNUdyut6scM5dM7ytm8hoxFvRtU1i", 129833188275),
+            ("5CnxCi7CdEriWSdw4LcXdbtjodxA6uTat4gBm4wuT9QToMdo", 3132978),
+            ("5G48fiQjhAd8hc4rYc6GituCuAPKznL28jyyyq1auMyZiG4t", 514913328178),
+            ("5FFGjW2hJ7tQ41qghSsLP4cVmA8j9pZVSrr2CrLG7fQAsLHJ", 346794972723),
+            ("5FWjnxeRMtMFxRc9kvZKCG5iJAyyz2kmXV8u3kqyiXizZtiz", 225939835005),
+            ("5CUw3sB4oxd3dVSHUr3kxsB591VEjaPzr444KkfjwVFnLRfJ", 208250614494),
+            ("5EaBhxNUwMRyKsaeA2BEjDCrvwE5J8FDSpfCHK9gGmnmbhCa", 278083207003),
+            ("5GHJ5HxFxYQyVoNFUxR3JCqqCKRumaFCY7N5zMxwF4CpRUWr", 1381466224829),
+            ("5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo", 774889),
+        ];
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            if diff > 0 {
+                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid, diff.unsigned_abs().into());
+            }
+        }
+
+        let w = try_restore_shares::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake is near 0 for all positive entires and near diff for all negative
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            if diff > 0 {
+                assert_relative_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), 0.into(), epsilon = 100_000_000.into());
+            } else {
+                assert_relative_eq!(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey_account_id, &coldkey_account_id, netuid), diff.unsigned_abs().into(), epsilon = 100_000_000.into());
+            }
+        }
     });
 }

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -18,6 +18,7 @@ use frame_support::{
     traits::{StorageInstance, StoredMap},
     weights::Weight,
 };
+use safe_math::SafeDiv;
 
 use crate::migrations::migrate_coldkey_swap_scheduled_to_announcements::deprecated as coldkey_swap_deprecated;
 use crate::migrations::migrate_storage;
@@ -3415,11 +3416,7 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
             )
             .expect("float conv fail");
             if diff > 0 {
-                log::debug!(
-                    "diff: {} for ck: {}",
-                    diff,
-                    coldkey
-                );
+                log::debug!("diff: {} for ck: {}", diff, coldkey);
                 assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
             } else {
                 let diff_float: f64 =
@@ -3430,20 +3427,709 @@ fn test_migrate_fix_bad_hk_swap_mainnet() {
     });
 }
 
-
-
 #[test]
 fn test_migrate_fix_bad_hk_swap_mainnet_some_exits() {
     // test with some of the gainers have exited fully or partially before the migration
     // i.e. balance is less than they owe
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+
+        let netuid = NetUid::from(59);
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let hotkey_account_id = decode_account_id32::<Test>(hotkey).expect("Invalid hotkey");
+
+        #[rustfmt::skip]
+        let diffs: [(&str, i64); 112] = [
+            ("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
+            ("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
+            ("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
+            ("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
+            ("5F7BkPL3EVjKTYMbBkEmPAtTZQSGeyNzFPaf1DtebPFmJsJ7", -4016510),
+            ("5EefisctzgWdVGFQaL4LjFFacTE7dM4YJVNy3ogGBQoapTU1", -13106893093),
+            ("5CwkvpBxHCaRK9xBC2n6WdhpF5zg9t5WLkGorASaoErdynFQ", 439139249152),
+            ("5FU7ErUtmi22xuqeeCYVpNZp6WVSSL98hqDi5iyeZbkXtkbe", -35958768555),
+            ("5D7HL8T95qkHQTPFjgSFCjRoeM7oE3vQBYjiR1kAPbPxcMKu", -201914811997),
+            ("5HL3pPdDFY94Qdf8VnbfT4W6LXFkpd68Y5GSGzNJfntMdGZX", -235660917467),
+            ("5EcYAz8SBKWsogA6meJmVXcwVp4tjCvw3ZnJE6UXTyWNUdF2", -500070769668),
+            ("5EoE3c7XMf8TN3yudAaFjv4yvjtWYRviHcXi73EXkLHmWTCB", -86442928436),
+            ("5CMDjL7t2biHGREBwrmd8renD74FLEhjCVqfJG2MXckWBwDu", 1039317),
+            ("5CVGKimL4cLgyTqvYKQbPKYFZfiztsdczU7HrwNdSFKbbn5D", 4224201),
+            ("5HmZnEcW4eHbXmUEFWJbc4GHnBBYEK8ZPsFa25PuEmP5iuwM", -13156128),
+            ("5FNa4J4fTKh555CEyXHgR29RicSm8nTEHx36utTa4MJepJyX", -9519954),
+            ("5Gun93uQgffYpxqMKSmfG18AHiQW7Z2GR2dfPPR8W188vJYc", -1127662),
+            ("5HW1C4js4RyjQqNwALSUZC8NJ2WinD5Si2X2XkstXrMW2uYo", -34457336758),
+            ("5EqMhjdLY9h64ui2mizRZyBp1mEPJ7s4TsfAxQSQkAFmMfzE", -9346443829744),
+            ("5H3XwzydgE2XUGoJCR4dSj7tkd7uxZDJqik69hux2DBcruom", -1215347774),
+            ("5DjkmYpCUX6dBTvGoyN9j4QZhtMPhdcywDE8cJ8Qq1vg4X6e", -3603984447),
+            ("5E7Z7Btjz74XpZLH5fRzfZqiHCo4j9PXKfqi88kQ5MFrds34", -823907380854),
+            ("5DSBWN4hN9413C6o6A2hR9tYUbHjWsQqPRV74GrnCrMkCGJx", -309708781),
+            ("5FMLRmKPqsTsMbakpVUwoYro1P64QXVNTWyzNDugaNwSKRzF", -137525398263),
+            ("5EFZf5pnTqLegv6gxCrb6TKBQBGz9xLJNK8x9eR273cSons6", -1521760918),
+            ("5CGAGEuMLaidBDk8bDZKJb23dxRSP1wLenLALGLw8BTG1E3W", -544739696),
+            ("5HSzRtcQjD5KP6Nh2GVSS16aLDe6q9R33Wpu6s2eEeeo3AYS", -2309184790),
+            ("5DALvFDcfANQJcWz6AXMfDqabnoZhdDMoH6FxqYUibug1ja7", -369405632507),
+            ("5Fy8iWkpcbsskmEN1nYZDdS9zKh167Em9RRYisoss7jaYXxi", 15257429),
+            ("5CQCVTRyqJgZKBDmtHzpoF8su6BScLcNGbX8t3WMm5qYbbJH", -10721968),
+            ("5DXZByh2NS4MU61a1aaLrcLYpyzpJgHe95TEBdcEN2cF1SA5", -655946136),
+            ("5EX5yAYiABFzKDQJDe1kRVwFm3XRRY4HyLMe4Vu9A5U2VEVT", -325581360246),
+            ("5FvabwjtyW887gtc7vUnUc47KVhy17UeaNLRjzTg5nkVACMP", -77588524213),
+            ("5HTbYi5cmgWJxvyTy9JeYdtnjoDzjXnEXTGFsPEVx9iRPmVF", -53542953784),
+            ("5CWzmvA17MAMQ9mnAecLxFXS2N8846rz6T7m4QNHyVtJVq4j", 2672295922502),
+            ("5DSYntgHZY4krYUtkkQZyyoffVtu5e8rYWhXuhs832zY6YKy", -2680205688),
+            ("5EYyTFyLDqXscaa5VtXTvUc3x2ow2TeT8G12ZDMZwE6uFWPQ", -39165843935),
+            ("5CohfM1qdyNwdeJEex1Zyht3S2WS48rV993DmVbyKs2mEEd6", -4004685632),
+            ("5Gx6Y7UQD39Latgxigr6mHbnh1herpwNPau2PjvzwLWEjXL3", -559504),
+            ("5Hh4Efq5WDwe8URjjUqUNX8KxtMwLHLViwoRvXfEpXQCZakh", -32541090531),
+            ("5GWRHC7Nd8njqTPsdJkp6ngniCCBu9UjGhLfxp2jF1fPrfZ4", -5394093031),
+            ("5GNAB64UN32krzr3Xxu5LW6naeu2P3XULcdBCR9VZ5Libyit", -24884230),
+            ("5EEz25th1nYNM5xR1UsyFFAUaXMjdHqLxZ3wUjyHokYbXHku", -12525171),
+            ("5HKJq4JCS9xoKdYhcRnsRp1bodovba7ncd5KTYVwfReKaxHT", -408133990236),
+            ("5DXs7x664RL5NdSW77DTseLiu84unstuHGuqvmY61UtJwzRN", -3095078614148),
+            ("5CDfdDaA2p9sK1ia5yMVYfzgtFs2e1TrSAxuQqXoS28Lcrxf", -1032856892),
+            ("5Ecg4vD2zKXHDFhQqogWq1dZdijPsDty8rGsZu3raeoJSiXb", -995678),
+            ("5C5Yg63TNLb68Tu819qXd3Bt4giG8mAPzLmAFSqa2HC1R5Rm", -40818739830910),
+            ("5HHH25Wuf9rmVuk9cMKU1hCCPJ1qbHBd1SyHj91R3fMT36yb", -391416057906),
+            ("5GKGGE5YLHoDciYJ6Ec2YnUP3SykSQPA47hqmwBP63EtVrd9", -413944553000),
+            ("5CSi9ZLyiXfLeYtEFaZSBuTofNMRnXEJEJE9CS4gGaT6CkWt", -17811605275),
+            ("5CSoA7QVdFHHBZz53bbRV2mC5vhL64ehhWa8ibtLppmt2n3J", -65701320107),
+            ("5GpA5BtfMMX52rXztrha79YqfwR4YaSfTuAcb48Yt73U4h71", -2194562),
+            ("5Euz5wpb4xiDWfV1A6AKK6i6ca3WoZQD5hCVyf1fws8GXh4z", -6143407839874),
+            ("5DZzmhCG7SMK3LwrkmHZ8ZBwaAByMjfBpEid14nNQdxHipCE", -386645),
+            ("5Fc9Vo3hkbr6bPxJpjQo5sQ43L5Hc2G8R5BdqRYF8psvB5pw", 55668553),
+            ("5GuSHC3iowySHLDW4pEyEZE6PKxKP62YpJYJyBy5tijzAnYz", -159317636526),
+            ("5HVVZrUBPvjYHiwaSvtvaN9GZogoznM49m2AEmVW6RXnYCka", -1995572213),
+            ("5EcGpeV2wjkCVsBjsBifSWbdcqH98b6oEY8beDY59c4fXkhw", -177096614584),
+            ("5GnCjvWJEESwVNFZzy85zbBzw26etuEt87WiqsE3ee2Ws1wm", -1961445),
+            ("5GWuPUpTuChAqKxvU22TRLvRkBFiyWWZnq9cLpJN6SSvkho1", -94157569391),
+            ("5FXHf7q5rvBXnzQgmsa31Db9rjcRy6ZHKMiyDSb8Vs5p2msN", -688433531658),
+            ("5GbxkzytnvbRuNQ7qxPpfPuWMoeitS8V4KDY9jSshE5fDegD", -19085313),
+            ("5Gus1B7c9uWkky7Yawh2tKR1V6AMh5DbqUBPq881JHqeqVqY", -16101671818),
+            ("5DLhRdbvWkYYScDmwx4QgJfieSN4apBWbZ2yno3MfgbR8hBP", -21062025),
+            ("5Cg5kVyNEs7MWWRHU8X5MHwX5cN3aegvC4RBt2JK19w2GiR8", -2593737050),
+            ("5Dkushsxtc8AdCf287MtTYHQv9DoZeBRpttUpBtmyFhGy3uR", -48672832345630),
+            ("5EqNqVsHj9bQVyEujcm62zjMYUFhTLY7rTP854txSrJzyoco", -3828526),
+            ("5Dea6d6nKErEbRQ4MBGuCALn8NZ2xo4kaa51hB5KMriPBkEM", -1560192853875),
+            ("5DNt2XDWdeMd4H92FLnfUvkqyXzmavezHvzLboP3VgT1xLZV", -831964576998),
+            ("5FKtFoTeK8aaG6HZTrDgvoYHVQ5NY4S9VyV7W5K74cWcwLYA", -60823501166),
+            ("5GEBanZKUU7Hrf8K2VNi33HxyJRstgQ3WD3odHgvMj2nPbhi", -98946626902),
+            ("5CUtw7LYB2n2bzgXt6YnmKDHt6PsB3kKAyD9azYJNcRG8TNg", -9779588557490),
+            ("5EynbF72b12fbgMvEeL1vJSY342rCryNbuwxFivU1Xevtmv3", -17314385200455),
+            ("5CapiZRuULed8ConS1gbjMVgnwcT5JnQah7tx6sZnK7sJJuJ", -5810972),
+            ("5DnaxLaNduf41WM6WWZ4fkzcGzWNWx6eLJyQpSaMueUGCsaU", -12668760),
+            ("5Cqz9SChYPxTFZ2623rE2aQQ5ttQoLwZ8yfwYgiZyQDANqZn", -683549),
+            ("5C8ZcLzF23GrXKdH4Pg3ZXC3vKQsF5PM8VvhzzxzTQksgj8e", -44720570590),
+            ("5GuNsmoswrP6hTKZkKcpTpZftTMKrmnCHvTL2V3NHJy2fpen", -5042891812715),
+            ("5F1TYDkLnP36HHY5btigxyKUPzBraxdrU1aX1bqFfPfcfnzU", -1189104279832),
+            ("5Dc384z9HuTGF6oratZs1fLciCHtPZaLhrHfCVw82a5AikWZ", -616163196988),
+            ("5DhcaEUsRKhZQ31qRffJqjtLmFkbVaCebn8nVjYhvB4KJtX5", -17746006723),
+            ("5HYE7z3xTcrN1rqz54NyZRAkehFfRMcaEcdoMq5g5ATET5wQ", 212509751245),
+            ("5F97DdEVTy9gPCtN6jkJJENDJuQiRGiwbMVSL74qRq8FCq5W", 2225287736222),
+            ("5FUVN133rSvuKXgsXKMR2ZEaysxZjkRUFUWS1UMyNGre9xFV", -73216740161),
+            ("5CZeimtfpRqQgPxVwr1MzfG2Sok8E1AMERHo6vUmEdRS5JiU", -3937802),
+            ("5Eqq2JwGh7qbtnjPiFEPmmnHxs3S4J4Ahg8fr4sybZV1tPdY", -173406860562),
+            ("5ERfDw6K3GmQqwqsEG6foFtu7VsYGifPi556UJKQsBnfbHKN", 96022588728),
+            ("5Ek8RkU6KMv5Fx7yivRVoQkuJYAKhULWiLWDpbGG4hvR9HFD", 968139369093),
+            ("5HpCpGALzqgnDTP1HXFiuhzD5MFaDTRHjXBCvaMY9LNNRkT9", 104943979521),
+            ("5FYqS77gxW9gHG8id1YYPS7Cd4TQmNUMhF8h3S77Fq2VvvRQ", 729199757977),
+            ("5FtBqMg13pNf1N6TwfG6BmwyaDM77mkeQ16UTHsGasrVDedX", 131457064336),
+            ("5GbnWR2XhWrRMt123SdrLbR9G2a4N5dtzA3TSu3Czkzoeu7x", 2295599153),
+            ("5GgiowcCG4kLpwkCTGxxQJQv8WwKFyBQ6McPRmqKtWPy8EaK", 113838605389),
+            ("5FL5YtYozpUAGaiVWonpbwEYdEMij3obJHSH3ACY4vgWmDgy", 8689039),
+            ("5Egq58bxRv7boM2s3rnDxx1udnkzxPQ23HuoqohVxjh9RenC", 216373234348),
+            ("5FRGeeEgRNR8U33FDKvN7yUgts8zR3qRJH4yKKWoR9GswBRb", 2196574958718),
+            ("5FnhSy79BPYyrmmFsbckinQw1fLiLqqPkQL2vgZwPxbRfu3k", 42319631507),
+            ("5Hj8jMhqAv7cfyRh5STfbZefMhv17QxZ1RxWq9jNcLAEsRRo", 132216702183491),
+            ("5EXYTGMqumAH6RLQgHwkMEMnSvHcpHc89R6U8krfNJTYWm9J", 504320264499),
+            ("5EFh8ctzmytXURqrCTUBWHTs87f7TMWB6XKUzdqxKXVUtvS2", 2209599669432),
+            ("5CqVqEcRBkw7Gm2reJ33cj7puR9W2Tq7qsLxSruV1BgnMqKN", 1033387458788),
+            ("5D79enmLSGimsruoraGagofhaSeYJZvGUqFCCrr83ZfZs1HS", 7591184215233),
+            ("5HbpyjsvyXLWtf1QT1CyNUdyut6scM5dM7ytm8hoxFvRtU1i", 129833188275),
+            ("5CnxCi7CdEriWSdw4LcXdbtjodxA6uTat4gBm4wuT9QToMdo", 3132978),
+            ("5G48fiQjhAd8hc4rYc6GituCuAPKznL28jyyyq1auMyZiG4t", 514913328178),
+            ("5FFGjW2hJ7tQ41qghSsLP4cVmA8j9pZVSrr2CrLG7fQAsLHJ", 346794972723),
+            ("5FWjnxeRMtMFxRc9kvZKCG5iJAyyz2kmXV8u3kqyiXizZtiz", 225939835005),
+            ("5CUw3sB4oxd3dVSHUr3kxsB591VEjaPzr444KkfjwVFnLRfJ", 208250614494),
+            ("5EaBhxNUwMRyKsaeA2BEjDCrvwE5J8FDSpfCHK9gGmnmbhCa", 278083207003),
+            ("5GHJ5HxFxYQyVoNFUxR3JCqqCKRumaFCY7N5zMxwF4CpRUWr", 1381466224829),
+            ("5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo", 774889),
+        ];
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            if diff > 0 {
+                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                    diff.unsigned_abs().into(),
+                );
+            }
+        }
+
+        // For one of the gainers, remove some of the stake
+        let idx = 6;
+        let gained_ck = diffs[idx].0;
+        let coldkey_account_id = decode_account_id32::<Test>(gained_ck).expect("Invalid coldkey");
+        SubtensorModule::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+            num_traits::ToPrimitive::to_u64(
+                &(num_traits::ToPrimitive::to_f64(&diffs[idx].1).expect("float conv fail")
+                    * 0.9_f64)
+                    .abs(),
+            )
+            .expect("u64 conv fail")
+            .into(),
+        );
+
+        let w = try_restore_shares::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake is near 0 for all positive entires except the one we removed
+        // Check the stake for all negative entries is proportional to the amount they lost
+        let total_lost: f64 = diffs
+            .iter()
+            .map(|(_, diff)| {
+                if diff.is_negative() {
+                    num_traits::ToPrimitive::to_f64(&diff.saturating_abs())
+                        .expect("float conv fail")
+                } else {
+                    0_f64
+                }
+            })
+            .sum::<f64>();
+        let mut total_returned = 0_f64;
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff > 0 {
+                log::debug!("diff: {} for ck: {}", diff, coldkey);
+                assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
+            } else {
+                total_returned += stake_float;
+            }
+        }
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff < 0 {
+                // Should get a return proportional to the amount they lost
+                // versus the amount that was able to be recovered
+                let prop_returned: f64 = num_traits::ToPrimitive::to_f64(&diff.abs())
+                    .expect("float conv fail")
+                    / total_lost
+                    * total_returned;
+                assert_relative_eq!(stake_float, prop_returned, max_relative = 0.001_f64);
+            }
+        }
+    });
 }
 
 #[test]
 fn test_migrate_fix_bad_hk_swap_mainnet_has_more() {
     // test with some of the gainers have a balance higher than the gain before the migration
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+
+        let netuid = NetUid::from(59);
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let hotkey_account_id = decode_account_id32::<Test>(hotkey).expect("Invalid hotkey");
+
+        #[rustfmt::skip]
+        let diffs: [(&str, i64); 112] = [
+            ("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
+            ("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
+            ("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
+            ("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
+            ("5F7BkPL3EVjKTYMbBkEmPAtTZQSGeyNzFPaf1DtebPFmJsJ7", -4016510),
+            ("5EefisctzgWdVGFQaL4LjFFacTE7dM4YJVNy3ogGBQoapTU1", -13106893093),
+            ("5CwkvpBxHCaRK9xBC2n6WdhpF5zg9t5WLkGorASaoErdynFQ", 439139249152),
+            ("5FU7ErUtmi22xuqeeCYVpNZp6WVSSL98hqDi5iyeZbkXtkbe", -35958768555),
+            ("5D7HL8T95qkHQTPFjgSFCjRoeM7oE3vQBYjiR1kAPbPxcMKu", -201914811997),
+            ("5HL3pPdDFY94Qdf8VnbfT4W6LXFkpd68Y5GSGzNJfntMdGZX", -235660917467),
+            ("5EcYAz8SBKWsogA6meJmVXcwVp4tjCvw3ZnJE6UXTyWNUdF2", -500070769668),
+            ("5EoE3c7XMf8TN3yudAaFjv4yvjtWYRviHcXi73EXkLHmWTCB", -86442928436),
+            ("5CMDjL7t2biHGREBwrmd8renD74FLEhjCVqfJG2MXckWBwDu", 1039317),
+            ("5CVGKimL4cLgyTqvYKQbPKYFZfiztsdczU7HrwNdSFKbbn5D", 4224201),
+            ("5HmZnEcW4eHbXmUEFWJbc4GHnBBYEK8ZPsFa25PuEmP5iuwM", -13156128),
+            ("5FNa4J4fTKh555CEyXHgR29RicSm8nTEHx36utTa4MJepJyX", -9519954),
+            ("5Gun93uQgffYpxqMKSmfG18AHiQW7Z2GR2dfPPR8W188vJYc", -1127662),
+            ("5HW1C4js4RyjQqNwALSUZC8NJ2WinD5Si2X2XkstXrMW2uYo", -34457336758),
+            ("5EqMhjdLY9h64ui2mizRZyBp1mEPJ7s4TsfAxQSQkAFmMfzE", -9346443829744),
+            ("5H3XwzydgE2XUGoJCR4dSj7tkd7uxZDJqik69hux2DBcruom", -1215347774),
+            ("5DjkmYpCUX6dBTvGoyN9j4QZhtMPhdcywDE8cJ8Qq1vg4X6e", -3603984447),
+            ("5E7Z7Btjz74XpZLH5fRzfZqiHCo4j9PXKfqi88kQ5MFrds34", -823907380854),
+            ("5DSBWN4hN9413C6o6A2hR9tYUbHjWsQqPRV74GrnCrMkCGJx", -309708781),
+            ("5FMLRmKPqsTsMbakpVUwoYro1P64QXVNTWyzNDugaNwSKRzF", -137525398263),
+            ("5EFZf5pnTqLegv6gxCrb6TKBQBGz9xLJNK8x9eR273cSons6", -1521760918),
+            ("5CGAGEuMLaidBDk8bDZKJb23dxRSP1wLenLALGLw8BTG1E3W", -544739696),
+            ("5HSzRtcQjD5KP6Nh2GVSS16aLDe6q9R33Wpu6s2eEeeo3AYS", -2309184790),
+            ("5DALvFDcfANQJcWz6AXMfDqabnoZhdDMoH6FxqYUibug1ja7", -369405632507),
+            ("5Fy8iWkpcbsskmEN1nYZDdS9zKh167Em9RRYisoss7jaYXxi", 15257429),
+            ("5CQCVTRyqJgZKBDmtHzpoF8su6BScLcNGbX8t3WMm5qYbbJH", -10721968),
+            ("5DXZByh2NS4MU61a1aaLrcLYpyzpJgHe95TEBdcEN2cF1SA5", -655946136),
+            ("5EX5yAYiABFzKDQJDe1kRVwFm3XRRY4HyLMe4Vu9A5U2VEVT", -325581360246),
+            ("5FvabwjtyW887gtc7vUnUc47KVhy17UeaNLRjzTg5nkVACMP", -77588524213),
+            ("5HTbYi5cmgWJxvyTy9JeYdtnjoDzjXnEXTGFsPEVx9iRPmVF", -53542953784),
+            ("5CWzmvA17MAMQ9mnAecLxFXS2N8846rz6T7m4QNHyVtJVq4j", 2672295922502),
+            ("5DSYntgHZY4krYUtkkQZyyoffVtu5e8rYWhXuhs832zY6YKy", -2680205688),
+            ("5EYyTFyLDqXscaa5VtXTvUc3x2ow2TeT8G12ZDMZwE6uFWPQ", -39165843935),
+            ("5CohfM1qdyNwdeJEex1Zyht3S2WS48rV993DmVbyKs2mEEd6", -4004685632),
+            ("5Gx6Y7UQD39Latgxigr6mHbnh1herpwNPau2PjvzwLWEjXL3", -559504),
+            ("5Hh4Efq5WDwe8URjjUqUNX8KxtMwLHLViwoRvXfEpXQCZakh", -32541090531),
+            ("5GWRHC7Nd8njqTPsdJkp6ngniCCBu9UjGhLfxp2jF1fPrfZ4", -5394093031),
+            ("5GNAB64UN32krzr3Xxu5LW6naeu2P3XULcdBCR9VZ5Libyit", -24884230),
+            ("5EEz25th1nYNM5xR1UsyFFAUaXMjdHqLxZ3wUjyHokYbXHku", -12525171),
+            ("5HKJq4JCS9xoKdYhcRnsRp1bodovba7ncd5KTYVwfReKaxHT", -408133990236),
+            ("5DXs7x664RL5NdSW77DTseLiu84unstuHGuqvmY61UtJwzRN", -3095078614148),
+            ("5CDfdDaA2p9sK1ia5yMVYfzgtFs2e1TrSAxuQqXoS28Lcrxf", -1032856892),
+            ("5Ecg4vD2zKXHDFhQqogWq1dZdijPsDty8rGsZu3raeoJSiXb", -995678),
+            ("5C5Yg63TNLb68Tu819qXd3Bt4giG8mAPzLmAFSqa2HC1R5Rm", -40818739830910),
+            ("5HHH25Wuf9rmVuk9cMKU1hCCPJ1qbHBd1SyHj91R3fMT36yb", -391416057906),
+            ("5GKGGE5YLHoDciYJ6Ec2YnUP3SykSQPA47hqmwBP63EtVrd9", -413944553000),
+            ("5CSi9ZLyiXfLeYtEFaZSBuTofNMRnXEJEJE9CS4gGaT6CkWt", -17811605275),
+            ("5CSoA7QVdFHHBZz53bbRV2mC5vhL64ehhWa8ibtLppmt2n3J", -65701320107),
+            ("5GpA5BtfMMX52rXztrha79YqfwR4YaSfTuAcb48Yt73U4h71", -2194562),
+            ("5Euz5wpb4xiDWfV1A6AKK6i6ca3WoZQD5hCVyf1fws8GXh4z", -6143407839874),
+            ("5DZzmhCG7SMK3LwrkmHZ8ZBwaAByMjfBpEid14nNQdxHipCE", -386645),
+            ("5Fc9Vo3hkbr6bPxJpjQo5sQ43L5Hc2G8R5BdqRYF8psvB5pw", 55668553),
+            ("5GuSHC3iowySHLDW4pEyEZE6PKxKP62YpJYJyBy5tijzAnYz", -159317636526),
+            ("5HVVZrUBPvjYHiwaSvtvaN9GZogoznM49m2AEmVW6RXnYCka", -1995572213),
+            ("5EcGpeV2wjkCVsBjsBifSWbdcqH98b6oEY8beDY59c4fXkhw", -177096614584),
+            ("5GnCjvWJEESwVNFZzy85zbBzw26etuEt87WiqsE3ee2Ws1wm", -1961445),
+            ("5GWuPUpTuChAqKxvU22TRLvRkBFiyWWZnq9cLpJN6SSvkho1", -94157569391),
+            ("5FXHf7q5rvBXnzQgmsa31Db9rjcRy6ZHKMiyDSb8Vs5p2msN", -688433531658),
+            ("5GbxkzytnvbRuNQ7qxPpfPuWMoeitS8V4KDY9jSshE5fDegD", -19085313),
+            ("5Gus1B7c9uWkky7Yawh2tKR1V6AMh5DbqUBPq881JHqeqVqY", -16101671818),
+            ("5DLhRdbvWkYYScDmwx4QgJfieSN4apBWbZ2yno3MfgbR8hBP", -21062025),
+            ("5Cg5kVyNEs7MWWRHU8X5MHwX5cN3aegvC4RBt2JK19w2GiR8", -2593737050),
+            ("5Dkushsxtc8AdCf287MtTYHQv9DoZeBRpttUpBtmyFhGy3uR", -48672832345630),
+            ("5EqNqVsHj9bQVyEujcm62zjMYUFhTLY7rTP854txSrJzyoco", -3828526),
+            ("5Dea6d6nKErEbRQ4MBGuCALn8NZ2xo4kaa51hB5KMriPBkEM", -1560192853875),
+            ("5DNt2XDWdeMd4H92FLnfUvkqyXzmavezHvzLboP3VgT1xLZV", -831964576998),
+            ("5FKtFoTeK8aaG6HZTrDgvoYHVQ5NY4S9VyV7W5K74cWcwLYA", -60823501166),
+            ("5GEBanZKUU7Hrf8K2VNi33HxyJRstgQ3WD3odHgvMj2nPbhi", -98946626902),
+            ("5CUtw7LYB2n2bzgXt6YnmKDHt6PsB3kKAyD9azYJNcRG8TNg", -9779588557490),
+            ("5EynbF72b12fbgMvEeL1vJSY342rCryNbuwxFivU1Xevtmv3", -17314385200455),
+            ("5CapiZRuULed8ConS1gbjMVgnwcT5JnQah7tx6sZnK7sJJuJ", -5810972),
+            ("5DnaxLaNduf41WM6WWZ4fkzcGzWNWx6eLJyQpSaMueUGCsaU", -12668760),
+            ("5Cqz9SChYPxTFZ2623rE2aQQ5ttQoLwZ8yfwYgiZyQDANqZn", -683549),
+            ("5C8ZcLzF23GrXKdH4Pg3ZXC3vKQsF5PM8VvhzzxzTQksgj8e", -44720570590),
+            ("5GuNsmoswrP6hTKZkKcpTpZftTMKrmnCHvTL2V3NHJy2fpen", -5042891812715),
+            ("5F1TYDkLnP36HHY5btigxyKUPzBraxdrU1aX1bqFfPfcfnzU", -1189104279832),
+            ("5Dc384z9HuTGF6oratZs1fLciCHtPZaLhrHfCVw82a5AikWZ", -616163196988),
+            ("5DhcaEUsRKhZQ31qRffJqjtLmFkbVaCebn8nVjYhvB4KJtX5", -17746006723),
+            ("5HYE7z3xTcrN1rqz54NyZRAkehFfRMcaEcdoMq5g5ATET5wQ", 212509751245),
+            ("5F97DdEVTy9gPCtN6jkJJENDJuQiRGiwbMVSL74qRq8FCq5W", 2225287736222),
+            ("5FUVN133rSvuKXgsXKMR2ZEaysxZjkRUFUWS1UMyNGre9xFV", -73216740161),
+            ("5CZeimtfpRqQgPxVwr1MzfG2Sok8E1AMERHo6vUmEdRS5JiU", -3937802),
+            ("5Eqq2JwGh7qbtnjPiFEPmmnHxs3S4J4Ahg8fr4sybZV1tPdY", -173406860562),
+            ("5ERfDw6K3GmQqwqsEG6foFtu7VsYGifPi556UJKQsBnfbHKN", 96022588728),
+            ("5Ek8RkU6KMv5Fx7yivRVoQkuJYAKhULWiLWDpbGG4hvR9HFD", 968139369093),
+            ("5HpCpGALzqgnDTP1HXFiuhzD5MFaDTRHjXBCvaMY9LNNRkT9", 104943979521),
+            ("5FYqS77gxW9gHG8id1YYPS7Cd4TQmNUMhF8h3S77Fq2VvvRQ", 729199757977),
+            ("5FtBqMg13pNf1N6TwfG6BmwyaDM77mkeQ16UTHsGasrVDedX", 131457064336),
+            ("5GbnWR2XhWrRMt123SdrLbR9G2a4N5dtzA3TSu3Czkzoeu7x", 2295599153),
+            ("5GgiowcCG4kLpwkCTGxxQJQv8WwKFyBQ6McPRmqKtWPy8EaK", 113838605389),
+            ("5FL5YtYozpUAGaiVWonpbwEYdEMij3obJHSH3ACY4vgWmDgy", 8689039),
+            ("5Egq58bxRv7boM2s3rnDxx1udnkzxPQ23HuoqohVxjh9RenC", 216373234348),
+            ("5FRGeeEgRNR8U33FDKvN7yUgts8zR3qRJH4yKKWoR9GswBRb", 2196574958718),
+            ("5FnhSy79BPYyrmmFsbckinQw1fLiLqqPkQL2vgZwPxbRfu3k", 42319631507),
+            ("5Hj8jMhqAv7cfyRh5STfbZefMhv17QxZ1RxWq9jNcLAEsRRo", 132216702183491),
+            ("5EXYTGMqumAH6RLQgHwkMEMnSvHcpHc89R6U8krfNJTYWm9J", 504320264499),
+            ("5EFh8ctzmytXURqrCTUBWHTs87f7TMWB6XKUzdqxKXVUtvS2", 2209599669432),
+            ("5CqVqEcRBkw7Gm2reJ33cj7puR9W2Tq7qsLxSruV1BgnMqKN", 1033387458788),
+            ("5D79enmLSGimsruoraGagofhaSeYJZvGUqFCCrr83ZfZs1HS", 7591184215233),
+            ("5HbpyjsvyXLWtf1QT1CyNUdyut6scM5dM7ytm8hoxFvRtU1i", 129833188275),
+            ("5CnxCi7CdEriWSdw4LcXdbtjodxA6uTat4gBm4wuT9QToMdo", 3132978),
+            ("5G48fiQjhAd8hc4rYc6GituCuAPKznL28jyyyq1auMyZiG4t", 514913328178),
+            ("5FFGjW2hJ7tQ41qghSsLP4cVmA8j9pZVSrr2CrLG7fQAsLHJ", 346794972723),
+            ("5FWjnxeRMtMFxRc9kvZKCG5iJAyyz2kmXV8u3kqyiXizZtiz", 225939835005),
+            ("5CUw3sB4oxd3dVSHUr3kxsB591VEjaPzr444KkfjwVFnLRfJ", 208250614494),
+            ("5EaBhxNUwMRyKsaeA2BEjDCrvwE5J8FDSpfCHK9gGmnmbhCa", 278083207003),
+            ("5GHJ5HxFxYQyVoNFUxR3JCqqCKRumaFCY7N5zMxwF4CpRUWr", 1381466224829),
+            ("5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo", 774889),
+        ];
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            if diff > 0 {
+                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                    diff.unsigned_abs().into(),
+                );
+            }
+        }
+
+        // For one of the gainers, add some extra stake
+        let idx = 6;
+        let gained_ck = diffs[idx].0;
+        let coldkey_account_id = decode_account_id32::<Test>(gained_ck).expect("Invalid coldkey");
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+            num_traits::ToPrimitive::to_u64(
+                &((num_traits::ToPrimitive::to_f64(&diffs[idx].1).expect("float conv fail")
+                    * 0.9_f64)
+                    .abs()),
+            )
+            .expect("u64 conv fail")
+            .into(),
+        );
+        let extra_balance = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+        )
+        .saturating_sub(
+            num_traits::ToPrimitive::to_u64(&diffs[idx].1.abs())
+                .expect("float conv fail")
+                .into(),
+        );
+        assert!(
+            extra_balance.to_u64() > 0_u64,
+            "extra balance must be positive"
+        );
+
+        let w = try_restore_shares::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake is near 0 for all positive entires except the one we removed
+        // Check the stake for all negative entries is proportional to the amount they lost
+        let total_lost: f64 = diffs
+            .iter()
+            .map(|(_, diff)| {
+                if diff.is_negative() {
+                    num_traits::ToPrimitive::to_f64(&diff.saturating_abs())
+                        .expect("float conv fail")
+                } else {
+                    0_f64
+                }
+            })
+            .sum::<f64>();
+        let mut total_returned = 0_f64;
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff > 0 {
+                if coldkey == gained_ck {
+                    // this CK should retain the extra balance
+                    assert_relative_eq!(
+                        stake_float,
+                        num_traits::ToPrimitive::to_f64(&extra_balance.to_u64())
+                            .expect("float conv fail"),
+                        max_relative = 0.001_f64
+                    );
+                } else {
+                    assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
+                }
+            } else {
+                total_returned += stake_float;
+            }
+        }
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff < 0 {
+                // Should get a return proportional to the amount they lost
+                // versus the amount that was able to be recovered
+                let prop_returned: f64 = num_traits::ToPrimitive::to_f64(&diff.abs())
+                    .expect("float conv fail")
+                    / total_lost
+                    * total_returned;
+                assert_relative_eq!(stake_float, prop_returned, max_relative = 0.001_f64);
+            }
+        }
+    });
 }
 
 #[test]
 fn test_migrate_fix_bad_hk_swap_mainnet_some_entries() {
     // test with some of the losers have an existing balance before the migration
+    new_test_ext(1).execute_with(|| {
+        use crate::migrations::migrate_fix_bad_hk_swap::*;
+
+        let netuid = NetUid::from(59);
+        // Add subnet 59
+        add_network(netuid, 10, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        SubnetMechanism::<Test>::insert(netuid, 1);
+
+        let hotkey = "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN";
+        let hotkey_account_id = decode_account_id32::<Test>(hotkey).expect("Invalid hotkey");
+
+        #[rustfmt::skip]
+        let diffs: [(&str, i64); 112] = [
+            ("5Fn9SqQhx5bhDua7AGgkKxxk3gfZ75WWBGCMPeKH1WBgPaMQ", -2375685930981_i64),
+            ("5Fnhtm7cpxEbZaChnRZ8yWoF8MXVxmobkmLRehh5bkYtyZA9", -4090996138227),
+            ("5C7j3w2zz1SVejRuFrb2zFWHXT7UfG7eWA87KXL1WyV5KLVR", -607494031),
+            ("5DthZ1rvnXBb9oXVNtrMaMsDAnRxBPZCjD6fdRdeqC3fg1ca", -17022477949),
+            ("5F7BkPL3EVjKTYMbBkEmPAtTZQSGeyNzFPaf1DtebPFmJsJ7", -4016510),
+            ("5EefisctzgWdVGFQaL4LjFFacTE7dM4YJVNy3ogGBQoapTU1", -13106893093),
+            ("5CwkvpBxHCaRK9xBC2n6WdhpF5zg9t5WLkGorASaoErdynFQ", 439139249152),
+            ("5FU7ErUtmi22xuqeeCYVpNZp6WVSSL98hqDi5iyeZbkXtkbe", -35958768555),
+            ("5D7HL8T95qkHQTPFjgSFCjRoeM7oE3vQBYjiR1kAPbPxcMKu", -201914811997),
+            ("5HL3pPdDFY94Qdf8VnbfT4W6LXFkpd68Y5GSGzNJfntMdGZX", -235660917467),
+            ("5EcYAz8SBKWsogA6meJmVXcwVp4tjCvw3ZnJE6UXTyWNUdF2", -500070769668),
+            ("5EoE3c7XMf8TN3yudAaFjv4yvjtWYRviHcXi73EXkLHmWTCB", -86442928436),
+            ("5CMDjL7t2biHGREBwrmd8renD74FLEhjCVqfJG2MXckWBwDu", 1039317),
+            ("5CVGKimL4cLgyTqvYKQbPKYFZfiztsdczU7HrwNdSFKbbn5D", 4224201),
+            ("5HmZnEcW4eHbXmUEFWJbc4GHnBBYEK8ZPsFa25PuEmP5iuwM", -13156128),
+            ("5FNa4J4fTKh555CEyXHgR29RicSm8nTEHx36utTa4MJepJyX", -9519954),
+            ("5Gun93uQgffYpxqMKSmfG18AHiQW7Z2GR2dfPPR8W188vJYc", -1127662),
+            ("5HW1C4js4RyjQqNwALSUZC8NJ2WinD5Si2X2XkstXrMW2uYo", -34457336758),
+            ("5EqMhjdLY9h64ui2mizRZyBp1mEPJ7s4TsfAxQSQkAFmMfzE", -9346443829744),
+            ("5H3XwzydgE2XUGoJCR4dSj7tkd7uxZDJqik69hux2DBcruom", -1215347774),
+            ("5DjkmYpCUX6dBTvGoyN9j4QZhtMPhdcywDE8cJ8Qq1vg4X6e", -3603984447),
+            ("5E7Z7Btjz74XpZLH5fRzfZqiHCo4j9PXKfqi88kQ5MFrds34", -823907380854),
+            ("5DSBWN4hN9413C6o6A2hR9tYUbHjWsQqPRV74GrnCrMkCGJx", -309708781),
+            ("5FMLRmKPqsTsMbakpVUwoYro1P64QXVNTWyzNDugaNwSKRzF", -137525398263),
+            ("5EFZf5pnTqLegv6gxCrb6TKBQBGz9xLJNK8x9eR273cSons6", -1521760918),
+            ("5CGAGEuMLaidBDk8bDZKJb23dxRSP1wLenLALGLw8BTG1E3W", -544739696),
+            ("5HSzRtcQjD5KP6Nh2GVSS16aLDe6q9R33Wpu6s2eEeeo3AYS", -2309184790),
+            ("5DALvFDcfANQJcWz6AXMfDqabnoZhdDMoH6FxqYUibug1ja7", -369405632507),
+            ("5Fy8iWkpcbsskmEN1nYZDdS9zKh167Em9RRYisoss7jaYXxi", 15257429),
+            ("5CQCVTRyqJgZKBDmtHzpoF8su6BScLcNGbX8t3WMm5qYbbJH", -10721968),
+            ("5DXZByh2NS4MU61a1aaLrcLYpyzpJgHe95TEBdcEN2cF1SA5", -655946136),
+            ("5EX5yAYiABFzKDQJDe1kRVwFm3XRRY4HyLMe4Vu9A5U2VEVT", -325581360246),
+            ("5FvabwjtyW887gtc7vUnUc47KVhy17UeaNLRjzTg5nkVACMP", -77588524213),
+            ("5HTbYi5cmgWJxvyTy9JeYdtnjoDzjXnEXTGFsPEVx9iRPmVF", -53542953784),
+            ("5CWzmvA17MAMQ9mnAecLxFXS2N8846rz6T7m4QNHyVtJVq4j", 2672295922502),
+            ("5DSYntgHZY4krYUtkkQZyyoffVtu5e8rYWhXuhs832zY6YKy", -2680205688),
+            ("5EYyTFyLDqXscaa5VtXTvUc3x2ow2TeT8G12ZDMZwE6uFWPQ", -39165843935),
+            ("5CohfM1qdyNwdeJEex1Zyht3S2WS48rV993DmVbyKs2mEEd6", -4004685632),
+            ("5Gx6Y7UQD39Latgxigr6mHbnh1herpwNPau2PjvzwLWEjXL3", -559504),
+            ("5Hh4Efq5WDwe8URjjUqUNX8KxtMwLHLViwoRvXfEpXQCZakh", -32541090531),
+            ("5GWRHC7Nd8njqTPsdJkp6ngniCCBu9UjGhLfxp2jF1fPrfZ4", -5394093031),
+            ("5GNAB64UN32krzr3Xxu5LW6naeu2P3XULcdBCR9VZ5Libyit", -24884230),
+            ("5EEz25th1nYNM5xR1UsyFFAUaXMjdHqLxZ3wUjyHokYbXHku", -12525171),
+            ("5HKJq4JCS9xoKdYhcRnsRp1bodovba7ncd5KTYVwfReKaxHT", -408133990236),
+            ("5DXs7x664RL5NdSW77DTseLiu84unstuHGuqvmY61UtJwzRN", -3095078614148),
+            ("5CDfdDaA2p9sK1ia5yMVYfzgtFs2e1TrSAxuQqXoS28Lcrxf", -1032856892),
+            ("5Ecg4vD2zKXHDFhQqogWq1dZdijPsDty8rGsZu3raeoJSiXb", -995678),
+            ("5C5Yg63TNLb68Tu819qXd3Bt4giG8mAPzLmAFSqa2HC1R5Rm", -40818739830910),
+            ("5HHH25Wuf9rmVuk9cMKU1hCCPJ1qbHBd1SyHj91R3fMT36yb", -391416057906),
+            ("5GKGGE5YLHoDciYJ6Ec2YnUP3SykSQPA47hqmwBP63EtVrd9", -413944553000),
+            ("5CSi9ZLyiXfLeYtEFaZSBuTofNMRnXEJEJE9CS4gGaT6CkWt", -17811605275),
+            ("5CSoA7QVdFHHBZz53bbRV2mC5vhL64ehhWa8ibtLppmt2n3J", -65701320107),
+            ("5GpA5BtfMMX52rXztrha79YqfwR4YaSfTuAcb48Yt73U4h71", -2194562),
+            ("5Euz5wpb4xiDWfV1A6AKK6i6ca3WoZQD5hCVyf1fws8GXh4z", -6143407839874),
+            ("5DZzmhCG7SMK3LwrkmHZ8ZBwaAByMjfBpEid14nNQdxHipCE", -386645),
+            ("5Fc9Vo3hkbr6bPxJpjQo5sQ43L5Hc2G8R5BdqRYF8psvB5pw", 55668553),
+            ("5GuSHC3iowySHLDW4pEyEZE6PKxKP62YpJYJyBy5tijzAnYz", -159317636526),
+            ("5HVVZrUBPvjYHiwaSvtvaN9GZogoznM49m2AEmVW6RXnYCka", -1995572213),
+            ("5EcGpeV2wjkCVsBjsBifSWbdcqH98b6oEY8beDY59c4fXkhw", -177096614584),
+            ("5GnCjvWJEESwVNFZzy85zbBzw26etuEt87WiqsE3ee2Ws1wm", -1961445),
+            ("5GWuPUpTuChAqKxvU22TRLvRkBFiyWWZnq9cLpJN6SSvkho1", -94157569391),
+            ("5FXHf7q5rvBXnzQgmsa31Db9rjcRy6ZHKMiyDSb8Vs5p2msN", -688433531658),
+            ("5GbxkzytnvbRuNQ7qxPpfPuWMoeitS8V4KDY9jSshE5fDegD", -19085313),
+            ("5Gus1B7c9uWkky7Yawh2tKR1V6AMh5DbqUBPq881JHqeqVqY", -16101671818),
+            ("5DLhRdbvWkYYScDmwx4QgJfieSN4apBWbZ2yno3MfgbR8hBP", -21062025),
+            ("5Cg5kVyNEs7MWWRHU8X5MHwX5cN3aegvC4RBt2JK19w2GiR8", -2593737050),
+            ("5Dkushsxtc8AdCf287MtTYHQv9DoZeBRpttUpBtmyFhGy3uR", -48672832345630),
+            ("5EqNqVsHj9bQVyEujcm62zjMYUFhTLY7rTP854txSrJzyoco", -3828526),
+            ("5Dea6d6nKErEbRQ4MBGuCALn8NZ2xo4kaa51hB5KMriPBkEM", -1560192853875),
+            ("5DNt2XDWdeMd4H92FLnfUvkqyXzmavezHvzLboP3VgT1xLZV", -831964576998),
+            ("5FKtFoTeK8aaG6HZTrDgvoYHVQ5NY4S9VyV7W5K74cWcwLYA", -60823501166),
+            ("5GEBanZKUU7Hrf8K2VNi33HxyJRstgQ3WD3odHgvMj2nPbhi", -98946626902),
+            ("5CUtw7LYB2n2bzgXt6YnmKDHt6PsB3kKAyD9azYJNcRG8TNg", -9779588557490),
+            ("5EynbF72b12fbgMvEeL1vJSY342rCryNbuwxFivU1Xevtmv3", -17314385200455),
+            ("5CapiZRuULed8ConS1gbjMVgnwcT5JnQah7tx6sZnK7sJJuJ", -5810972),
+            ("5DnaxLaNduf41WM6WWZ4fkzcGzWNWx6eLJyQpSaMueUGCsaU", -12668760),
+            ("5Cqz9SChYPxTFZ2623rE2aQQ5ttQoLwZ8yfwYgiZyQDANqZn", -683549),
+            ("5C8ZcLzF23GrXKdH4Pg3ZXC3vKQsF5PM8VvhzzxzTQksgj8e", -44720570590),
+            ("5GuNsmoswrP6hTKZkKcpTpZftTMKrmnCHvTL2V3NHJy2fpen", -5042891812715),
+            ("5F1TYDkLnP36HHY5btigxyKUPzBraxdrU1aX1bqFfPfcfnzU", -1189104279832),
+            ("5Dc384z9HuTGF6oratZs1fLciCHtPZaLhrHfCVw82a5AikWZ", -616163196988),
+            ("5DhcaEUsRKhZQ31qRffJqjtLmFkbVaCebn8nVjYhvB4KJtX5", -17746006723),
+            ("5HYE7z3xTcrN1rqz54NyZRAkehFfRMcaEcdoMq5g5ATET5wQ", 212509751245),
+            ("5F97DdEVTy9gPCtN6jkJJENDJuQiRGiwbMVSL74qRq8FCq5W", 2225287736222),
+            ("5FUVN133rSvuKXgsXKMR2ZEaysxZjkRUFUWS1UMyNGre9xFV", -73216740161),
+            ("5CZeimtfpRqQgPxVwr1MzfG2Sok8E1AMERHo6vUmEdRS5JiU", -3937802),
+            ("5Eqq2JwGh7qbtnjPiFEPmmnHxs3S4J4Ahg8fr4sybZV1tPdY", -173406860562),
+            ("5ERfDw6K3GmQqwqsEG6foFtu7VsYGifPi556UJKQsBnfbHKN", 96022588728),
+            ("5Ek8RkU6KMv5Fx7yivRVoQkuJYAKhULWiLWDpbGG4hvR9HFD", 968139369093),
+            ("5HpCpGALzqgnDTP1HXFiuhzD5MFaDTRHjXBCvaMY9LNNRkT9", 104943979521),
+            ("5FYqS77gxW9gHG8id1YYPS7Cd4TQmNUMhF8h3S77Fq2VvvRQ", 729199757977),
+            ("5FtBqMg13pNf1N6TwfG6BmwyaDM77mkeQ16UTHsGasrVDedX", 131457064336),
+            ("5GbnWR2XhWrRMt123SdrLbR9G2a4N5dtzA3TSu3Czkzoeu7x", 2295599153),
+            ("5GgiowcCG4kLpwkCTGxxQJQv8WwKFyBQ6McPRmqKtWPy8EaK", 113838605389),
+            ("5FL5YtYozpUAGaiVWonpbwEYdEMij3obJHSH3ACY4vgWmDgy", 8689039),
+            ("5Egq58bxRv7boM2s3rnDxx1udnkzxPQ23HuoqohVxjh9RenC", 216373234348),
+            ("5FRGeeEgRNR8U33FDKvN7yUgts8zR3qRJH4yKKWoR9GswBRb", 2196574958718),
+            ("5FnhSy79BPYyrmmFsbckinQw1fLiLqqPkQL2vgZwPxbRfu3k", 42319631507),
+            ("5Hj8jMhqAv7cfyRh5STfbZefMhv17QxZ1RxWq9jNcLAEsRRo", 132216702183491),
+            ("5EXYTGMqumAH6RLQgHwkMEMnSvHcpHc89R6U8krfNJTYWm9J", 504320264499),
+            ("5EFh8ctzmytXURqrCTUBWHTs87f7TMWB6XKUzdqxKXVUtvS2", 2209599669432),
+            ("5CqVqEcRBkw7Gm2reJ33cj7puR9W2Tq7qsLxSruV1BgnMqKN", 1033387458788),
+            ("5D79enmLSGimsruoraGagofhaSeYJZvGUqFCCrr83ZfZs1HS", 7591184215233),
+            ("5HbpyjsvyXLWtf1QT1CyNUdyut6scM5dM7ytm8hoxFvRtU1i", 129833188275),
+            ("5CnxCi7CdEriWSdw4LcXdbtjodxA6uTat4gBm4wuT9QToMdo", 3132978),
+            ("5G48fiQjhAd8hc4rYc6GituCuAPKznL28jyyyq1auMyZiG4t", 514913328178),
+            ("5FFGjW2hJ7tQ41qghSsLP4cVmA8j9pZVSrr2CrLG7fQAsLHJ", 346794972723),
+            ("5FWjnxeRMtMFxRc9kvZKCG5iJAyyz2kmXV8u3kqyiXizZtiz", 225939835005),
+            ("5CUw3sB4oxd3dVSHUr3kxsB591VEjaPzr444KkfjwVFnLRfJ", 208250614494),
+            ("5EaBhxNUwMRyKsaeA2BEjDCrvwE5J8FDSpfCHK9gGmnmbhCa", 278083207003),
+            ("5GHJ5HxFxYQyVoNFUxR3JCqqCKRumaFCY7N5zMxwF4CpRUWr", 1381466224829),
+            ("5H1WgA7ET3FmEarJK6qc1vaTWbNd6g41mgvyLRkysrH4MDdo", 774889),
+        ];
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            if diff > 0 {
+                SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                    diff.unsigned_abs().into(),
+                );
+            }
+        }
+
+        // For one of the losers, add some extra stake
+        let idx = 0;
+        let lost_ck = diffs[idx].0;
+        let coldkey_account_id = decode_account_id32::<Test>(lost_ck).expect("Invalid coldkey");
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+            num_traits::ToPrimitive::to_u64(
+                &((num_traits::ToPrimitive::to_f64(&diffs[idx].1).expect("float conv fail")
+                    * 0.9_f64)
+                    .abs()),
+            )
+            .expect("u64 conv fail")
+            .into(),
+        );
+        let extra_balance = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+        );
+        assert!(!extra_balance.is_zero(), "extra balance must be non-zero");
+
+        let w = try_restore_shares::<Test>();
+        assert!(!w.is_zero(), "weight must be non-zero");
+
+        // Check stake is near 0 for all positive entires except the one we removed
+        // Check the stake for all negative entries is proportional to the amount they lost
+        let total_lost: f64 = diffs
+            .iter()
+            .map(|(_, diff)| {
+                if diff.is_negative() {
+                    num_traits::ToPrimitive::to_f64(&diff.saturating_abs())
+                        .expect("float conv fail")
+                } else {
+                    0_f64
+                }
+            })
+            .sum::<f64>();
+        let mut total_returned = 0_f64;
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff > 0 {
+                assert_relative_eq!(stake_float, 0_f64, max_relative = 0.001_f64);
+            } else {
+                if coldkey == lost_ck {
+                    total_returned += stake_float
+                        - num_traits::ToPrimitive::to_f64(&extra_balance.to_u64())
+                            .expect("float conv fail");
+                } else {
+                    total_returned += stake_float;
+                }
+            }
+        }
+
+        for (coldkey, diff) in diffs {
+            let coldkey_account_id = decode_account_id32::<Test>(coldkey).expect("Invalid coldkey");
+            let stake_float: f64 = num_traits::ToPrimitive::to_f64(
+                &SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &hotkey_account_id,
+                    &coldkey_account_id,
+                    netuid,
+                )
+                .to_u64(),
+            )
+            .expect("float conv fail");
+            if diff < 0 {
+                // Should get a return proportional to the amount they lost
+                // versus the amount that was able to be recovered
+                let prop_returned: f64 = num_traits::ToPrimitive::to_f64(&diff.abs())
+                    .expect("float conv fail")
+                    / total_lost
+                    * total_returned;
+
+                let mut expected_stake: f64 = prop_returned;
+                if coldkey == lost_ck {
+                    // this CK should retain the extra balance
+                    expected_stake = prop_returned
+                        + num_traits::ToPrimitive::to_f64(&extra_balance.to_u64())
+                            .expect("float conv fail");
+                }
+
+                assert_relative_eq!(stake_float, expected_stake, max_relative = 0.001_f64);
+            }
+        }
+    });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -268,7 +268,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 392,
+    spec_version: 393,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Migrates SN59 entries for hotkey `5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN` to restore stake map


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.