### PR TITLE
feat(subtensor): add MinTradeDelay post-start trading delay (#2844)

### DIFF
--- a/chain-extensions/src/mock.rs
+++ b/chain-extensions/src/mock.rs
@@ -349,6 +349,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  7 * 24 * 60 * 60 / 12; // Default as 7 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(10_000_000);
     pub const HotkeySwapOnSubnetInterval: u64 = 15; // 15 block, should be bigger than subnet number, then trigger clean up for all subnets
     pub const MaxContributorsPerLeaseToRemove: u32 = 3;
@@ -430,6 +431,7 @@ impl pallet_subtensor::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = pallet_subtensor_swap::Pallet<Self>;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -244,6 +244,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;
     pub const HotkeySwapOnSubnetInterval: u64 = 15; // 15 block, should be bigger than subnet number, then trigger clean up for all subnets
     pub const MaxContributorsPerLeaseToRemove: u32 = 3;
@@ -324,6 +325,7 @@ impl pallet_subtensor::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = pallet_subtensor_swap::Pallet<Self>;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2076,6 +2076,17 @@ pub mod pallet {
             Ok(())
         }
 
+        /// Sets the number of blocks after subnet-start during which staking is blocked (#2844).
+        #[pallet::call_index(98)]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
+        pub fn sudo_set_min_trade_delay(origin: OriginFor<T>, delay: u64) -> DispatchResult {
+            ensure_root(origin)?;
+            pallet_subtensor::Pallet::<T>::set_min_trade_delay(delay);
+            log::debug!("MinTradeDelay( delay: {delay:?} ) ");
+            Ok(())
+        }
+
         /// Sets the announcement delay for coldkey swap.
         #[pallet::call_index(86)]
         #[pallet::weight(<T as pallet::Config>::WeightInfo::sudo_set_coldkey_swap_announcement_delay())]

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -159,6 +159,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = u64::MAX/10; // 10% global weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 = 0; // 0 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(10_000_000);
     pub const HotkeySwapOnSubnetInterval: u64 = 7 * 24 * 60 * 60 / 12; // 7 days
     pub const LeaseDividendsDistributionInterval: u32 = 100; // 100 blocks
@@ -239,6 +240,7 @@ impl pallet_subtensor::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = Swap;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -3383,3 +3383,33 @@ fn test_sudo_set_start_call_delay_permissions_and_zero_delay() {
         );
     });
 }
+
+// #2844 — sudo can set the post-start trading delay; non-root cannot.
+#[test]
+fn test_sudo_set_min_trade_delay() {
+    new_test_ext().execute_with(|| {
+        let non_root = U256::from(1);
+
+        // Mock default is 0.
+        assert_eq!(pallet_subtensor::MinTradeDelay::<Test>::get(), 0);
+
+        // Non-root is rejected.
+        assert_noop!(
+            AdminUtils::sudo_set_min_trade_delay(
+                <<Test as Config>::RuntimeOrigin>::signed(non_root),
+                360
+            ),
+            DispatchError::BadOrigin
+        );
+
+        // Root sets it, storage updates, event is emitted.
+        assert_ok!(AdminUtils::sudo_set_min_trade_delay(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            360
+        ));
+        assert_eq!(pallet_subtensor::MinTradeDelay::<Test>::get(), 360);
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::SubtensorModule(
+            pallet_subtensor::Event::MinTradeDelaySet(360),
+        ));
+    });
+}

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -249,6 +249,13 @@ impl<T: Config> Pallet<T> {
         StartCallDelay::<T>::set(delay);
         Self::deposit_event(Event::StartCallDelaySet(delay));
     }
