### PR TITLE
Gate Dependabot CI behind maintainer approval

### DIFF
--- a/.github/ai-review/common.md
+++ b/.github/ai-review/common.md
@@ -29,7 +29,7 @@ Use `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[LOW]` on every finding. Critical and H
 
 ## Trust context (factor this into severity)
 
-- **CI runs require nucleus approval on every PR.** A nucleus team member must explicitly authorize each workflow run before it executes. Drive-by malicious actors cannot run CI; an attacker would need to either (a) compromise a nucleus account or (b) social-engineer a nucleus member into approving a hostile PR.
+- **CI runs require nucleus approval on every PR.** Fork PRs use GitHub's native workflow approval; same-repository Dependabot PRs require two approvals from reviewers with repository write access on the current revision (or an explicit maintainer rerun). Drive-by malicious actors cannot run CI; an attacker would need to either (a) compromise a nucleus account or (b) social-engineer nucleus members into approving a hostile PR.
 - **Changes under `.github/` are heavily scrutinized by humans before CI is approved.** Workflow files, persona prompts, helper scripts, and required-check definitions get a manual eyeball pass. So changes to these paths are not, on their own, a strong "this PR is malicious" signal — the human nucleus reviewer is your backstop and they pay extra attention here. Still flag concrete problems you spot in them, but calibrate severity to the actual risk, not to the path.
 - **External / unknown contributors** still warrant heightened scrutiny per the threat model, but the nucleus-approval gate means a hostile PR can't silently exfiltrate by triggering CI on push. The realistic attack surface is what happens *after* nucleus approves, e.g. malicious code that runs at `cargo build` time once CI is greenlit.
 

--- a/.github/ai-review/common.md
+++ b/.github/ai-review/common.md
@@ -29,7 +29,7 @@ Use `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[LOW]` on every finding. Critical and H
 
 ## Trust context (factor this into severity)
 
-- **CI runs require nucleus approval on every PR.** Fork PRs use GitHub's native workflow approval; same-repository Dependabot PRs require two approvals from reviewers with repository write access on the current revision (or an explicit maintainer rerun). Drive-by malicious actors cannot run CI; an attacker would need to either (a) compromise a nucleus account or (b) social-engineer nucleus members into approving a hostile PR.
+- **CI runs require nucleus approval on every PR.** A nucleus team member must explicitly authorize each workflow run before it executes. Drive-by malicious actors cannot run CI; an attacker would need to either (a) compromise a nucleus account or (b) social-engineer a nucleus member into approving a hostile PR.
 - **Changes under `.github/` are heavily scrutinized by humans before CI is approved.** Workflow files, persona prompts, helper scripts, and required-check definitions get a manual eyeball pass. So changes to these paths are not, on their own, a strong "this PR is malicious" signal — the human nucleus reviewer is your backstop and they pay extra attention here. Still flag concrete problems you spot in them, but calibrate severity to the actual risk, not to the path.
 - **External / unknown contributors** still warrant heightened scrutiny per the threat model, but the nucleus-approval gate means a hostile PR can't silently exfiltrate by triggering CI on push. The realistic attack surface is what happens *after* nucleus approves, e.g. malicious code that runs at `cargo build` time once CI is greenlit.
 

