### PR TITLE
Add getStakeInfoForColdkeyAndNetuid and getStakeOperationThreshold views to StakingPrecompileV2

### DIFF
--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -780,6 +780,11 @@ impl<T: Config> Pallet<T> {
         SubnetOwner::<T>::iter_values().any(|owner| *address == owner)
     }
 
+    /// The minimum TAO-equivalent value a stake operation must reach to be accepted.
+    pub fn get_stake_operation_threshold() -> TaoBalance {
+        DefaultMinStake::<T>::get()
+    }
+
     /// The NominatorMinRequiredStake is the factor by which we multiply
     /// the DefaultMinStake to get nominator minimum stake. With DefaulMinStake
     /// of 0.001 TAO and NominatorMinRequiredStake of 100_000_000, the

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -125,6 +125,42 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getStakeInfoForColdkeyAndNetuid",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "hotkey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "stake",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct StakeInfo[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "hotkey",
         "type": "bytes32"
       },
@@ -186,6 +222,19 @@
   {
     "inputs": [],
     "name": "getNominatorMinRequiredStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStakeOperationThreshold",
     "outputs": [
       {
         "internalType": "uint256",

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -2,6 +2,12 @@ pragma solidity ^0.8.0;
 
 address constant ISTAKING_ADDRESS = 0x0000000000000000000000000000000000000805;
 
+/// A coldkey's stake position: the `hotkey` and the `stake` amount in alpha.
+struct StakeInfo {
+    bytes32 hotkey;
+    uint256 stake;
+}
+
 interface IStaking {
     /**
      * @dev Adds a subtensor stake `amount` associated with the `hotkey`.
@@ -152,6 +158,19 @@ interface IStaking {
     ) external view returns (uint256);
 
     /**
+     * @dev Returns the coldkey's non-zero stake positions on `netuid`; zero-stake
+     * hotkeys are omitted.
+     *
+     * @param coldkey The coldkey public key (32 bytes).
+     * @param netuid The subnet to query.
+     * @return The coldkey's (hotkey, stake) positions on `netuid`.
+     */
+    function getStakeInfoForColdkeyAndNetuid(
+        bytes32 coldkey,
+        uint256 netuid
+    ) external view returns (StakeInfo[] memory);
+
+    /**
      * @dev Delegates staking to a proxy account.
      *
      * @param delegate The public key (32 bytes) of the delegate.
@@ -204,6 +223,15 @@ interface IStaking {
      * @return The minimum required stake for a nominator.
      */
     function getNominatorMinRequiredStake() external view returns (uint256);
+
+    /**
+     * @dev Returns the minimum TAO-equivalent value (in rao) a stake operation must
+     * reach to be accepted; operations below this threshold are rejected.
+     * It is a view function, meaning it does not modify the state of the contract and is free to call.
+     *
+     * @return The stake operation threshold in rao.
+     */
+    function getStakeOperationThreshold() external view returns (uint256);
 
     /**
      * @dev Adds a subtensor stake `amount` associated with the `hotkey` within a price limit.

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -45,7 +45,9 @@ use pallet_subtensor_proxy as pallet_proxy;
 use precompile_utils::EvmResult;
 use precompile_utils::prelude::{Address, revert};
 use sp_core::{H160, H256, U256};
-use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable, StaticLookup, UniqueSaturatedInto};
+use sp_runtime::traits::{
+    AsSystemOriginSigner, Dispatchable, StaticLookup, UniqueSaturatedInto, Zero,
+};
 use sp_std::vec;
 use subtensor_runtime_common::{NetUid, ProxyType, Token};
 
@@ -340,6 +342,37 @@ where
         Ok(u64::from(stake).into())
     }
 
+    #[precompile::public("getStakeInfoForColdkeyAndNetuid(bytes32,uint256)")]
+    #[precompile::view]
+    fn get_stake_info_for_coldkey_and_netuid(
+        handle: &mut impl PrecompileHandle,
+        coldkey: H256,
+        netuid: U256,
+    ) -> EvmResult<Vec<(H256, U256)>> {
+        let coldkey = R::AccountId::from(coldkey.0);
+        let netuid = NetUid::from(try_u16_from_u256(netuid)?);
+
+        // StakingHotkeys index read.
+        handle.record_db_reads::<R>(1)?;
+        let hotkeys = pallet_subtensor::StakingHotkeys::<R>::get(&coldkey);
+
+        let mut stakes: Vec<(H256, U256)> = vec![];
+        for hotkey in hotkeys {
+            // Alpha share pool reads.
+            handle.record_db_reads::<R>(2)?;
+            let alpha = pallet_subtensor::Pallet::<R>::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey, &coldkey, netuid,
+            );
+            if alpha.is_zero() {
+                continue;
+            }
+            let hotkey_bytes: [u8; 32] = hotkey.into();
+            stakes.push((hotkey_bytes.into(), U256::from(alpha.to_u64())));
+        }
+
+        Ok(stakes)
+    }
+
     #[precompile::public("getAlphaStakedValidators(bytes32,uint256)")]
     #[precompile::view]
     fn get_alpha_staked_validators(
@@ -387,6 +420,17 @@ where
         let stake = pallet_subtensor::Pallet::<R>::get_nominator_min_required_stake();
 
         Ok(stake.into())
+    }
+
+    #[precompile::public("getStakeOperationThreshold()")]
+    #[precompile::view]
+    fn get_stake_operation_threshold(handle: &mut impl PrecompileHandle) -> EvmResult<U256> {
+        // The threshold is a runtime constant, but gas accounting conservatively
+        // charges it as one storage read.
+        handle.record_db_reads::<R>(1)?;
+        let threshold = pallet_subtensor::Pallet::<R>::get_stake_operation_threshold();
+
+        Ok(threshold.to_u64().into())
     }
 
     #[precompile::public("addProxy(bytes32)")]
@@ -942,6 +986,7 @@ mod tests {
         execute_precompile, fund_account, mapped_account, new_test_ext, precompiles, selector_u32,
         substrate_to_evm,
     };
+    use precompile_utils::prelude::RuntimeHelper;
     use precompile_utils::solidity::{encode_return_value, encode_with_selector};
     use precompile_utils::testing::PrecompileTesterExt;
     use sp_core::{H160, H256};
@@ -949,6 +994,7 @@ mod tests {
     use subtensor_runtime_common::{AlphaBalance, TaoBalance};
 
     const TEST_NETUID_U16: u16 = 1;
+    const SECOND_NETUID_U16: u16 = 2;
     const INVALID_NETUID_U16: u16 = 12_345;
     const TEMPO: u16 = 100;
     const RESERVE_TAO: u64 = 200_000_000_000;
@@ -962,7 +1008,11 @@ mod tests {
     const ALLOWANCE_DECREASE_RAO: u64 = 2_000_000_000;
 
     fn setup_staking_subnet() -> NetUid {
-        let netuid = NetUid::from(TEST_NETUID_U16);
+        setup_staking_subnet_id(TEST_NETUID_U16)
+    }
+
+    fn setup_staking_subnet_id(netuid_u16: u16) -> NetUid {
+        let netuid = NetUid::from(netuid_u16);
         pallet_subtensor::Pallet::<Runtime>::init_new_network(netuid, TEMPO);
         pallet_subtensor::Pallet::<Runtime>::set_network_registration_allowed(netuid, true);
         pallet_subtensor::Pallet::<Runtime>::set_max_allowed_uids(netuid, 4096);
@@ -1104,6 +1154,250 @@ mod tests {
             ),
             expected,
         );
+    }
+
+    fn stake_info_selector_netuid() -> u32 {
+        selector_u32("getStakeInfoForColdkeyAndNetuid(bytes32,uint256)")
+    }
+
+    /// Reads charged by the precompile: one for the `StakingHotkeys` index plus
+    /// two per hotkey visited (matching `get_stake_info_for_coldkey_and_netuid`).
+    fn expected_stake_info_cost(hotkey_count: usize) -> u64 {
+        let reads = 1u64.saturating_add(2u64 * hotkey_count as u64);
+        RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(reads)
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_filtered_by_netuid_matches_state() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1101);
+            let coldkey = mapped_account(caller);
+            let hotkey = hotkey();
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+
+            let alpha = stake_for(&hotkey, &coldkey, netuid);
+            assert!(alpha > 0, "expected non-zero stake after add_stake");
+
+            let expected: Vec<(H256, U256)> =
+                vec![(H256::from_slice(hotkey.as_ref()), U256::from(alpha))];
+
+            // One hotkey, one filtered netuid.
+            let expected_cost = expected_stake_info_cost(1);
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        stake_info_selector_netuid(),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(expected_cost)
+                .execute_returns_raw(encode_return_value(expected));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_returns_all_hotkeys_on_netuid() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1102);
+            let coldkey = mapped_account(caller);
+            let hotkey_a = hotkey();
+            let hotkey_b = AccountId::from([0x33; 32]);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey_a, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            add_stake_v2(caller, &hotkey_b, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+
+            // Build the expected list in the precompile's enumeration order: over
+            // `StakingHotkeys` for the queried netuid.
+            let hotkeys = pallet_subtensor::StakingHotkeys::<Runtime>::get(&coldkey);
+            let mut expected: Vec<(H256, U256)> = vec![];
+            for hotkey_i in &hotkeys {
+                let alpha = stake_for(hotkey_i, &coldkey, netuid);
+                if alpha == 0 {
+                    continue;
+                }
+                expected.push((H256::from_slice(hotkey_i.as_ref()), U256::from(alpha)));
+            }
+            // Staked to exactly the two hotkeys we set up on this subnet.
+            assert_eq!(expected.len(), 2, "expected two non-zero stake positions");
+
+            let expected_cost = expected_stake_info_cost(hotkeys.len());
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        stake_info_selector_netuid(),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(expected_cost)
+                .execute_returns_raw(encode_return_value(expected));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_empty_for_unstaked_coldkey() {
+        new_test_ext().execute_with(|| {
+            setup_staking_subnet();
+            let caller = addr_from_index(0x1103);
+            let coldkey = mapped_account(caller);
+
+            // Coldkey never stakes: `StakingHotkeys` is empty, so the loop never
+            // runs and only the index read is charged.
+            let expected: Vec<(H256, U256)> = vec![];
+            let expected_cost = expected_stake_info_cost(0);
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        stake_info_selector_netuid(),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(expected_cost)
+                .execute_returns_raw(encode_return_value(expected));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_netuid_filter_excludes_other_subnets() {
+        new_test_ext().execute_with(|| {
+            setup_staking_subnet();
+            let netuid2 = setup_staking_subnet_id(SECOND_NETUID_U16);
+            let caller = addr_from_index(0x1104);
+            let coldkey = mapped_account(caller);
+            let hotkey = hotkey();
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+
+            // The coldkey has a hotkey but no stake on netuid 2, so the filtered
+            // query returns an empty list (the pair is still visited/charged).
+            assert_eq!(stake_for(&hotkey, &coldkey, netuid2), 0);
+
+            let expected: Vec<(H256, U256)> = vec![];
+            let expected_cost = expected_stake_info_cost(1);
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        stake_info_selector_netuid(),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(SECOND_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(expected_cost)
+                .execute_returns_raw(encode_return_value(expected));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_skips_hotkeys_with_zero_stake_on_netuid() {
+        new_test_ext().execute_with(|| {
+            let netuid1 = setup_staking_subnet();
+            setup_staking_subnet_id(SECOND_NETUID_U16);
+            let caller = addr_from_index(0x1105);
+            let coldkey = mapped_account(caller);
+            let hotkey_a = hotkey();
+            let hotkey_b = AccountId::from([0x44; 32]);
+            let hotkey_c = AccountId::from([0x55; 32]);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            // a and c staked on netuid1; b only on netuid2. All three enter the
+            // coldkey's StakingHotkeys index (it is never pruned on unstake), so a
+            // query on netuid1 must skip b (stale/zero there) mid-list.
+            add_stake_v2(caller, &hotkey_a, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            add_stake_v2(caller, &hotkey_b, SECOND_NETUID_U16, INITIAL_STAKE_RAO);
+            add_stake_v2(caller, &hotkey_c, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+
+            let hotkeys = pallet_subtensor::StakingHotkeys::<Runtime>::get(&coldkey);
+            assert_eq!(hotkeys.len(), 3, "all three hotkeys should be indexed");
+            assert_eq!(stake_for(&hotkey_b, &coldkey, netuid1), 0);
+
+            let mut expected: Vec<(H256, U256)> = vec![];
+            for hotkey_i in &hotkeys {
+                let alpha = stake_for(hotkey_i, &coldkey, netuid1);
+                if alpha == 0 {
+                    continue;
+                }
+                expected.push((H256::from_slice(hotkey_i.as_ref()), U256::from(alpha)));
+            }
+            assert_eq!(expected.len(), 2, "only the two hotkeys staked on netuid1");
+
+            // Gas is charged per index entry (all 3), not per returned row (2).
+            let expected_cost = expected_stake_info_cost(hotkeys.len());
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        stake_info_selector_netuid(),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(expected_cost)
+                .execute_returns_raw(encode_return_value(expected));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_stake_info_rejects_out_of_range_netuid() {
+        new_test_ext().execute_with(|| {
+            setup_staking_subnet();
+            let caller = addr_from_index(0x1106);
+            let coldkey = mapped_account(caller);
+
+            // netuid is a u16 on-chain; a uint256 past u16::MAX must revert rather
+            // than silently truncate into a valid subnet id.
+            let out_of_range = U256::from(u32::from(u16::MAX) + 1);
+
+            let rejected = execute_precompile(
+                &precompiles::<StakingPrecompileV2<Runtime>>(),
+                addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                caller,
+                encode_with_selector(
+                    stake_info_selector_netuid(),
+                    (H256::from_slice(coldkey.as_ref()), out_of_range),
+                ),
+                U256::zero(),
+            )
+            .expect("staking v2 stake info should route to the precompile");
+
+            assert!(rejected.is_err());
+        });
     }
 
     #[test]
@@ -1587,6 +1881,134 @@ mod tests {
                 encode_with_selector(selector_u32("getNominatorMinRequiredStake()"), ()),
                 U256::from(pallet_subtensor::Pallet::<Runtime>::get_nominator_min_required_stake()),
             );
+
+            let threshold =
+                pallet_subtensor::Pallet::<Runtime>::get_stake_operation_threshold().to_u64();
+            assert!(threshold > 0);
+            assert_static_call(
+                &precompiles,
+                caller,
+                precompile_addr,
+                encode_with_selector(selector_u32("getStakeOperationThreshold()"), ()),
+                U256::from(threshold),
+            );
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_add_stake_below_threshold_is_rejected() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1010);
+            let caller_account = mapped_account(caller);
+            let hotkey = hotkey();
+
+            fund_account(&caller_account, COLDKEY_BALANCE);
+            ensure_hotkey_exists(&hotkey);
+
+            let threshold =
+                pallet_subtensor::Pallet::<Runtime>::get_stake_operation_threshold().to_u64();
+
+            let rejected = execute_precompile(
+                &precompiles::<StakingPrecompileV2<Runtime>>(),
+                addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                caller,
+                encode_with_selector(
+                    selector_u32("addStake(bytes32,uint256,uint256)"),
+                    (
+                        H256::from_slice(hotkey.as_ref()),
+                        U256::from(threshold - 1),
+                        U256::from(TEST_NETUID_U16),
+                    ),
+                ),
+                U256::zero(),
+            )
+            .expect("staking v2 add stake should route to the precompile");
+
+            assert!(rejected.is_err());
+            assert_eq!(stake_for(&hotkey, &caller_account, netuid), 0);
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_transfer_stake_below_threshold_is_rejected() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1011);
+            let caller_account = mapped_account(caller);
+            let destination_coldkey = AccountId::from([0x33; 32]);
+            let hotkey = hotkey();
+
+            fund_account(&caller_account, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            let caller_stake_before = stake_for(&hotkey, &caller_account, netuid);
+
+            let threshold =
+                pallet_subtensor::Pallet::<Runtime>::get_stake_operation_threshold().to_u64();
+            // Alpha priced at ~2 TAO in this pool, so an alpha amount far below the
+            // threshold is guaranteed to fall short of it in TAO terms.
+            let below_threshold_alpha = threshold / 100;
+            assert!(below_threshold_alpha > 0);
+
+            let rejected = execute_precompile(
+                &precompiles::<StakingPrecompileV2<Runtime>>(),
+                addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                caller,
+                encode_with_selector(
+                    selector_u32("transferStake(bytes32,bytes32,uint256,uint256,uint256)"),
+                    (
+                        H256::from_slice(destination_coldkey.as_ref()),
+                        H256::from_slice(hotkey.as_ref()),
+                        U256::from(TEST_NETUID_U16),
+                        U256::from(TEST_NETUID_U16),
+                        U256::from(below_threshold_alpha),
+                    ),
+                ),
+                U256::zero(),
+            )
+            .expect("staking v2 transfer stake should route to the precompile");
+
+            assert!(rejected.is_err());
+            assert_eq!(stake_for(&hotkey, &destination_coldkey, netuid), 0);
+            assert_eq!(
+                stake_for(&hotkey, &caller_account, netuid),
+                caller_stake_before
+            );
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_transfer_stake_above_threshold_moves_stake() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1012);
+            let caller_account = mapped_account(caller);
+            let destination_coldkey = AccountId::from([0x33; 32]);
+            let hotkey = hotkey();
+
+            fund_account(&caller_account, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            let caller_stake_before = stake_for(&hotkey, &caller_account, netuid);
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        selector_u32("transferStake(bytes32,bytes32,uint256,uint256,uint256)"),
+                        (
+                            H256::from_slice(destination_coldkey.as_ref()),
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                            U256::from(TEST_NETUID_U16),
+                            U256::from(TRANSFERRED_ALLOWANCE_RAO),
+                        ),
+                    ),
+                )
+                .execute_returns(());
+
+            assert!(stake_for(&hotkey, &destination_coldkey, netuid) > 0);
+            assert!(stake_for(&hotkey, &caller_account, netuid) < caller_stake_before);
         });
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 427,
+    spec_version: 428,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/ts-tests/utils/evm-config.ts
+++ b/ts-tests/utils/evm-config.ts
@@ -195,6 +195,42 @@ export const IStakingV2ABI = [
         inputs: [
             {
                 internalType: "bytes32",
+                name: "coldkey",
+                type: "bytes32",
+            },
+            {
+                internalType: "uint256",
+                name: "netuid",
+                type: "uint256",
+            },
+        ],
+        name: "getStakeInfoForColdkeyAndNetuid",
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: "bytes32",
+                        name: "hotkey",
+                        type: "bytes32",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "stake",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct StakeInfo[]",
+                name: "",
+                type: "tuple[]",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "bytes32",
                 name: "hotkey",
                 type: "bytes32",
             },
@@ -280,6 +316,19 @@ export const IStakingV2ABI = [
     {
         inputs: [],
         name: "getNominatorMinRequiredStake",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "getStakeOperationThreshold",
         outputs: [
             {
                 internalType: "uint256",


### PR DESCRIPTION
## Description

Adds two read-only view functions to the V2 staking precompile:

- **`getStakeInfoForColdkeyAndNetuid(coldkey, netuid)`** — returns every hotkey a coldkey stakes to on a given subnet, each with its stake amount. Contracts built on top of staking currently have no way of tracking the hotkeys they stake under, especially in the case of hotkey swaps.
- **`getStakeOperationThreshold()`** — returns the minimum stake amount the chain will accept for a stake operation. Contracts integrating with the staking precompile currently have no on-chain way to read this limit, even though operations below it revert (`AmountTooLow`); they are forced to hardcode the value and break silently if it changes.

Both functions are read-only and charge gas per storage read, so they can't be used to force unbounded work.

## Related Issue(s)

- N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

None. Both are additive, read-only view functions — no storage, extrinsic, or existing-selector changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

- The Solidity name is `getStakeOperationThreshold` rather than the storage item's literal name (`DefaultMinStake`) so integrators understand what the value does without reading pallet internals.