+    pub fn get_min_trade_delay() -> u64 {
+        MinTradeDelay::<T>::get()
+    }
+    pub fn set_min_trade_delay(delay: u64) {
+        MinTradeDelay::<T>::set(delay);
+        Self::deposit_event(Event::MinTradeDelaySet(delay));
+    }
     pub fn set_network_min_lock(net_min_lock: TaoBalance) {
         NetworkMinLockCost::<T>::set(net_min_lock);
         Self::deposit_event(Event::NetworkMinLockCostSet(net_min_lock));

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1881,6 +1881,13 @@ pub mod pallet {
     #[pallet::storage]
     pub type StartCallDelay<T: Config> = StorageValue<_, u64, ValueQuery, T::InitialStartCallDelay>;
 
+    /// ITEM( min_trade_delay )
+    /// Blocks after subnet-start (`start_call`) during which staking in/out is blocked, so a
+    /// subnet owner cannot bundle `add_stake` into the `start_call` block and self-snipe the
+    /// launch. See opentensor/subtensor#2844.
+    #[pallet::storage]
+    pub type MinTradeDelay<T: Config> = StorageValue<_, u64, ValueQuery, T::InitialMinTradeDelay>;
+
     /// ITEM( min_network_lock_cost )
     #[pallet::storage]
     pub type NetworkMinLockCost<T> =
@@ -3014,12 +3021,27 @@ pub mod pallet {
             true
         }
 
-        /// Ensure subtoken enalbed
+        /// Ensure the subtoken is enabled AND the post-start trading delay has elapsed.
+        ///
+        /// Staking (in or out) is blocked until `MinTradeDelay` blocks after the subnet-start
+        /// block, so a subnet owner cannot bundle `add_stake` into the same block as `start_call`
+        /// and self-snipe the launch (opentensor/subtensor#2844). The subnet-start block is
+        /// `FirstEmissionBlockNumber - 1` (both set atomically by `do_start_call`). Subnets whose
+        /// subtoken was enabled without a start block (e.g. root / genesis paths where
+        /// `FirstEmissionBlockNumber` is unset) are unaffected.
         pub fn ensure_subtoken_enabled(subnet: NetUid) -> Result<(), Error<T>> {
             ensure!(
                 SubtokenEnabled::<T>::get(subnet),
                 Error::<T>::SubtokenDisabled
             );
+            if let Some(first_emission_block) = FirstEmissionBlockNumber::<T>::get(subnet) {
+                let start_call_block = first_emission_block.saturating_sub(1);
+                let trading_open_block = start_call_block.saturating_add(MinTradeDelay::<T>::get());
+                ensure!(
+                    Self::get_current_block_as_u64() >= trading_open_block,
+                    Error::<T>::TradingNotOpenYet
+                );
+            }
             Ok(())
         }
     }

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -267,6 +267,9 @@ mod config {
         /// Delay after which a new subnet can dispatch start call extrinsic.
         #[pallet::constant]
         type InitialStartCallDelay: Get<u64>;
+        /// Initial blocks after subnet-start during which staking is blocked (#2844).
+        #[pallet::constant]
+        type InitialMinTradeDelay: Get<u64>;
         /// Cost of swapping a hotkey in a subnet.
         #[pallet::constant]
         type KeySwapOnSubnetCost: Get<TaoBalance>;

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -346,5 +346,7 @@ mod errors {
         /// with miner collateral on the subnet
         /// ([`crate::MAX_COLDKEY_COLLATERAL_HOTKEYS`]).
         ColdkeyCollateralPositionsFull,
+        /// Trading is not open yet: the post-start trading delay (MinTradeDelay) has not elapsed.
+        TradingNotOpenYet,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -154,6 +154,8 @@ mod events {
         NetworkImmunityPeriodSet(u64),
         /// the start call delay is set.
         StartCallDelaySet(u64),
+        /// the minimum post-start trading delay is set.
+        MinTradeDelaySet(u64),
         /// the network minimum locking cost is set.
         NetworkMinLockCostSet(TaoBalance),
         /// the maximum number of subnets is set

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1296,15 +1296,12 @@ impl<T: Config> Pallet<T> {
             );
         }
 
-        ensure!(
-            SubtokenEnabled::<T>::get(origin_netuid),
-            Error::<T>::SubtokenDisabled
-        );
-
-        ensure!(
-            SubtokenEnabled::<T>::get(destination_netuid),
-            Error::<T>::SubtokenDisabled
-        );
+        // Route through ensure_subtoken_enabled so the post-start trading delay (#2844) also
+        // gates swap/move/transfer. Otherwise an owner could pre-stake into an always-open
+        // subnet (e.g. root) and bundle batch_all[start_call, swap_stake(root -> new)] to
+        // acquire alpha in the new subnet at launch, bypassing the add_stake gate.
+        Self::ensure_subtoken_enabled(origin_netuid)?;
+        Self::ensure_subtoken_enabled(destination_netuid)?;
 
         // Ensure that the origin hotkey account exists
         ensure!(

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -295,6 +295,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;
     pub const HotkeySwapOnSubnetInterval: u64 = 15; // 15 block, should be bigger than subnet number, then trigger clean up for all subnets
     pub const MaxContributorsPerLeaseToRemove: u32 = 3;
@@ -375,6 +376,7 @@ impl crate::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = pallet_subtensor_swap::Pallet<Self>;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/pallets/subtensor/src/tests/mock_high_ed.rs
+++ b/pallets/subtensor/src/tests/mock_high_ed.rs
@@ -217,6 +217,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;
     pub const HotkeySwapOnSubnetInterval: u64 = 15; // 15 block, should be bigger than subnet number, then trigger clean up for all subnets
     pub const MaxContributorsPerLeaseToRemove: u32 = 3;
@@ -297,6 +298,7 @@ impl crate::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = pallet_subtensor_swap::Pallet<Self>;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -989,3 +989,81 @@ fn test_register_network_gives_owner_no_initial_alpha_distribution() {
         );
     });
 }
+
+/***************************
+  #2844 — post-start trading delay (MinTradeDelay)
+*****************************/
+
+// A non-zero MinTradeDelay must block staking (including an owner's same-block bundle) until
+// `start_call_block + MinTradeDelay`, then open it. This is the fix for the SN99 self-snipe.
+#[test]
+fn test_min_trade_delay_blocks_stake_until_window_elapses() {
+    new_test_ext(0).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 13;
+        let coldkey = U256::from(0); // default subnet owner
+        let hotkey = U256::from(1);
+        let delay: u64 = 10;
+
+        add_network_without_emission_block(netuid, tempo, 0);
+        mock::setup_reserves(netuid, 1_000_000_000.into(), 1_000_000_000.into());
+        register_ok_neuron(netuid, hotkey, coldkey, 0);
+        add_balance_to_coldkey_account(&coldkey, 10_000.into());
+
+        SubtensorModule::set_min_trade_delay(delay);
+        assert_eq!(MinTradeDelay::<Test>::get(), delay);
+
+        // Owner starts the subnet at block B: FirstEmissionBlockNumber = B+1, start block = B.
+        let start_block = System::block_number();
+        assert_ok!(SubtensorModule::start_call(
+            RuntimeOrigin::signed(coldkey),
+            netuid
+        ));
+        assert!(SubtokenEnabled::<Test>::get(netuid));
+
+        // Same block as start: the owner's bundled add_stake is rejected.
+        assert_noop!(
+            SubtensorModule::add_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                1_000_000.into()
+            ),
+            Error::<Test>::TradingNotOpenYet
+        );
+
+        // The gate stays closed for the whole window and opens exactly at start + delay.
+        assert!(matches!(
+            SubtensorModule::ensure_subtoken_enabled(netuid),
+            Err(Error::<Test>::TradingNotOpenYet)
+        ));
+        System::set_block_number(start_block + delay - 1);
+        assert!(matches!(
+            SubtensorModule::ensure_subtoken_enabled(netuid),
+            Err(Error::<Test>::TradingNotOpenYet)
+        ));
+        System::set_block_number(start_block + delay);
+        assert!(SubtensorModule::ensure_subtoken_enabled(netuid).is_ok());
+    });
+}
+
+// A zero MinTradeDelay preserves today's behaviour: trading is open in the start block.
+#[test]
+fn test_min_trade_delay_zero_preserves_immediate_trading() {
+    new_test_ext(0).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 13;
+        let coldkey = U256::from(0);
+
+        add_network_without_emission_block(netuid, tempo, 0);
+        mock::setup_reserves(netuid, 1_000_000_000.into(), 1_000_000_000.into());
+
+        SubtensorModule::set_min_trade_delay(0);
+        assert_ok!(SubtensorModule::start_call(
+            RuntimeOrigin::signed(coldkey),
+            netuid
+        ));
+        // delay = 0 -> trading is open in the start block, exactly as today.
+        assert!(SubtensorModule::ensure_subtoken_enabled(netuid).is_ok());
+    });
+}