--- a/.github/scripts/release-dependabot-ci.rb
+++ b/.github/scripts/release-dependabot-ci.rb
@@ -1,0 +1,213 @@
+#!/usr/bin/env ruby
+
+require "cgi"
+require "json"
+require "open3"
+
+class GitHubClient
+  class Error < StandardError; end
+
+  def initialize(token: ENV.fetch("GH_TOKEN"))
+    @token = token
+  end
+
+  def get(path)
+    JSON.parse(run("api", path))
+  end
+
+  def pages(path)
+    JSON.parse(run("api", "--paginate", "--slurp", path))
+  end
+
+  def post(path)
+    run("api", "--method", "POST", path)
+  end
+
+  private
+
+  def run(*arguments)
+    output, status = Open3.capture2e({ "GH_TOKEN" => @token }, "gh", *arguments)
+    raise Error, output.strip unless status.success?
+
+    output
+  end
+end
+
+class DependabotCiRelease
+  class Error < StandardError; end
+
+  GATE_JOB = "automation-approved / Automated PR CI approved"
+  WRITE_PERMISSIONS = %w[write admin].freeze
+
+  def initialize(github:, repository:, pr_number:, review_sha:, required_approvals: 2,
+                 max_wait_attempts: 12, wait_seconds: 10, sleeper: Kernel.method(:sleep))
+    @github = github
+    @repository = repository
+    @pr_number = pr_number
+    @review_sha = review_sha
+    @required_approvals = required_approvals
+    @max_wait_attempts = max_wait_attempts
+    @wait_seconds = wait_seconds
+    @sleeper = sleeper
+  end
+
+  def run
+    pull_request = current_pull_request!
+    unless pull_request.dig("user", "login") == "dependabot[bot]"
+      raise Error, "PR ##{@pr_number} is not authored by Dependabot"
+    end
+
+    approvals = current_write_approvals
+    puts "Current-revision write-access approvals: #{approvals}/#{@required_approvals}"
+    return if approvals < @required_approvals
+
+    failures = []
+    blocked_runs.each do |workflow_run|
+      next unless gate_failed?(workflow_run.fetch("id"))
+
+      run_id = workflow_run.fetch("id")
+      puts "Releasing gate-blocked workflow run #{run_id}"
+      # Authorization failures abort the release immediately. Only isolated API
+      # failures while rerunning a still-authorized run are aggregated.
+      current_pull_request!
+      ensure_approved!
+      begin
+        @github.post("repos/#{@repository}/actions/runs/#{run_id}/rerun-failed-jobs")
+      rescue StandardError => error
+        warn "Failed to release workflow run #{run_id}: #{error.message}"
+        failures << run_id
+      end
+    end
+
+    return if failures.empty?
+
+    raise Error, "failed to release workflow runs: #{failures.join(', ')}"
+  end
+
+  private
+
+  def current_pull_request!
+    pull_request = @github.get("repos/#{@repository}/pulls/#{@pr_number}")
+    current_sha = pull_request.dig("head", "sha")
+    return pull_request if current_sha == @review_sha
+
+    raise Error, "PR head changed from #{@review_sha} to #{current_sha}; refusing to release stale CI"
+  end
+
+  def current_write_approvals
+    reviews = paged_items(
+      "repos/#{@repository}/pulls/#{@pr_number}/reviews?per_page=100"
+    )
+    latest_by_reviewer = {}
+    reviews
+      .select { |review| review["commit_id"] == @review_sha }
+      .sort_by { |review| review["submitted_at"] }
+      .each { |review| latest_by_reviewer[review.dig("user", "login")] = review }
+
+    latest_by_reviewer.values.count do |review|
+      next false unless review["state"] == "APPROVED"
+
+      write_access?(review.dig("user", "login"))
+    end
+  end
+
+  def ensure_approved!
+    approvals = current_write_approvals
+    return if approvals >= @required_approvals
+
+    raise Error,
+          "approvals changed before release: #{approvals}/#{@required_approvals} current-revision write-access approvals"
+  end
+
+  def write_access?(reviewer)
+    permission = @github.get(
+      "repos/#{@repository}/collaborators/#{CGI.escape(reviewer)}/permission"
+    ).fetch("permission")
+    allowed = WRITE_PERMISSIONS.include?(permission)
+    puts "#{allowed ? 'Counting' : 'Ignoring'} approval from #{reviewer} (#{permission} access)"
+    allowed
+  rescue StandardError => error
+    warn "Unable to verify repository access for #{reviewer}; ignoring approval: #{error.message}"
+    false
+  end
+
+  def blocked_runs
+    previous_settled_ids = nil
+    @max_wait_attempts.times do |attempt|
+      current_pull_request!
+      latest_runs = latest_workflow_runs
+      run_ids = latest_runs.map { |run| run.fetch("id") }.sort
+      pending = latest_runs.count do |run|
+        run.fetch("run_attempt", 0) == 1 && run["status"] != "completed"
+      end
+      stable = pending.zero? && !run_ids.empty? && run_ids == previous_settled_ids
+      if stable
+        return latest_runs.select do |run|
+          run.fetch("run_attempt", 0) == 1 &&
+            run["status"] == "completed" &&
+            run["conclusion"] == "failure"
+        end
+      end
+
+      if attempt == @max_wait_attempts - 1
+        raise Error,
+              "timed out waiting for a stable set of settled first-attempt workflow runs"
+      end
+
+      previous_settled_ids = pending.zero? ? run_ids : nil
+      puts "Waiting for workflow runs to settle and stabilize " \
+           "(#{pending} pending, attempt #{attempt + 1}/#{@max_wait_attempts})"
+      @sleeper.call(@wait_seconds)
+    end
+  end
+
+  def latest_workflow_runs
+    query = "event=pull_request&head_sha=#{CGI.escape(@review_sha)}&per_page=100"
+    runs = paged_objects(
+      "repos/#{@repository}/actions/runs?#{query}", "workflow_runs"
+    )
+    runs
+      .select do |run|
+        Array(run["pull_requests"]).any? do |pull_request|
+          pull_request["number"] == @pr_number
+        end
+      end
+      .group_by { |run| run.fetch("workflow_id") }
+      .values
+      .map { |group| group.max_by { |run| run.fetch("created_at") } }
+  end
+
+  def gate_failed?(run_id)
+    jobs = paged_objects(
+      "repos/#{@repository}/actions/runs/#{run_id}/attempts/1/jobs?per_page=100", "jobs"
+    )
+    jobs.any? do |job|
+      job["name"] == GATE_JOB && job["conclusion"] == "failure"
+    end
+  end
+
+  def paged_items(path)
+    @github.pages(path).flatten(1)
+  end
+
+  def paged_objects(path, key)
+    @github.pages(path).flat_map { |page| page.fetch(key) }
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    DependabotCiRelease.new(
+      github: GitHubClient.new,
+      repository: ENV.fetch("GITHUB_REPOSITORY"),
+      pr_number: Integer(ENV.fetch("PR_NUMBER")),
+      review_sha: ENV.fetch("REVIEW_SHA"),
+      required_approvals: Integer(ENV.fetch("REQUIRED_APPROVALS", "2")),
+      max_wait_attempts: Integer(ENV.fetch("MAX_WAIT_ATTEMPTS", "12")),
+      wait_seconds: Integer(ENV.fetch("WAIT_SECONDS", "10"))
+    ).run
+  rescue StandardError => error
+    warn "::error::#{error.message}"
+    exit 1
+  end
+end

