### PR TITLE
Update polkadot-sdk deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1435,7 +1435,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "hash-db",
  "log",
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2742,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2808,7 +2808,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2855,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2902,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2925,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2952,7 +2952,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2962,7 +2962,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3136,7 +3136,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4230,7 +4230,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "alloy-core",
 ]
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4620,13 +4620,13 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
 ]
 
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4791,7 +4791,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "environmental",
  "evm",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4891,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -4918,7 +4918,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5007,7 +5007,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5035,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5132,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5146,7 +5146,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5200,7 +5200,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "syn 2.0.106",
 ]
 
@@ -5220,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.4.0",
@@ -5243,7 +5243,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5272,7 +5272,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5296,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7906,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "log",
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -8882,7 +8882,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-io",
  "sp-runtime",
 ]
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8908,7 +8908,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8955,7 +8955,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8973,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9019,7 +9019,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9034,7 +9034,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9060,7 +9060,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9111,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9181,7 +9181,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9206,7 +9206,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9261,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9281,7 +9281,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9340,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9359,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9448,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9479,7 +9479,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9554,7 +9554,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9569,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9635,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9653,7 +9653,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9674,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9749,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9774,7 +9774,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9785,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9807,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "num",
@@ -9816,7 +9816,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9825,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9853,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9893,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9969,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10035,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10080,7 +10080,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10131,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10160,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10180,7 +10180,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10190,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10205,7 +10205,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10246,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10292,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10308,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10318,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10346,7 +10346,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10396,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10442,7 +10442,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10456,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10494,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10550,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10563,7 +10563,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10584,7 +10584,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10642,7 +10642,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10681,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10704,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10740,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -10751,7 +10751,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10760,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10945,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10978,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10996,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11027,7 +11027,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11088,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11117,7 +11117,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11132,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11146,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11156,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11199,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11580,7 +11580,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11598,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11613,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fatality",
  "futures",
@@ -11636,7 +11636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11669,7 +11669,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11693,7 +11693,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11716,7 +11716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11727,7 +11727,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fatality",
  "futures",
@@ -11749,7 +11749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11763,7 +11763,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11776,7 +11776,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -11784,7 +11784,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11807,7 +11807,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11825,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11857,7 +11857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -11881,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "futures",
@@ -11900,7 +11900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11921,7 +11921,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11936,7 +11936,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -11958,7 +11958,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11972,7 +11972,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11988,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fatality",
  "futures",
@@ -12006,7 +12006,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -12023,7 +12023,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fatality",
  "futures",
@@ -12037,7 +12037,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12054,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12082,7 +12082,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12110,7 +12110,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12121,7 +12121,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12136,7 +12136,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bs58",
  "futures",
@@ -12153,7 +12153,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12178,7 +12178,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12202,7 +12202,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12239,7 +12239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fatality",
  "futures",
@@ -12270,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "clap",
@@ -12358,7 +12358,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -12378,7 +12378,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -12394,7 +12394,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -12423,7 +12423,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12456,7 +12456,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12518,7 +12518,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12566,7 +12566,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -12724,7 +12724,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12759,7 +12759,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12869,7 +12869,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12889,7 +12889,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -13191,14 +13191,14 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=9883a6ad7607bcec3f49f65a910a3024169ec5f5#9883a6ad7607bcec3f49f65a910a3024169ec5f5"
+source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
 dependencies = [
  "case",
  "num_enum",
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "syn 2.0.106",
 ]
 
@@ -13380,7 +13380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "syn 2.0.106",
 ]
 
@@ -14027,7 +14027,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14125,7 +14125,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14521,7 +14521,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "sp-core",
@@ -14532,7 +14532,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -14563,7 +14563,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "log",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14600,7 +14600,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -14616,7 +14616,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -14627,7 +14627,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -14638,7 +14638,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -14680,7 +14680,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fnv",
  "futures",
@@ -14706,7 +14706,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -14757,7 +14757,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14811,7 +14811,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -14822,7 +14822,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14844,7 +14844,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14878,7 +14878,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14898,7 +14898,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14911,7 +14911,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -14945,7 +14945,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -14955,7 +14955,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14975,7 +14975,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15010,7 +15010,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -15033,7 +15033,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -15056,7 +15056,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -15069,7 +15069,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15080,7 +15080,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "anyhow",
  "log",
@@ -15096,7 +15096,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "console",
  "futures",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -15126,7 +15126,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15154,7 +15154,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15204,7 +15204,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15214,7 +15214,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ahash",
  "futures",
@@ -15233,7 +15233,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15254,7 +15254,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15274,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15309,7 +15309,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15328,7 +15328,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bs58",
  "bytes",
@@ -15349,7 +15349,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bytes",
  "fnv",
@@ -15383,7 +15383,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15392,7 +15392,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15424,7 +15424,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15444,7 +15444,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15468,7 +15468,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15501,13 +15501,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -15516,7 +15516,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "directories",
@@ -15580,7 +15580,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15591,7 +15591,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-db",
@@ -15610,7 +15610,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "clap",
  "fs4",
@@ -15623,7 +15623,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15642,7 +15642,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -15655,14 +15655,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "chrono",
  "futures",
@@ -15681,7 +15681,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "chrono",
  "console",