--- a/pallets/transaction-fee/src/tests/mock.rs
+++ b/pallets/transaction-fee/src/tests/mock.rs
@@ -229,6 +229,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = u64::MAX/10; // 10% global weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 = 0; // 0 days
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(10_000_000);
     pub const HotkeySwapOnSubnetInterval: u64 = 7 * 24 * 60 * 60 / 12; // 7 days
     pub const LeaseDividendsDistributionInterval: u32 = 100; // 100 blocks
@@ -309,6 +310,7 @@ impl pallet_subtensor::Config for Test {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = Swap;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/precompiles/src/mock.rs
+++ b/precompiles/src/mock.rs
@@ -175,6 +175,7 @@ parameter_types! {
     pub const InitialTaoWeight: u64 = u64::MAX / 10;
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600;
     pub const InitialStartCallDelay: u64 = 0;
+    pub const InitialMinTradeDelay: u64 = 0; // #2844: 0 in mocks
     pub const InitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(10_000_000);
     pub const HotkeySwapOnSubnetInterval: u64 = 50_400;
     pub const LeaseDividendsDistributionInterval: u32 = 100;
@@ -511,6 +512,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialTaoWeight = InitialTaoWeight;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = Swap;
     type KeySwapOnSubnetCost = InitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 437,
+    spec_version: 438,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -849,6 +849,9 @@ parameter_types! {
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     // 0 days
     pub const InitialStartCallDelay: u64 = 0;
+    // #2844: block staking for a predictable window after subnet-start (prod ~72 min; 0 on
+    // fast-blocks). The value is the policy knob — sudo-tunable via sudo_set_min_trade_delay.
+    pub const InitialMinTradeDelay: u64 = prod_or_fast!(360, 0);
     pub const SubtensorInitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(1_000_000); // 0.001 TAO
     pub const HotkeySwapOnSubnetInterval : BlockNumber = prod_or_fast!(24 * 60 * 60 / 12, 1); // 1 day
     pub const LeaseDividendsDistributionInterval: BlockNumber = 100; // 100 blocks
@@ -928,6 +931,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
     type InitialStartCallDelay = InitialStartCallDelay;
+    type InitialMinTradeDelay = InitialMinTradeDelay;
     type SwapInterface = Swap;
     type KeySwapOnSubnetCost = SubtensorInitialKeySwapOnSubnetCost;
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -585,6 +585,7 @@ call_filter_group!(
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_net_tao_flow_enabled),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_max_mechanism_count),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_start_call_delay),
+        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_min_trade_delay),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_coldkey_swap_announcement_delay),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_coldkey_swap_reannouncement_delay),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_subnet_emission_enabled),