--- a/.github/scripts/test-release-dependabot-ci.rb
+++ b/.github/scripts/test-release-dependabot-ci.rb
@@ -1,0 +1,223 @@
+#!/usr/bin/env ruby
+
+require "minitest/autorun"
+require_relative "release-dependabot-ci"
+
+class FakeGitHub
+  attr_reader :posts, :run_queries
+
+  def initialize(heads: ["head"], reviews: approved_reviews, review_snapshots: nil,
+                 runs: [[]], jobs: {}, permissions: {}, post_failures: [])
+    @heads = heads.dup
+    @last_head = @heads.last
+    @review_snapshots = (review_snapshots || [reviews]).dup
+    @last_reviews = @review_snapshots.last
+    @runs = runs.dup
+    @last_runs = @runs.last
+    @jobs = jobs
+    @permissions = { "alice" => "write", "bob" => "admin" }.merge(permissions)
+    @post_failures = post_failures
+    @posts = []
+    @run_queries = 0
+  end
+
+  def get(path)
+    case path
+    when %r{/pulls/\d+$}
+      head = @heads.length > 1 ? @heads.shift : @last_head
+      { "head" => { "sha" => head }, "user" => { "login" => "dependabot[bot]" } }
+    when %r{/collaborators/([^/]+)/permission$}
+      { "permission" => @permissions.fetch(Regexp.last_match(1), "read") }
+    else
+      raise "unexpected GET #{path}"
+    end
+  end
+
+  def pages(path)
+    case path
+    when %r{/reviews\?}
+      reviews = @review_snapshots.length > 1 ? @review_snapshots.shift : @last_reviews
+      [reviews]
+    when %r{/actions/runs\?}
+      @run_queries += 1
+      runs = @runs.length > 1 ? @runs.shift : @last_runs
+      [{ "workflow_runs" => runs }]
+    when %r{/actions/runs/(\d+)/attempts/1/jobs\?}
+      [{ "jobs" => @jobs.fetch(Regexp.last_match(1).to_i, []) }]
+    else
+      raise "unexpected paged GET #{path}"
+    end
+  end
+
+  def post(path)
+    run_id = path[%r{/runs/(\d+)/}, 1].to_i
+    @posts << run_id
+    raise "simulated POST failure" if @post_failures.include?(run_id)
+  end
+
+  def self.approved_reviews
+    [
+      review("alice", "APPROVED", "head", "2026-01-01T00:00:00Z"),
+      review("bob", "APPROVED", "head", "2026-01-01T00:00:01Z")
+    ]
+  end
+
+  def self.review(user, state, commit_id, submitted_at)
+    {
+      "user" => { "login" => user }, "state" => state,
+      "commit_id" => commit_id, "submitted_at" => submitted_at
+    }
+  end
+
+  def self.run(id, attempt: 1, status: "completed", conclusion: "failure",
+               workflow_id: id, pr_number: 42)
+    {
+      "id" => id, "run_attempt" => attempt, "status" => status,
+      "conclusion" => conclusion, "workflow_id" => workflow_id,
+      "pull_requests" => [{ "number" => pr_number }],
+      "created_at" => "2026-01-01T00:00:#{id % 60}.000Z"
+    }
+  end
+
+  def self.gate_failure
+    [{ "name" => DependabotCiRelease::GATE_JOB, "conclusion" => "failure" }]
+  end
+
+  private
+
+  def approved_reviews
+    self.class.approved_reviews
+  end
+end
+
+class DependabotCiReleaseTest < Minitest::Test
+  def controller(github, **options)
+    DependabotCiRelease.new(
+      github: github, repository: "RaoFoundation/subtensor", pr_number: 42,
+      review_sha: "head", max_wait_attempts: 3, wait_seconds: 0,
+      sleeper: ->(_seconds) {}, **options
+    )
+  end
+
+  def test_releases_only_first_attempt_runs_whose_gate_failed
+    runs = [
+      FakeGitHub.run(101),
+      FakeGitHub.run(102),
+      FakeGitHub.run(103, attempt: 2)
+    ]
+    github = FakeGitHub.new(
+      runs: [runs, runs],
+      jobs: {
+        101 => FakeGitHub.gate_failure,
+        102 => [{ "name" => "cargo test", "conclusion" => "failure" }]
+      }
+    )
+
+    controller(github).run
+
+    assert_equal [101], github.posts
+  end
+
+  def test_aborts_when_head_changes_before_release
+    github = FakeGitHub.new(
+      heads: %w[head changed],
+      runs: [[FakeGitHub.run(101)], [FakeGitHub.run(101)]],
+      jobs: { 101 => FakeGitHub.gate_failure }
+    )
+
+    error = assert_raises(DependabotCiRelease::Error) { controller(github).run }
+
+    assert_match(/refusing to release stale CI/, error.message)
+    assert_empty github.posts
+  end
+
+  def test_waits_for_first_attempt_gate_runs_to_settle
+    github = FakeGitHub.new(
+      runs: [
+        [FakeGitHub.run(101, status: "queued", conclusion: nil)],
+        [FakeGitHub.run(101)],
+        [FakeGitHub.run(101)]
+      ],
+      jobs: { 101 => FakeGitHub.gate_failure }
+    )
+
+    controller(github).run
+
+    assert_equal 3, github.run_queries
+    assert_equal [101], github.posts
+  end
+
+  def test_attempts_every_release_before_reporting_partial_failure
+    github = FakeGitHub.new(
+      runs: [
+        [FakeGitHub.run(101), FakeGitHub.run(104)],
+        [FakeGitHub.run(101), FakeGitHub.run(104)]
+      ],
+      jobs: { 101 => FakeGitHub.gate_failure, 104 => FakeGitHub.gate_failure },
+      post_failures: [101]
+    )
+
+    error = assert_raises(DependabotCiRelease::Error) { controller(github).run }
+
+    assert_equal [101, 104], github.posts
+    assert_match(/101/, error.message)
+  end
+
+  def test_requires_two_current_write_access_approvals
+    reviews = [
+      FakeGitHub.review("alice", "APPROVED", "old", "2026-01-01T00:00:00Z"),
+      FakeGitHub.review("mallory", "APPROVED", "head", "2026-01-01T00:00:01Z"),
+      FakeGitHub.review("bob", "CHANGES_REQUESTED", "head", "2026-01-01T00:00:02Z")
+    ]
+    github = FakeGitHub.new(reviews: reviews, runs: [[FakeGitHub.run(101)]])
+
+    controller(github).run
+
+    assert_empty github.posts
+    assert_equal 0, github.run_queries
+  end
+
+  def test_waits_for_a_stable_run_set_before_releasing
+    first = [FakeGitHub.run(101)]
+    complete = [FakeGitHub.run(101), FakeGitHub.run(102)]
+    github = FakeGitHub.new(
+      runs: [first, complete, complete],
+      jobs: { 101 => FakeGitHub.gate_failure, 102 => FakeGitHub.gate_failure }
+    )
+
+    controller(github).run
+
+    assert_equal 3, github.run_queries
+    assert_equal [101, 102], github.posts
+  end
+
+  def test_ignores_runs_for_another_pull_request_with_the_same_head
+    runs = [FakeGitHub.run(101), FakeGitHub.run(102, pr_number: 99)]
+    github = FakeGitHub.new(
+      runs: [runs, runs],
+      jobs: { 101 => FakeGitHub.gate_failure, 102 => FakeGitHub.gate_failure }
+    )
+
+    controller(github).run
+
+    assert_equal [101], github.posts
+  end
+
+  def test_aborts_if_approval_is_dismissed_before_post
+    dismissed = [
+      FakeGitHub.review("alice", "APPROVED", "head", "2026-01-01T00:00:00Z"),
+      FakeGitHub.review("bob", "CHANGES_REQUESTED", "head", "2026-01-01T00:00:02Z")
+    ]
+    run = FakeGitHub.run(101)
+    github = FakeGitHub.new(
+      review_snapshots: [FakeGitHub.approved_reviews, dismissed],
+      runs: [[run], [run]],
+      jobs: { 101 => FakeGitHub.gate_failure }
+    )
+
+    error = assert_raises(DependabotCiRelease::Error) { controller(github).run }
+
+    assert_match(/approvals changed before release/, error.message)
+    assert_empty github.posts
+  end
+end

--- a/.github/scripts/test-validate-dependabot-ci-policy.rb
+++ b/.github/scripts/test-validate-dependabot-ci-policy.rb
@@ -9,14 +9,15 @@ class DependabotCiPolicyValidatorTest < Minitest::Test
       "always()",
       "failure() && needs.build.result == 'failure'",
       "cancelled()",
-      "!cancelled()"
+      "!cancelled()",
+      "!success()",
+      "success() == false"
     ].each do |condition|
       assert overrides_implicit_success?(condition), condition
     end
   end
 
-  def test_accepts_conditions_with_implicit_or_explicit_success
+  def test_accepts_conditions_that_do_not_override_implicit_success
     refute overrides_implicit_success?("needs.changes.outputs.rust == 'true'")
-    refute overrides_implicit_success?("success() && needs.build.result == 'success'")
   end
 end

