### PR TITLE
feat(subtensor): finalize lazy alpha v1->v2 share-pool migration

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -179,7 +179,11 @@ mod hooks {
                 // Fix lock state left behind by subnet-scoped hotkey swaps.
                 .saturating_add(migrations::migrate_fix_subnet_hotkey_lock_swaps::migrate_fix_subnet_hotkey_lock_swaps::<T>())
                 // Populate reverse lookup index for EVM address associations.
-                .saturating_add(migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<T>());
+                .saturating_add(migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<T>())
+                // Finalize the lazy Alpha -> AlphaV2 / TotalHotkeyShares -> TotalHotkeySharesV2
+                // migration (issue #2636): copy remaining legacy entries into the v2 maps and
+                // clear the legacy maps so the v1-first read fallback can be removed later.
+                .saturating_add(migrations::migrate_alpha_v1_to_v2::migrate_alpha_v1_to_v2::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_alpha_v1_to_v2.rs
+++ b/pallets/subtensor/src/migrations/migrate_alpha_v1_to_v2.rs
@@ -1,0 +1,120 @@
+use super::*;
+use frame_support::{traits::Get, weights::Weight};
+use scale_info::prelude::string::String;
+use share_pool::SafeFloat;
+use substrate_fixed::types::U64F64;
+
+/// Finalize the lazy `Alpha` -> `AlphaV2` and `TotalHotkeyShares` ->
+/// `TotalHotkeySharesV2` migration.
+///
+/// # Background (issue #2636)
+///
+/// The alpha share-pool was moved from the legacy `Alpha` / `TotalHotkeyShares`
+/// maps (`U64F64`) to `AlphaV2` / `TotalHotkeySharesV2` (`SafeFloat`). To avoid a
+/// one-shot rewrite of every staker at the v2 cutover, the move is performed
+/// lazily by `HotkeyAlphaSharePoolDataOperations::set_share` /
+/// `set_denominator`, which delete the legacy entry and write the v2 entry on
+/// every write. Reads still consult the legacy map first and fall back to v2.
+///
+/// Lazy migration only ever touches keys that are *written*. Keys that are only
+/// ever read remain in the legacy maps indefinitely, so the legacy maps can never
+/// be retired without an explicit finalization pass. This migration *is* that
+/// pass: it copies every remaining legacy entry into the corresponding v2 map and
+/// removes the legacy entry. Once it has run, the legacy maps are empty and the
+/// v1-first read fallback in `HotkeyAlphaSharePoolDataOperations` becomes a dead
+/// branch that a follow-up can delete, closing the "Deprecate v1 alpha share pool
+/// maps after they have lazy-migrated" sub-task of #2636.
+///
+/// # Safety
+///
+/// The legacy and v2 maps are mutually exclusive per key: the lazy writer always
+/// deletes the legacy entry before writing v2, and the legacy maps have no
+/// remaining write paths (`insert` / `mutate` / `put`) outside this migration, so
+/// a legacy entry is guaranteed to have no v2 counterpart and copying legacy ->
+/// v2 can never overwrite a newer v2 value. As defense in depth we still skip the
+/// copy when a v2 value is already present, preserving the "v2 wins on duplicate"
+/// semantics of `Pallet::alpha_iter`.
+///
+/// The persisted v2 value is produced with the exact same `SafeFloat::from(U64F64)`
+/// conversion the read path (`get_share` / `get_denominator`) already applies on
+/// every read, so this migration changes no observable value - it only relocates
+/// it from the legacy key to the v2 key.
+pub fn migrate_alpha_v1_to_v2<T: Config>() -> Weight {
+    let migration_name = b"migrate_alpha_v1_to_v2".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            target: "runtime",
+            "Migration '{}' already run - skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(target: "runtime", "Running migration 'migrate_alpha_v1_to_v2'");
+
+    let mut storage_reads: u64 = 0;
+    let mut storage_writes: u64 = 0;
+
+    // Collect entries up front: we mutate the very map we iterate over, so a live
+    // iterator cursor would be invalidated by the removals below.
+    let alpha_entries: Vec<((T::AccountId, T::AccountId, NetUid), U64F64)> =
+        Alpha::<T>::iter().collect();
+    for ((hotkey, coldkey, netuid), legacy_value) in alpha_entries {
+        storage_reads = storage_reads.saturating_add(1);
+
+        // Same conversion the read path uses; SafeFloat exposes is_zero (U64F64 does not).
+        let migrated = SafeFloat::from(legacy_value);
+        if migrated.is_zero() {
+            // Defensive: the lazy writer removes zero entries, but clear any that
+            // somehow remain instead of carrying them into v2.
+            Alpha::<T>::remove((&hotkey, &coldkey, netuid));
+            storage_writes = storage_writes.saturating_add(1);
+            continue;
+        }
+
+        // Defense in depth: never overwrite an existing v2 entry. Legacy and v2
+        // are mutually exclusive per key, so this branch is not expected to fire,
+        // but if it ever did the v2 value (the newer one) must win.
+        if AlphaV2::<T>::try_get((&hotkey, &coldkey, netuid)).is_err() {
+            storage_reads = storage_reads.saturating_add(1);
+            AlphaV2::<T>::insert((&hotkey, &coldkey, netuid), migrated);
+            storage_writes = storage_writes.saturating_add(1);
+        }
+
+        Alpha::<T>::remove((&hotkey, &coldkey, netuid));
+        storage_writes = storage_writes.saturating_add(1);
+    }
+
+    let shares_entries: Vec<(T::AccountId, NetUid, U64F64)> =
+        TotalHotkeyShares::<T>::iter().collect();
+    for (hotkey, netuid, legacy_value) in shares_entries {
+        storage_reads = storage_reads.saturating_add(1);
+
+        let migrated = SafeFloat::from(legacy_value);
+        if migrated.is_zero() {
+            TotalHotkeyShares::<T>::remove(&hotkey, netuid);
+            storage_writes = storage_writes.saturating_add(1);
+            continue;
+        }
+
+        if TotalHotkeySharesV2::<T>::try_get(&hotkey, netuid).is_err() {
+            storage_reads = storage_reads.saturating_add(1);
+            TotalHotkeySharesV2::<T>::insert(&hotkey, netuid, migrated);
+            storage_writes = storage_writes.saturating_add(1);
+        }
+
+        TotalHotkeyShares::<T>::remove(&hotkey, netuid);
+        storage_writes = storage_writes.saturating_add(1);
+    }
+
+    weight = weight.saturating_add(T::DbWeight::get().reads_writes(storage_reads, storage_writes));
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(target: "runtime", "Migration 'migrate_alpha_v1_to_v2' completed.");
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -4,6 +4,7 @@ use frame_support::pallet_prelude::Weight;
 use sp_io::KillStorageResult;
 use sp_io::hashing::twox_128;
 use sp_io::storage::clear_prefix;
+pub mod migrate_alpha_v1_to_v2;
 pub mod migrate_associated_evm_address_index;
 pub mod migrate_auto_stake_destination;
 pub mod migrate_cleanup_swap_v3;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -28,6 +28,7 @@ use frame_system::Config;
 use pallet_drand::types::RoundNumber;
 use pallet_scheduler::ScheduledOf;
 use scale_info::prelude::collections::VecDeque;
+use share_pool::SafeFloat;
 use sp_core::{H160, H256, U256, crypto::Ss58Codec};
 use sp_io::hashing::twox_128;
 use sp_runtime::{
@@ -5065,5 +5066,126 @@ fn test_migrate_dynamic_tempo_idempotent() {
             last_epoch_first,
             "second migration call must be a no-op"
         );
+    });
+}
+
+#[test]
+fn test_migrate_alpha_v1_to_v2_finalizes_legacy_maps_and_preserves_values() {
+    new_test_ext(1).execute_with(|| {
+        const MIGRATION_NAME: &[u8] = b"migrate_alpha_v1_to_v2";
+        HasMigrationRun::<Test>::remove(MIGRATION_NAME.to_vec());
+
+        let hot_a = U256::from(1);
+        let cold_a = U256::from(2);
+        let hot_b = U256::from(3);
+        let cold_b = U256::from(4);
+        let netuid = NetUid::from(7);
+
+        // Legacy Alpha (v1): two non-zero entries plus a zero entry.
+        let legacy_alpha_value = U64F64::from(123_456_u64);
+        Alpha::<Test>::insert((hot_a, cold_a, netuid), legacy_alpha_value);
+        Alpha::<Test>::insert((hot_b, cold_b, netuid), U64F64::from(7_u64));
+        Alpha::<Test>::insert((hot_b, cold_a, netuid), U64F64::from(0_u64));
+
+        // Legacy TotalHotkeyShares (v1).
+        let legacy_shares_value = U64F64::from(9_876_u64);
+        TotalHotkeyShares::<Test>::insert(hot_a, netuid, legacy_shares_value);
+
+        // Defense-in-depth probe: a colliding v2 entry already exists. The lazy
+        // invariant says this never happens on-chain, but if it did the migration
+        // must keep the (newer) v2 value.
+        let pre_existing_v2 = SafeFloat::from(999_u64);
+        AlphaV2::<Test>::insert((hot_b, cold_b, netuid), pre_existing_v2.clone());
+
+        // Capture the merged read-path view before migration (merges v1 + v2, v2 wins).
+        let before: BTreeMap<_, SafeFloat> = SubtensorModule::alpha_iter().collect();
+
+        // Run the migration.
+        let _ = migrations::migrate_alpha_v1_to_v2::migrate_alpha_v1_to_v2::<Test>();
+
+        assert!(
+            HasMigrationRun::<Test>::get(MIGRATION_NAME.to_vec()),
+            "migration should be marked as completed"
+        );
+
+        // Legacy maps are fully drained.
+        assert_eq!(
+            Alpha::<Test>::iter().count(),
+            0,
+            "legacy Alpha map must be empty"
+        );
+        assert_eq!(
+            TotalHotkeyShares::<Test>::iter().count(),
+            0,
+            "legacy TotalHotkeyShares map must be empty"
+        );
+
+        // Non-zero legacy values are relocated byte-for-byte (same conversion the
+        // read path already uses).
+        assert_eq!(
+            AlphaV2::<Test>::get((hot_a, cold_a, netuid)),
+            SafeFloat::from(legacy_alpha_value)
+        );
+        assert_eq!(
+            TotalHotkeySharesV2::<Test>::get(hot_a, netuid),
+            SafeFloat::from(legacy_shares_value)
+        );
+
+        // The zero legacy entry was dropped, not carried into v2.
+        assert!(
+            AlphaV2::<Test>::get((hot_b, cold_a, netuid)).is_zero(),
+            "zero legacy entry must not be carried into v2"
+        );
+
+        // Defense in depth: the pre-existing v2 value wins over the colliding
+        // legacy value (7), matching the v2-wins semantics of alpha_iter.
+        assert_eq!(
+            AlphaV2::<Test>::get((hot_b, cold_b, netuid)),
+            pre_existing_v2
+        );
+
+        // The merged read path is unchanged by the migration (behavior preservation).
+        let after: BTreeMap<_, SafeFloat> = SubtensorModule::alpha_iter().collect();
+        assert_eq!(
+            before.get(&(hot_a, cold_a, netuid)),
+            after.get(&(hot_a, cold_a, netuid)),
+            "read-path value for the migrated key must be unchanged"
+        );
+        assert_eq!(
+            before.get(&(hot_b, cold_b, netuid)),
+            after.get(&(hot_b, cold_b, netuid)),
+            "colliding key read-path value must be unchanged"
+        );
+
+        // Idempotency: a second run is a no-op.
+        let v2_count = AlphaV2::<Test>::iter().count();
+        let _ = migrations::migrate_alpha_v1_to_v2::migrate_alpha_v1_to_v2::<Test>();
+        assert_eq!(
+            AlphaV2::<Test>::iter().count(),
+            v2_count,
+            "second run must not mutate"
+        );
+    });
+}
+
+#[test]
+fn test_migrate_alpha_v1_to_v2_is_a_noop_on_empty_legacy_maps() {
+    new_test_ext(1).execute_with(|| {
+        const MIGRATION_NAME: &[u8] = b"migrate_alpha_v1_to_v2";
+        HasMigrationRun::<Test>::remove(MIGRATION_NAME.to_vec());
+
+        // No legacy data at all (fresh state / fully lazy-migrated steady state).
+        assert_eq!(Alpha::<Test>::iter().count(), 0);
+        assert_eq!(TotalHotkeyShares::<Test>::iter().count(), 0);
+
+        let _ = migrations::migrate_alpha_v1_to_v2::migrate_alpha_v1_to_v2::<Test>();
+
+        assert!(HasMigrationRun::<Test>::get(MIGRATION_NAME.to_vec()));
+        assert_eq!(
+            AlphaV2::<Test>::iter().count(),
+            0,
+            "must not synthesize any v2 entries"
+        );
+        assert_eq!(TotalHotkeySharesV2::<Test>::iter().count(), 0);
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 428,
+    spec_version: 429,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Hi! I am Loom Agent - an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome - I will do my best to address review comments promptly.

This advances one sub-task of the alpha-operations epic (#2636): "Deprecate v1 alpha share pool maps after they have lazy-migrated (finalizing migration)."

## Release Notes
- Added a runtime migration that finalizes the lazy `Alpha` -> `AlphaV2` and `TotalHotkeyShares` -> `TotalHotkeySharesV2` share-pool relocation: remaining legacy entries are copied into the v2 maps and the legacy maps are cleared, so the v1-first read fallback can be removed in a follow-up.
- No observable alpha/stake value changes: the migration persists exactly the value the read path already computes (same `SafeFloat::from(U64F64)` conversion), only relocating it from the legacy key to the v2 key.

## Description

The alpha share-pool was moved from the legacy `Alpha` / `TotalHotkeyShares` maps (`U64F64`) to `AlphaV2` / `TotalHotkeySharesV2` (`SafeFloat`). To avoid a one-shot rewrite of every staker at the v2 cutover the relocation is performed lazily by `HotkeyAlphaSharePoolDataOperations::set_share` / `set_denominator`, which delete the legacy entry and write the v2 entry on every write. Reads still consult the legacy map first and fall back to v2. Because lazy migration only ever relocates keys that are *written*, keys that are only ever read stay in the legacy maps indefinitely, so the legacy maps can never be retired without an explicit finalization pass. This is sub-task 2 of #2636.

**Root cause / approach:** there is no bug - the lazy strategy is intentional. What is missing is the *finalizing* pass that retires the legacy maps. This PR adds it as a new `migrate_alpha_v1_to_v2` migration that copies every remaining legacy entry into the corresponding v2 map and removes the legacy entry. After it runs the legacy maps are empty and the v1-first read fallback becomes dead code a follow-up can delete.

**Safety:** the legacy and v2 maps are mutually exclusive per key:
- The lazy writer (`set_share` / `set_denominator`) always deletes the legacy entry before writing v2.
- The legacy `Alpha` / `TotalHotkeyShares` maps have no remaining write paths (`insert` / `mutate` / `put`) outside this migration - verified by a precise search; the only other accessors are the read path, removals in `set_share`/`set_denominator`, subnet-dissolution cleanup in `remove_stake` (which removes *both* legacy and v2), and hotkey-swap re-keying (which routes through `set_share`, i.e. migrates to v2).

So a legacy entry is guaranteed to have no v2 counterpart, and the copy cannot overwrite a newer v2 value. As defense in depth the migration still skips the copy when a v2 value already exists (matching the "v2 wins on duplicate" semantics of `Pallet::alpha_iter`). The persisted v2 value uses the exact same `SafeFloat::from(U64F64)` conversion the read path (`get_share` / `get_denominator`) already applies on every read. The migration is wired into the subtensor pallet `on_runtime_upgrade` hook, runs once (idempotent via `HasMigrationRun`), and follows the same one-shot pattern as the adjacent wired migrations (e.g. `migrate_fix_subnet_hotkey_lock_swaps`). `spec_version` is bumped 428 -> 429.

## Related Issue(s)
- Advances #2636 (sub-task: finalize the lazy v1 alpha share-pool migration). It does not close the epic, which has other sub-tasks outstanding.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Non-breaking: the migration is value-preserving - it changes only where the data lives, not what it is. `spec_version` is bumped (428 -> 429) so nodes run the migration in lockstep; `transaction_version` is unchanged.

## Testing

Built and tested with the project toolchain (rustc 1.89.0). Real output:
- `cargo fmt --all -- --check` -> clean (exit 0).
- `cargo clippy -p pallet-subtensor --all-features --all-targets -- -D warnings` -> finished, exit 0, no warnings in this crate.
- `cargo test -p pallet-subtensor --all-features --lib migration::` -> `test result: ok. 76 passed; 0 failed`.

New tests in `pallets/subtensor/src/tests/migration.rs`:
- `test_migrate_alpha_v1_to_v2_finalizes_legacy_maps_and_preserves_values` - seeds legacy entries (non-zero, zero, and a colliding pre-existing v2 value), runs the migration, and asserts the legacy maps are drained, non-zero values are relocated byte-for-byte, the zero entry is dropped, the pre-existing v2 value is preserved (defense in depth), and the merged read path (`alpha_iter`) is unchanged before/after; plus idempotency on a second run.
- `test_migrate_alpha_v1_to_v2_is_a_noop_on_empty_legacy_maps` - verifies the migration is a clean no-op (and marks itself run) when there is no legacy data.

(`./scripts/fix_rust.sh` was not run verbatim because it auto-fixes and auto-commits; the equivalent per-crate `fmt`/`clippy`/`test` gates above were run read-only with the pinned toolchain instead.)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Scope: this PR finalizes the data relocation only. Removing the v1-first read fallback in `HotkeyAlphaSharePoolDataOperations` and dropping the legacy `Alpha` / `TotalHotkeyShares` storage declarations is deliberately left to a follow-up, to be done after this migration has run on mainnet and the legacy maps are confirmed empty. That sequencing keeps each step independently revertable. If other spec_version-bumping PRs land first, this branch will need a trivial rebase on `runtime/src/lib.rs` (the usual `spec_version` conflict).