### PR DESCRIPTION
# PR: Add `MinTradeDelay` — a post-start trading delay to prevent subnet-start self-snipes

Closes / implements the mechanism requested in #2844.

## Problem
`do_start_call` sets `SubtokenEnabled = true` in the **same block** as the subnet start
(`subnets/subnet.rs`). Because `add_stake` (and the swap/move/transfer family) validate against
`SubtokenEnabled`, a subnet owner can submit `batch_all[start_call, add_stake]` and buy alpha
**atomically in the block trading opens**, before anyone else can react — the SN99 case in #2844.

## Change
Adds a sudo-configurable hyperparameter **`MinTradeDelay`** (blocks) and enforces a *post-start
trading-open delay*: staking in/out is rejected with a new `TradingNotOpenYet` error until
`current_block >= start_block + MinTradeDelay`, where `start_block = FirstEmissionBlockNumber - 1`
(set atomically by `do_start_call`). This mirrors the existing `StartCallDelay` hyperparameter end
to end (storage / config const / event / getter-setter / `sudo_set_min_trade_delay`).

The check lives in `Pallet::ensure_subtoken_enabled`, which is the single gate for `add_stake`,
`add_stake_limit`, `remove_stake`, `recycle`, `buy_alpha`, and `transfer_staked_alpha`. The
`swap_stake` / `move_stake` / `transfer_stake` family was checking `SubtokenEnabled` **directly**
(`validate_stake_transition`), which would have let an owner pre-stake into root and bundle
`batch_all[start_call, swap_stake(root -> new)]` to snipe anyway — so those two checks are now
routed through `ensure_subtoken_enabled` too, closing that bypass.