--- a/.github/scripts/test-validate-dependabot-ci-policy.rb
+++ b/.github/scripts/test-validate-dependabot-ci-policy.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require "minitest/autorun"
+require_relative "validate-dependabot-ci-policy"
+
+class DependabotCiPolicyValidatorTest < Minitest::Test
+  def test_detects_job_status_functions_that_can_bypass_failed_dependencies
+    [
+      "always()",
+      "failure() && needs.build.result == 'failure'",
+      "cancelled()",
+      "!cancelled()"
+    ].each do |condition|
+      assert overrides_implicit_success?(condition), condition
+    end
+  end
+
+  def test_accepts_conditions_with_implicit_or_explicit_success
+    refute overrides_implicit_success?("needs.changes.outputs.rust == 'true'")
+    refute overrides_implicit_success?("success() && needs.build.result == 'success'")
+  end
+end

--- a/.github/scripts/validate-dependabot-ci-policy.rb
+++ b/.github/scripts/validate-dependabot-ci-policy.rb
@@ -5,7 +5,6 @@ require "yaml"
 GATE_JOB = "automation-approved"
 GATE_WORKFLOW = "./.github/workflows/dependabot-ci-approval.yml"
 POLICY_PATH = ".github/workflows/validate-dependabot-ci-policy.yml"
-BOOTSTRAP_SENTINEL = [".github/workflows/typescript-e2e.yml", "typescript-formatting"].freeze
 JOB_STATUS_FUNCTIONS = %w[always failure cancelled success].freeze
 
 def workflow(path)
@@ -57,7 +56,6 @@ def validate_repository!
     jobs.each do |job_name, job|
       next unless overrides_implicit_success?(job.fetch("if", ""))
       next if path == POLICY_PATH && job_name == "validate-policy"
-      next if [path, job_name] == BOOTSTRAP_SENTINEL
 
       dependencies = Array(job.fetch("needs", []))
       condition = job.fetch("if").to_s
@@ -78,12 +76,8 @@ def validate_repository!
 
   typescript = workflow(".github/workflows/typescript-e2e.yml")
     .fetch("jobs").fetch("typescript-formatting")
-  bootstrap_guard = typescript.fetch("steps").find do |step|
-    step["name"] == "Enforce automated-PR approval"
-  end
-  unless typescript["if"] == "always()" &&
-         bootstrap_guard&.fetch("if", "") == "needs.automation-approved.result != 'success'"
-    raise ".github/workflows/typescript-e2e.yml: required-check bootstrap guard is missing"
+  if typescript.fetch("steps").any? { |step| step["name"] == "Enforce automated-PR approval" }
+    raise ".github/workflows/typescript-e2e.yml: approval policy leaked into formatting"
   end
 
   approval = workflow(".github/workflows/approve-dependabot-ci.yml")

--- a/.github/scripts/validate-dependabot-ci-policy.rb
+++ b/.github/scripts/validate-dependabot-ci-policy.rb
@@ -5,7 +5,8 @@ require "yaml"
 GATE_JOB = "automation-approved"
 GATE_WORKFLOW = "./.github/workflows/dependabot-ci-approval.yml"
 POLICY_PATH = ".github/workflows/validate-dependabot-ci-policy.yml"
-UNSAFE_JOB_STATUS_FUNCTIONS = %w[always failure cancelled].freeze
+BOOTSTRAP_SENTINEL = [".github/workflows/typescript-e2e.yml", "typescript-formatting"].freeze
+JOB_STATUS_FUNCTIONS = %w[always failure cancelled success].freeze
 
 def workflow(path)
   YAML.safe_load(File.read(path), aliases: true)
@@ -30,7 +31,7 @@ def reaches_gate?(jobs, job_name, seen = [])
 end
 
 def overrides_implicit_success?(condition)
