### PR TITLE
Fix build warnings

### DIFF
--- a/vendor/frontier/client/rpc/src/eth/pending.rs
+++ b/vendor/frontier/client/rpc/src/eth/pending.rs
@@ -61,7 +61,7 @@ where
 	P: TransactionPool<Block = B, Hash = B::Hash> + 'static,
 {
 	/// Creates a pending runtime API.
-	pub(crate) async fn pending_runtime_api(&self) -> Result<(B::Hash, ApiRef<C::Api>), Error> {
+	pub(crate) async fn pending_runtime_api(&self) -> Result<(B::Hash, ApiRef<'_, C::Api>), Error> {
 		let api = self.client.runtime_api();
 
 		let info = self.client.info();

--- a/vendor/frontier/precompiles/src/evm/handle.rs
+++ b/vendor/frontier/precompiles/src/evm/handle.rs
@@ -49,7 +49,7 @@ pub trait PrecompileHandleExt: PrecompileHandle {
 	fn read_u32_selector(&self) -> MayRevert<u32>;
 
 	/// Returns a reader of the input, skipping the selector.
-	fn read_after_selector(&self) -> MayRevert<Reader>;
+	fn read_after_selector(&self) -> MayRevert<Reader<'_>>;
 }
 
 impl<T: PrecompileHandle> PrecompileHandleExt for T {
@@ -96,7 +96,7 @@ impl<T: PrecompileHandle> PrecompileHandleExt for T {
 	}
 
 	/// Returns a reader of the input, skipping the selector.
-	fn read_after_selector(&self) -> MayRevert<Reader> {
+	fn read_after_selector(&self) -> MayRevert<Reader<'_>> {
 		Reader::new_skip_selector(self.input())
 	}
 }

--- a/vendor/frontier/precompiles/src/testing/execution.rs
+++ b/vendor/frontier/precompiles/src/testing/execution.rs
@@ -239,7 +239,7 @@ pub trait PrecompileTesterExt: PrecompileSet + Sized {
 		from: impl Into<H160>,
 		to: impl Into<H160>,
 		data: impl Into<Vec<u8>>,
-	) -> PrecompilesTester<Self>;
+	) -> PrecompilesTester<'_, Self>;
 }
 
 impl<T: PrecompileSet> PrecompileTesterExt for T {
@@ -248,7 +248,7 @@ impl<T: PrecompileSet> PrecompileTesterExt for T {
 		from: impl Into<H160>,
 		to: impl Into<H160>,
 		data: impl Into<Vec<u8>>,
-	) -> PrecompilesTester<Self> {
+	) -> PrecompilesTester<'_, Self> {
 		PrecompilesTester::new(self, from, to, data.into())
 	}
 }

--- a/vendor/w3f-bls/src/double_pop.rs
+++ b/vendor/w3f-bls/src/double_pop.rs
@@ -17,7 +17,6 @@ use ark_ec::Group;
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
 
 const PROOF_OF_POSSESSION_CONTEXT: &'static [u8] = b"POP_";
-const BLS_CONTEXT: &'static [u8] = b"BLS_";
 
 /// Proof Of Possession of the secret key as the secret scaler genarting both public
 /// keys in G1 and G2 by generating a BLS Signature of public key (in G2)

--- a/vendor/w3f-bls/src/verifiers.rs
+++ b/vendor/w3f-bls/src/verifiers.rs
@@ -268,7 +268,7 @@ pub fn verify_using_aggregated_auxiliary_public_keys<
 
     //Simplify from here on.
     for (m, pk) in itr {
-        publickeys.push(pk.borrow().0.clone());
+        publickeys.push(pk.0);
         messages.push(
             m.hash_to_signature_curve::<E>()
                 + E::SignatureGroupAffine::generator() * pseudo_random_scalar,


### PR DESCRIPTION
## Motivation

Rust builds currently report warnings in the vendored Frontier and w3f-bls sources. This PR removes those warnings without changing runtime behavior.

## Changes

- Add explicit anonymous lifetimes to borrowed Frontier RPC and precompile return types.
- Remove an unused w3f-bls context constant.
- Avoid an unnecessary clone of a copyable w3f-bls public-key value.

Files of interest:

- `vendor/frontier/client/rpc/src/eth/pending.rs`
- `vendor/frontier/precompiles/src/evm/handle.rs`
- `vendor/frontier/precompiles/src/testing/execution.rs`
- `vendor/w3f-bls/src/double_pop.rs`
- `vendor/w3f-bls/src/verifiers.rs`

## Behavioral impact

None expected. These changes only make inferred lifetimes explicit and remove unused or redundant operations.

## Migration and spec version

No storage migration is required, and no runtime spec-version bump is needed.

## Testing

The changes were reviewed statically as warning-only, behavior-preserving cleanup.