Result: in the start block (with delay > 0) **no** alpha-acquiring path succeeds — the owner's
bundled buy reverts `TradingNotOpenYet`. Everyone, owner included, can only stake at the known,
public block `start + MinTradeDelay`.

## Files
- `pallets/subtensor/src/lib.rs` — `MinTradeDelay` storage + the delay check in `ensure_subtoken_enabled`.
- `pallets/subtensor/src/macros/{config,events,errors}.rs` — `InitialMinTradeDelay`, `MinTradeDelaySet`, `TradingNotOpenYet`.
- `pallets/subtensor/src/coinbase/root.rs` — `get/set_min_trade_delay`.
- `pallets/subtensor/src/staking/stake_utils.rs` — route `validate_stake_transition` through the gate.
- `pallets/admin-utils/src/lib.rs` — `sudo_set_min_trade_delay` (call_index 98).
- `runtime/src/lib.rs` — `InitialMinTradeDelay = prod_or_fast!(360, 0)`, wiring, `spec_version` 431→432.
- `runtime/src/proxy_filters/call_groups.rs` — add the new sudo call to the proxy-filter allow-group.
- 7 test mocks — provide `InitialMinTradeDelay` (compile requirement).
- Tests in `pallets/subtensor/src/tests/subnet.rs` and `pallets/admin-utils/src/tests/mod.rs`.

## Compatibility
- **Existing subnets**: their `FirstEmissionBlockNumber` is in the past, so `start + delay` is in the
  past → not retroactively frozen.
- **Root / not-yet-started subnets** (`FirstEmissionBlockNumber = None`): delay branch skipped → behave as today.
- **Emissions**: `FirstEmissionBlockNumber` is unchanged and emission eligibility uses `.is_some()`, not a
  block compare — emission timing is unaffected.
- **Storage**: `ValueQuery` + default ⇒ no migration.

## Open questions for reviewers (policy, not mechanism)
1. **Default value.** I defaulted to `prod_or_fast!(360, 0)` (~72 min on prod, 0 on fast-blocks) so the
   protection is on by default while remaining sudo-tunable. Happy to default `0` (mechanism only, opt-in
   via sudo) if the team prefers a no-behaviour-change merge, matching how `StartCallDelay` shipped.
2. **Sell-side symmetry.** This gates the buy side (the self-snipe) and plain `remove_stake`. Some sell
   paths (`unstake_all`, `remove_stake_limit`) intentionally no-op / aren't gated today; I left that
   pre-existing behaviour alone. If "no staking in *or* out during the window" is desired verbatim, those
   can be routed through the gate too — flagging as a scope decision.