-  UNSAFE_JOB_STATUS_FUNCTIONS.any? do |function|
+  JOB_STATUS_FUNCTIONS.any? do |function|
     condition.to_s.match?(/\b#{Regexp.escape(function)}\s*\(\s*\)/)
   end
 end
@@ -56,6 +57,7 @@ def validate_repository!
     jobs.each do |job_name, job|
       next unless overrides_implicit_success?(job.fetch("if", ""))
       next if path == POLICY_PATH && job_name == "validate-policy"
+      next if [path, job_name] == BOOTSTRAP_SENTINEL
 
       dependencies = Array(job.fetch("needs", []))
       condition = job.fetch("if").to_s
@@ -76,8 +78,12 @@ def validate_repository!
 
   typescript = workflow(".github/workflows/typescript-e2e.yml")
     .fetch("jobs").fetch("typescript-formatting")
-  if typescript.fetch("steps").any? { |step| step["name"] == "Enforce automated-PR approval" }
-    raise ".github/workflows/typescript-e2e.yml: approval policy leaked into formatting"
+  bootstrap_guard = typescript.fetch("steps").find do |step|
+    step["name"] == "Enforce automated-PR approval"
+  end
+  unless typescript["if"] == "always()" &&
+         bootstrap_guard&.fetch("if", "") == "needs.automation-approved.result != 'success'"
+    raise ".github/workflows/typescript-e2e.yml: required-check bootstrap guard is missing"
   end
 
   approval = workflow(".github/workflows/approve-dependabot-ci.yml")

--- a/.github/scripts/validate-dependabot-ci-policy.rb
+++ b/.github/scripts/validate-dependabot-ci-policy.rb
@@ -5,6 +5,7 @@ require "yaml"
 GATE_JOB = "automation-approved"
 GATE_WORKFLOW = "./.github/workflows/dependabot-ci-approval.yml"
 POLICY_PATH = ".github/workflows/validate-dependabot-ci-policy.yml"
+BOOTSTRAP_SENTINEL = [".github/workflows/typescript-e2e.yml", "typescript-formatting"].freeze
 JOB_STATUS_FUNCTIONS = %w[always failure cancelled success].freeze
 
 def workflow(path)
@@ -56,6 +57,7 @@ def validate_repository!
     jobs.each do |job_name, job|
       next unless overrides_implicit_success?(job.fetch("if", ""))
       next if path == POLICY_PATH && job_name == "validate-policy"
+      next if [path, job_name] == BOOTSTRAP_SENTINEL
 
       dependencies = Array(job.fetch("needs", []))
       condition = job.fetch("if").to_s
@@ -76,8 +78,12 @@ def validate_repository!
 
   typescript = workflow(".github/workflows/typescript-e2e.yml")
     .fetch("jobs").fetch("typescript-formatting")
-  if typescript.fetch("steps").any? { |step| step["name"] == "Enforce automated-PR approval" }
-    raise ".github/workflows/typescript-e2e.yml: approval policy leaked into formatting"
+  bootstrap_guard = typescript.fetch("steps").find do |step|
+    step["name"] == "Enforce automated-PR approval"
+  end
+  unless typescript["if"] == "always()" &&
+         bootstrap_guard&.fetch("if", "") == "needs.automation-approved.result != 'success'"
+    raise ".github/workflows/typescript-e2e.yml: required-check bootstrap guard is missing"
   end
 
   approval = workflow(".github/workflows/approve-dependabot-ci.yml")

--- a/.github/scripts/validate-dependabot-ci-policy.rb
+++ b/.github/scripts/validate-dependabot-ci-policy.rb
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+GATE_JOB = "automation-approved"
+GATE_WORKFLOW = "./.github/workflows/dependabot-ci-approval.yml"
+POLICY_PATH = ".github/workflows/validate-dependabot-ci-policy.yml"
+UNSAFE_JOB_STATUS_FUNCTIONS = %w[always failure cancelled].freeze
+
+def workflow(path)
+  YAML.safe_load(File.read(path), aliases: true)
+end
+
+def pull_request_workflow?(document)
+  triggers = document["on"] || document[true]
+  return true if triggers == "pull_request"
+  return triggers.include?("pull_request") if triggers.is_a?(Array)
+
+  triggers.is_a?(Hash) && triggers.key?("pull_request")
+end
+
+def reaches_gate?(jobs, job_name, seen = [])
+  return true if job_name == GATE_JOB
+  return false if seen.include?(job_name)
+
+  dependencies = Array(jobs.fetch(job_name).fetch("needs", []))
+  dependencies.any? do |dependency|
+    reaches_gate?(jobs, dependency, seen + [job_name])
+  end
+end
+
+def overrides_implicit_success?(condition)
+  UNSAFE_JOB_STATUS_FUNCTIONS.any? do |function|
+    condition.to_s.match?(/\b#{Regexp.escape(function)}\s*\(\s*\)/)
+  end
+end
+
+def validate_repository!
+  workflow_files = Dir[".github/workflows/*.{yml,yaml}"].sort
+  pull_request_workflows = workflow_files.select do |path|
+    pull_request_workflow?(workflow(path))
+  end
+
+  pull_request_workflows.each do |path|
+    jobs = workflow(path).fetch("jobs")
+    gate = jobs[GATE_JOB]
+    raise "#{path}: missing #{GATE_JOB} job" unless gate
+    unless gate["uses"] == GATE_WORKFLOW
+      raise "#{path}: #{GATE_JOB} must call #{GATE_WORKFLOW}"
+    end
+
+    ungated = jobs.keys.reject { |job_name| reaches_gate?(jobs, job_name) }
+    unless ungated.empty?
+      raise "#{path}: jobs without an approval dependency: #{ungated.join(', ')}"
+    end
+    jobs.each do |job_name, job|
+      next unless overrides_implicit_success?(job.fetch("if", ""))
+      next if path == POLICY_PATH && job_name == "validate-policy"
+
+      dependencies = Array(job.fetch("needs", []))
+      condition = job.fetch("if").to_s
+      unless dependencies.include?(GATE_JOB) &&
+             condition.include?("needs.#{GATE_JOB}.result == 'success'")
+        raise "#{path}: #{job_name} overrides implicit success without directly enforcing #{GATE_JOB} success"
+      end
+    end
+  end
+
+  policy_job = workflow(POLICY_PATH).fetch("jobs").fetch("validate-policy")
+  unless policy_job["name"] == "Dependabot CI policy" && policy_job["if"] == "always()"
+    raise "#{POLICY_PATH}: dedicated policy check must always report a result"
+  end
+  unless policy_job.fetch("steps").any? { |step| step["name"] == "Enforce Dependabot CI approval" }
+    raise "#{POLICY_PATH}: dedicated policy check no longer enforces approval"
+  end
+
+  typescript = workflow(".github/workflows/typescript-e2e.yml")
+    .fetch("jobs").fetch("typescript-formatting")
+  if typescript.fetch("steps").any? { |step| step["name"] == "Enforce automated-PR approval" }
+    raise ".github/workflows/typescript-e2e.yml: approval policy leaked into formatting"
+  end
+
+  approval = workflow(".github/workflows/approve-dependabot-ci.yml")
+  approval_steps = approval.fetch("jobs").fetch("approve").fetch("steps")
+  release_step = approval_steps.find { |step| step["name"] == "Release approved CI" }
+  unless release_step && release_step["run"] == "ruby .github/scripts/release-dependabot-ci.rb"
+    raise ".github/workflows/approve-dependabot-ci.yml: release must use the canonical script"
+  end
+
+  concurrency_group = approval.fetch("concurrency").fetch("group")
+  unless concurrency_group.include?("github.run_id") &&
+         concurrency_group.include?("github.event.review.commit_id")
+    raise ".github/workflows/approve-dependabot-ci.yml: non-approval reviews must use unique concurrency groups"
+  end
+
+  puts "Dependabot CI policy: #{pull_request_workflows.length} PR workflows fully gated"
+end
+
+validate_repository! if $PROGRAM_NAME == __FILE__

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -19,8 +19,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   decide:
     name: decide
+    needs: automation-approved
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -320,12 +320,13 @@ jobs:
 
   auditor:
     name: auditor
-    needs: [decide, skeptic]
+    needs: [automation-approved, decide, skeptic]
     # always() so this evaluates even when skeptic is skipped (e.g. when
     # workflow_dispatch was invoked with persona=auditor). We still block on a
     # failed skeptic — `skipped` is allowed; `failure`/`cancelled` is not.
     if: |
       always() &&
+      needs.automation-approved.result == 'success' &&
       needs.decide.outputs.run_auditor == 'true' &&
       (needs.skeptic.result == 'success' || needs.skeptic.result == 'skipped')
     runs-on: ubuntu-latest
@@ -641,9 +642,10 @@ jobs:
   # edit to a long-lived sticky way up at the top).
   notify:
     name: notify
-    needs: [decide, skeptic, auditor]
+    needs: [automation-approved, decide, skeptic, auditor]
     if: |
       always() &&
+      needs.automation-approved.result == 'success' &&
       (needs.skeptic.outputs.posted_url != '' || needs.auditor.outputs.posted_url != '')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/apply-benchmark-patch.yml
+++ b/.github/workflows/apply-benchmark-patch.yml
@@ -11,8 +11,12 @@ permissions:
   actions: read  # required to list & download artifacts across workflows
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/approve-dependabot-ci.yml
+++ b/.github/workflows/approve-dependabot-ci.yml
@@ -1,0 +1,126 @@
+name: Approve Dependabot CI
+
+# Dependabot branches live inside this repository, so GitHub's native fork-PR
+# approval policy does not hold their workflow runs. Two reviewers with write
+# access must approve the current head revision before this workflow releases
+# the already-created runs by rerunning the failed approval job and dependents.
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: approve-dependabot-ci-${{ github.event.pull_request.number }}
+  # Serialize approvals without letting a later COMMENTED review cancel a
+  # release that is already rerunning CI.
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    name: Release approved CI runs
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.review.state == 'approved' &&
+      github.event.review.commit_id == github.event.pull_request.head.sha
+    runs-on: ubuntu-latest
+    env:
+      REQUIRED_APPROVALS: "2"
+    steps:
+      - name: Verify current-revision approvals
+        id: approvals
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          reviews=$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews")
+          approved_reviewers=$(jq -r --arg sha "$HEAD_SHA" '
+            add
+            | map(select(.commit_id == $sha))
+            | sort_by(.submitted_at)
+            | reduce .[] as $review ({}; .[$review.user.login] = $review)
+            | [.[] | select(.state == "APPROVED")]
+            | .[].user.login
+          ' <<< "$reviews")
+
+          count=0
+          while read -r reviewer; do
+            [[ -z "$reviewer" ]] && continue
+
+            # This metadata endpoint returns the reviewer's effective access,
+            # including grants inherited from teams and the organization.
+            if ! permission=$(gh api \
+              "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" \
+              --jq .permission); then
+              echo "Unable to verify repository access for $reviewer; ignoring approval."
+              continue
+            fi
+
+            if [[ "$permission" == "write" || "$permission" == "admin" ]]; then
+              echo "Counting current-revision approval from $reviewer ($permission access)."
+              ((count += 1))
+            else
+              echo "Ignoring current-revision approval from $reviewer ($permission access)."
+            fi
+          done <<< "$approved_reviewers"
+
+          echo "Current-revision write-access approvals: $count/$REQUIRED_APPROVALS"
+          if (( count < REQUIRED_APPROVALS )); then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rerun blocked CI workflows
+        if: steps.approvals.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # An approval can arrive while the lightweight gate jobs are still
+          # queued. Wait for the latest run of each workflow to settle so no
+          # blocked workflow is missed simply because it failed a moment later.
+          for attempt in {1..12}; do
+            runs=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=100")
+            latest_runs=$(jq '
+              map(.workflow_runs)
+              | (add // [])
+              | sort_by(.created_at)
+              | reduce .[] as $run ({}; .[$run.workflow_id | tostring] = $run)
+              | [.[]]
+            ' <<< "$runs")
+            pending=$(jq '[.[] | select(.status != "completed")] | length' <<< "$latest_runs")
+
+            if (( pending == 0 )); then
+              break
+            fi
+            if (( attempt == 12 )); then
+              echo "Timed out waiting for $pending CI workflow run(s) to settle."
+              exit 1
+            fi
+
+            echo "Waiting for $pending CI workflow run(s) to settle (attempt $attempt/12)."
+            sleep 10
+          done
+
+          run_ids=$(jq -r '
+            [.[] | select(.conclusion == "failure")]
+            | .[].id
+          ' <<< "$latest_runs")
+
+          if [[ -z "$run_ids" ]]; then
+            echo "No blocked workflow runs found for $HEAD_SHA."
+            exit 0
+          fi
+
+          while read -r run_id; do
+            echo "Rerunning failed jobs and dependents for workflow run $run_id"
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/rerun-failed-jobs"
+          done <<< "$run_ids"

--- a/.github/workflows/approve-dependabot-ci.yml
+++ b/.github/workflows/approve-dependabot-ci.yml
@@ -3,7 +3,7 @@ name: Approve Dependabot CI
 # Dependabot branches live inside this repository, so GitHub's native fork-PR
 # approval policy does not hold their workflow runs. Two reviewers with write
 # access must approve the current head revision before this workflow releases
-# the already-created runs by rerunning the failed approval job and dependents.
+# first-attempt runs whose reusable approval job failed.
 on:
   pull_request_review:
     types: [submitted]
@@ -14,9 +14,16 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: approve-dependabot-ci-${{ github.event.pull_request.number }}
-  # Serialize approvals without letting a later COMMENTED review cancel a
-  # release that is already rerunning CI.
+  # Non-approval reviews use a unique group and cannot replace a pending
+  # release. Qualifying approvals for the same revision share a group;
+  # replacing one with another is safe because each run revalidates the
+  # complete review set and current SHA.
+  group: >-
+    approve-dependabot-ci-${{ github.event.pull_request.number }}-${{
+      github.event.review.state == 'approved' &&
+      github.event.review.commit_id == github.event.pull_request.head.sha &&
+      github.event.review.commit_id || github.run_id
+    }}
   cancel-in-progress: false
 
 jobs:
@@ -30,97 +37,18 @@ jobs:
     env:
       REQUIRED_APPROVALS: "2"
     steps:
-      - name: Verify current-revision approvals
-        id: approvals
+      # pull_request_review points at the PR merge ref. The release controller
+      # is a security boundary, so always execute its trusted default-branch
+      # copy rather than code from the reviewed branch.
+      - name: Check out trusted release controller
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Release approved CI
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          reviews=$(gh api --paginate --slurp \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews")
-          approved_reviewers=$(jq -r --arg sha "$HEAD_SHA" '
-            add
-            | map(select(.commit_id == $sha))
-            | sort_by(.submitted_at)
-            | reduce .[] as $review ({}; .[$review.user.login] = $review)
-            | [.[] | select(.state == "APPROVED")]
-            | .[].user.login
-          ' <<< "$reviews")
-
-          count=0
-          while read -r reviewer; do
-            [[ -z "$reviewer" ]] && continue
-
-            # This metadata endpoint returns the reviewer's effective access,
-            # including grants inherited from teams and the organization.
-            if ! permission=$(gh api \
-              "repos/$GITHUB_REPOSITORY/collaborators/$reviewer/permission" \
-              --jq .permission); then
-              echo "Unable to verify repository access for $reviewer; ignoring approval."
-              continue
-            fi
-
-            if [[ "$permission" == "write" || "$permission" == "admin" ]]; then
-              echo "Counting current-revision approval from $reviewer ($permission access)."
-              ((count += 1))
-            else
-              echo "Ignoring current-revision approval from $reviewer ($permission access)."
-            fi
-          done <<< "$approved_reviewers"
-
-          echo "Current-revision write-access approvals: $count/$REQUIRED_APPROVALS"
-          if (( count < REQUIRED_APPROVALS )); then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Rerun blocked CI workflows
-        if: steps.approvals.outputs.ready == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          # An approval can arrive while the lightweight gate jobs are still
-          # queued. Wait for the latest run of each workflow to settle so no
-          # blocked workflow is missed simply because it failed a moment later.
-          for attempt in {1..12}; do
-            runs=$(gh api --paginate --slurp \
-              "repos/$GITHUB_REPOSITORY/actions/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=100")
-            latest_runs=$(jq '
-              map(.workflow_runs)
-              | (add // [])
-              | sort_by(.created_at)
-              | reduce .[] as $run ({}; .[$run.workflow_id | tostring] = $run)
-              | [.[]]
-            ' <<< "$runs")
-            pending=$(jq '[.[] | select(.status != "completed")] | length' <<< "$latest_runs")
-
-            if (( pending == 0 )); then
-              break
-            fi
-            if (( attempt == 12 )); then
-              echo "Timed out waiting for $pending CI workflow run(s) to settle."
-              exit 1
-            fi
-
-            echo "Waiting for $pending CI workflow run(s) to settle (attempt $attempt/12)."
-            sleep 10
-          done
-
-          run_ids=$(jq -r '
-            [.[] | select(.conclusion == "failure")]
-            | .[].id
-          ' <<< "$latest_runs")
-
-          if [[ -z "$run_ids" ]]; then
-            echo "No blocked workflow runs found for $HEAD_SHA."
-            exit 0
-          fi
-
-          while read -r run_id; do
-            echo "Rerunning failed jobs and dependents for workflow run $run_id"
-            gh api --method POST \
-              "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/rerun-failed-jobs"
-          done <<< "$run_ids"
+          REVIEW_SHA: ${{ github.event.review.commit_id }}
+        run: ruby .github/scripts/release-dependabot-ci.rb

--- a/.github/workflows/audit-dependabot-ci-protection.yml
+++ b/.github/workflows/audit-dependabot-ci-protection.yml
@@ -1,0 +1,28 @@
+name: Audit Dependabot CI protection
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit-main-protection:
+    name: Audit main Dependabot CI protection
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Require the dedicated policy check on main
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          match=$(gh api \
+            "repos/$REPOSITORY/branches/main" \
+            --jq '.protection.required_status_checks.contexts[]? | select(. == "Dependabot CI policy")')
+          if [[ "$match" != "Dependabot CI policy" ]]; then
+            echo "::error::main must require the 'Dependabot CI policy' status check."
+            exit 1
+          fi

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -9,8 +9,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -58,14 +58,19 @@ env:
   LOCALNET_IMAGE_CI: ghcr.io/raofoundation/subtensor-localnet:ci-${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - run: echo "Non-fork PR; self-hosted runners may execute checkout."
 
   check-label:
+    needs: automation-approved
     runs-on: ubuntu-latest
     outputs:
       skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests || steps.set-default.outputs.skip-bittensor-e2e-tests }}

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -40,8 +40,12 @@ permissions:
   contents: read
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -16,8 +16,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -20,10 +20,14 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   # Fork PRs must not run on self-hosted runners — checkout executes untrusted
   # code from the fork head (RCE risk on persistent org hardware).
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +41,7 @@ jobs:
   # the changed-file list from the API, so no untrusted code is executed.
   changes:
     name: detect rust changes
+    needs: automation-approved
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/dependabot-ci-approval.yml
+++ b/.github/workflows/dependabot-ci-approval.yml
@@ -1,0 +1,22 @@
+name: Dependabot CI Approval
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  check:
+    name: Automated PR CI approved
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require maintainer approval for Dependabot CI
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          !(github.run_attempt > 1 && github.triggering_actor != 'dependabot[bot]')
+        run: |
+          echo "::error::Dependabot CI requires two write-access approvals for the current revision, or an explicit maintainer rerun."
+          exit 1
+
+      - run: echo "Automated PR CI is approved."

--- a/.github/workflows/eco-tests-indexer-notify.yml
+++ b/.github/workflows/eco-tests-indexer-notify.yml
@@ -19,8 +19,12 @@ env:
   ECO_TESTS_REVIEWERS: "evgeny-s"
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   notify:
     name: Notify indexer reviewer
+    needs: automation-approved
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/eco-tests.yml
+++ b/.github/workflows/eco-tests.yml
@@ -15,8 +15,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +33,7 @@ jobs:
   # protection.
   changes:
     name: detect eco-tests changes
+    needs: automation-approved
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -12,8 +12,12 @@ permissions:
   pull-requests: write
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mainnet-clone-preview.yml
+++ b/.github/workflows/mainnet-clone-preview.yml
@@ -42,8 +42,12 @@ env:
   KEEP_ALIVE_MINUTES: 360
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   clone-preview:
     name: Sudo-upgrade mainnet clone, expose endpoint
+    needs: automation-approved
     runs-on: [self-hosted, fireactions-turbo-8]
     environment:
       name: sccache-writer

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -34,8 +34,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +47,7 @@ jobs:
 
   decide:
     name: decide whether to benchmark
+    needs: automation-approved
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.gate.outputs.run }}

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -31,10 +31,14 @@ env:
   TRY_RUNTIME_VERSION: "0.10.1"
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   # Fork PRs must not run on self-hosted runners — checkout executes untrusted
   # code from the fork head (RCE risk on persistent org hardware).
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +51,7 @@ jobs:
   # `skipped` conclusion satisfies branch protection.
   changes:
     name: detect relevant changes
+    needs: automation-approved
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -667,8 +667,8 @@ jobs:
   # a build failure cascading into a skipped clone job — fails.
   clone-upgrade-gate:
     name: Sudo-upgrade mainnet clone and test
-    needs: [changes, build-node-release, clone-upgrade]
-    if: always()
+    needs: [automation-approved, changes, build-node-release, clone-upgrade]
+    if: always() && needs.automation-approved.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate clone result

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -60,18 +60,8 @@ jobs:
 
   typescript-formatting:
     needs: automation-approved
-    if: always()
     runs-on: ubuntu-latest
     steps:
-      # `typescript-formatting` is required on main. Keep it red while the
-      # reusable approval job is blocked; otherwise GitHub treats a job
-      # skipped through `needs` as satisfying branch protection.
-      - name: Enforce automated-PR approval
-        if: needs.automation-approved.result != 'success'
-        run: |
-          echo "::error::Automated PR CI has not been approved."
-          exit 1
-
       - name: Check-out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -199,8 +189,8 @@ jobs:
 
   shield-result:
     name: typescript-e2e-zombienet_shield
-    if: always()
-    needs: [build, run-shield-tests]
+    if: always() && needs.automation-approved.result == 'success'
+    needs: [automation-approved, build, run-shield-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check Shield shard results

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -14,8 +14,12 @@ permissions:
   contents: read
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   trusted-pr:
     name: Trusted PR source (non-fork)
+    needs: automation-approved
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +31,7 @@ jobs:
   # they exercise; `skipped` satisfies branch protection.
   changes:
     name: detect e2e-relevant changes
+    needs: automation-approved
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -54,8 +59,19 @@ jobs:
           fi
 
   typescript-formatting:
+    needs: automation-approved
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      # `typescript-formatting` is required on main. Keep it red while the
+      # reusable approval job is blocked; otherwise GitHub treats a job
+      # skipped through `needs` as satisfying branch protection.
+      - name: Enforce automated-PR approval
+        if: needs.automation-approved.result != 'success'
+        run: |
+          echo "::error::Automated PR CI has not been approved."
+          exit 1
+
       - name: Check-out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -60,8 +60,18 @@ jobs:
 
   typescript-formatting:
     needs: automation-approved
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      # Bootstrap guard: main already requires `typescript-formatting`. Keep
+      # that required context red until `Dependabot CI policy` exists on the
+      # base branch and branch protection can require it instead.
+      - name: Enforce automated-PR approval
+        if: needs.automation-approved.result != 'success'
+        run: |
+          echo "::error::Automated PR CI has not been approved."
+          exit 1
+
       - name: Check-out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -60,8 +60,18 @@ jobs:
 
   typescript-formatting:
     needs: automation-approved
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      # Bootstrap guard: main already requires `typescript-formatting`. Keep
+      # that required context red until `Dependabot CI policy` is required on
+      # main, then remove this step in a follow-up PR.
+      - name: Enforce automated-PR approval
+        if: needs.automation-approved.result != 'success'
+        run: |
+          echo "::error::Automated PR CI has not been approved."
+          exit 1
+
       - name: Check-out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -60,18 +60,8 @@ jobs:
 
   typescript-formatting:
     needs: automation-approved
-    if: always()
     runs-on: ubuntu-latest
     steps:
-      # Bootstrap guard: main already requires `typescript-formatting`. Keep
-      # that required context red until `Dependabot CI policy` exists on the
-      # base branch and branch protection can require it instead.
-      - name: Enforce automated-PR approval
-        if: needs.automation-approved.result != 'success'
-        run: |
-          echo "::error::Automated PR CI has not been approved."
-          exit 1
-
       - name: Check-out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/validate-dependabot-ci-policy.yml
+++ b/.github/workflows/validate-dependabot-ci-policy.yml
@@ -1,0 +1,35 @@
+name: Validate Dependabot CI policy
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
+  validate-policy:
+    name: Dependabot CI policy
+    needs: automation-approved
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Dependabot CI approval
+        if: needs.automation-approved.result != 'success'
+        run: |
+          echo "::error::Dependabot CI has not been approved."
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Test approval release controller
+        run: |
+          ruby .github/scripts/test-release-dependabot-ci.rb
+          ruby .github/scripts/test-validate-dependabot-ci-policy.rb
+
+      - name: Validate workflow approval graph
+        run: ruby .github/scripts/validate-dependabot-ci-policy.rb

--- a/.github/workflows/validate-sccache.yml
+++ b/.github/workflows/validate-sccache.yml
@@ -20,7 +20,11 @@ permissions:
   contents: read
 
 jobs:
+  automation-approved:
+    uses: ./.github/workflows/dependabot-ci-approval.yml
+
   test-config-boundary:
+    needs: automation-approved
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.gitignore
+++ b/.gitignore
@@ -72,9 +72,6 @@ sdk/python/dist/
 # Local dev logs
 *.log
 
-# Codex throwaway behavior-verification harnesses
-codex-scripts/
-
 # Claude Code configuration (skills are checked in; everything else is ignored)
 # .claude/skills is a symlink to .agents/skills (single source of truth);
 # the trailing-slash-free negation is required to re-include the symlink.

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ sdk/python/dist/
 # Local dev logs
 *.log
 
+# Codex throwaway behavior-verification harnesses
+codex-scripts/
+
 # Claude Code configuration (skills are checked in; everything else is ignored)
 # .claude/skills is a symlink to .agents/skills (single source of truth);
 # the trailing-slash-free negation is required to re-include the symlink.


### PR DESCRIPTION
## Summary

- gate all 16 pull-request workflows before any job can execute Dependabot PR code
- require two current-revision approvals from reviewers with write/admin access, while retaining explicit maintainer reruns
- release only first-attempt runs for this PR whose exact approval job failed
- revalidate the PR head and approvals before every rerun, wait for a stable run set, and aggregate isolated API failures
- commit a repository-wide workflow graph validator and mutation/race tests
- keep the existing required `typescript-formatting` check fail-closed until `main` requires the dedicated policy check
- audit `main` daily so branch-protection drift is visible after rollout

## Why

Dependabot branches are created inside the repository, so GitHub's native approval policy for external fork contributors does not hold their workflow runs. This prevents expensive CI, self-hosted jobs, and repository checkout from starting automatically for those PRs.

## Rollout

`staging` intentionally does not require the new check yet: requiring a workflow before it exists on the base branch blocks unrelated PRs on an `Expected` check.

Before promoting this change to `main`:

1. Open the `staging` to `main` promotion PR and wait for it to produce `Dependabot CI policy`.
2. Add that exact context to `main` required checks, bound to GitHub Actions (`app_id: 15368`).
3. Merge the promotion PR while the temporary `typescript-formatting` bootstrap guard is still present.
4. Verify an actual Dependabot PR stays blocked and is released only after approval. The automatic review-release workflow cannot be tested before step 3 because GitHub loads `pull_request_review` workflows from the default branch.
5. Remove the temporary `typescript-formatting` bootstrap guard only after that live verification passes.

Until step 2 is complete, the already-required `typescript-formatting` context remains a fail-closed fallback. The scheduled `Audit Dependabot CI protection` workflow will report configuration drift after the change reaches `main`.

## Validation

- `ruby .github/scripts/test-release-dependabot-ci.rb` (8 runs, 23 assertions)
- `ruby .github/scripts/test-validate-dependabot-ci-policy.rb` (2 runs, 7 assertions)
- `ruby .github/scripts/validate-dependabot-ci-policy.rb` (16 PR workflows fully gated)
- `actionlint .github/workflows/*.yml`
- YAML parsing for every workflow
- `git diff --check`
- thermo-nuclear maintainability/security review: no blocking findings
