### PR TITLE
Cleanup SubnetUidToLeaseId in do_terminate_lease

### DIFF
--- a/pallets/subtensor/src/subnets/leasing.rs
+++ b/pallets/subtensor/src/subnets/leasing.rs
@@ -215,6 +215,7 @@ impl<T: Config> Pallet<T> {
             SubnetLeaseShares::<T>::clear_prefix(lease_id, T::MaxContributors::get(), None);
         AccumulatedLeaseDividends::<T>::remove(lease_id);
         SubnetLeases::<T>::remove(lease_id);
+        SubnetUidToLeaseId::<T>::remove(lease.netuid);
 
         // Remove the beneficiary proxy
         T::ProxyInterface::remove_lease_beneficiary_proxy(&lease.coldkey, &lease.beneficiary)?;
@@ -397,7 +398,7 @@ impl<T: frame_system::Config> SubnetLeasingWeightInfo<T> {
             .saturating_add(Weight::from_parts(912_993, 0).saturating_mul(k.into()))
             .saturating_add(T::DbWeight::get().reads(4_u64))
             .saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(k.into())))
-            .saturating_add(T::DbWeight::get().writes(6_u64))
+            .saturating_add(T::DbWeight::get().writes(7_u64))
             .saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(k.into())))
             .saturating_add(Weight::from_parts(0, 2529).saturating_mul(k.into()))
     }

--- a/pallets/subtensor/src/tests/leasing.rs
+++ b/pallets/subtensor/src/tests/leasing.rs
@@ -281,6 +281,7 @@ fn test_terminate_lease_works() {
         assert_eq!(SubnetLeases::<Test>::get(lease_id), None);
         assert!(!SubnetLeaseShares::<Test>::contains_prefix(lease_id));
         assert!(!AccumulatedLeaseDividends::<Test>::contains_key(lease_id));
+        assert!(!SubnetUidToLeaseId::<Test>::contains_key(lease.netuid));
 
         // Ensure the beneficiary has been removed as a proxy
         assert!(PROXIES.with_borrow(|proxies| proxies.0.is_empty()));


### PR DESCRIPTION
`do_terminate_lease` removes `SubnetLeases`, shares, and accumulated dividends, but never removes `SubnetUidToLeaseId`. Coinbase subsequently follows the stale mapping and invokes a no-op distribution path.

This PR adds the removal and extends the cleanup assertion in the existing test.