@@ -15709,7 +15709,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -15737,7 +15737,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -15751,7 +15751,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -15768,7 +15768,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16495,7 +16495,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16758,7 +16758,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -16842,7 +16842,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "hash-db",
@@ -16864,7 +16864,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16878,7 +16878,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16890,7 +16890,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16904,7 +16904,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16916,7 +16916,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16926,7 +16926,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16945,7 +16945,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "futures",
@@ -16959,7 +16959,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16975,7 +16975,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16993,7 +16993,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17001,7 +17001,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -17013,7 +17013,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17030,7 +17030,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17041,7 +17041,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -17072,7 +17072,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -17089,7 +17089,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17123,7 +17123,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17136,17 +17136,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -17155,7 +17155,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17165,7 +17165,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17175,7 +17175,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17187,7 +17187,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17200,7 +17200,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bytes",
  "docify",
@@ -17212,7 +17212,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -17226,7 +17226,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17236,7 +17236,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -17247,7 +17247,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17256,7 +17256,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17266,7 +17266,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17277,7 +17277,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17294,7 +17294,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17307,7 +17307,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -17317,7 +17317,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "backtrace",
  "regex",
@@ -17326,7 +17326,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17336,7 +17336,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17365,7 +17365,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17384,7 +17384,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "Inflector",
  "expander",
@@ -17397,7 +17397,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17411,7 +17411,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17424,7 +17424,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "hash-db",
  "log",
@@ -17444,7 +17444,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17457,7 +17457,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -17468,12 +17468,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17485,7 +17485,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17497,7 +17497,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17508,7 +17508,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17517,7 +17517,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17531,7 +17531,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -17556,7 +17556,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17573,7 +17573,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17585,7 +17585,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17597,7 +17597,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -17771,7 +17771,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "clap",
  "docify",
@@ -17784,7 +17784,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -17802,7 +17802,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17815,7 +17815,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.4",
@@ -17836,7 +17836,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "environmental",
  "frame-support",
@@ -17860,7 +17860,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17914,7 +17914,7 @@ dependencies = [
 [[package]]
 name = "stc-shield"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17935,7 +17935,7 @@ dependencies = [
 [[package]]
 name = "stp-shield"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18005,7 +18005,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -18030,7 +18030,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 
 [[package]]
 name = "substrate-fixed"
@@ -18046,7 +18046,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18066,7 +18066,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "http-body-util",
  "hyper 1.7.0",
@@ -18080,7 +18080,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -18107,7 +18107,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19142,7 +19142,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19153,7 +19153,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -20147,7 +20147,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20254,7 +20254,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -20895,7 +20895,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20906,7 +20906,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20920,7 +20920,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=285b4f8b392c517e50e237e717d28ea4f3666e7c#285b4f8b392c517e50e237e717d28ea4f3666e7c"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,8 @@ subtensor-runtime-common = { default-features = false, path = "common" }
 subtensor-swap-interface = { default-features = false, path = "pallets/swap-interface" }
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
-stp-shield = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-stc-shield = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+stp-shield = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+stc-shield = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
 ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
@@ -128,158 +128,159 @@ num_enum = { version = "0.7.4", default-features = false }
 environmental = { version = "1.1.4", default-features = false }
 tokio = { version = "1.38", default-features = false }
 
-frame = { package = "polkadot-sdk-frame", git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+frame = { package = "polkadot-sdk-frame", git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 
 pallet-subtensor-proxy = { path = "pallets/proxy", default-features = false }
 pallet-subtensor-utility = { path = "pallets/utility", default-features = false }
-pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-contracts = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-contracts = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
 # NPoS
-frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
-sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed.git", tag = "v0.6.0", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
-polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
-runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
+# current frontier branch is polkadot-stable2506-2-otf-get-call-indices-metadata
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "9883a6ad7607bcec3f49f65a910a3024169ec5f5", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
-sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
 w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std", default-features = false }
 ark-crypto-primitives = { version = "0.4.0", default-features = false }
 ark-scale = { version = "0.0.11", default-features = false }

--- a/eco-tests/Cargo.toml
+++ b/eco-tests/Cargo.toml
@@ -19,17 +19,17 @@ useless_conversion = "allow"
 
 [dependencies]
 pallet-subtensor = { path = "../pallets/subtensor", default-features = false, features = ["std"] }
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive", "std"] }
 scale-info = { version = "2.11.2", default-features = false, features = ["derive", "std"] }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
-pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
 pallet-drand = { path = "../pallets/drand", default-features = false, features = ["std"] }
 pallet-subtensor-swap = { path = "../pallets/swap", default-features = false, features = ["std"] }
 pallet-crowdloan = { path = "../pallets/crowdloan", default-features = false, features = ["std"] }
@@ -42,7 +42,7 @@ share-pool = { path = "../primitives/share-pool", default-features = false, feat
 safe-math = { path = "../primitives/safe-math", default-features = false, features = ["std"] }
 log = { version = "0.4.21", default-features = false, features = ["std"] }
 approx = "0.5"
-sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "285b4f8b392c517e50e237e717d28ea4f3666e7c", default-features = false, features = ["std"] }
+sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
 tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "=0.3.18", features = ["fmt", "env-filter"] }


### PR DESCRIPTION
## Description

Updates polkadot-sdk dependencies to one with the [`GetCallMetadata::get_call_indices` patch](https://github.com/opentensor/polkadot-sdk/pull/21).


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.