### PR TITLE
ci: restore public multi-arch localnet images

### DIFF
--- a/.github/scripts/cleanup-localnet-ci-images.sh
+++ b/.github/scripts/cleanup-localnet-ci-images.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+select_candidates() {
+  local versions_file="$1"
+  local cutoff="$2"
+
+  jq -c --arg cutoff "$cutoff" '
+    .[]
+    | select(.created_at < $cutoff)
+    | select(
+        (.metadata.container.tags | length) == 0
+        or all(.metadata.container.tags[]; test("^ci-[0-9a-f]{40}$"))
+      )
+  ' "$versions_file"
+}
+
+cleanup_package() {
+  : "${PACKAGE_OWNER:?PACKAGE_OWNER is required}"
+  : "${GH_TOKEN:?GH_TOKEN is required}"
+
+  local package_name="subtensor-localnet-ci"
+  local retention_days="${RETENTION_DAYS:-30}"
+  local temp_dir="${RUNNER_TEMP:-/tmp}"
+  local versions candidates cutoff deleted version id tags created_at
+
+  [[ "$retention_days" =~ ^[0-9]+$ ]] || {
+    echo "RETENTION_DAYS must be a non-negative integer: $retention_days" >&2
+    return 1
+  }
+
+  versions="$(mktemp "$temp_dir/localnet-ci-versions.XXXXXX")"
+  candidates="$(mktemp "$temp_dir/localnet-ci-candidates.XXXXXX")"
+  trap "rm -f '$versions' '$candidates'" EXIT
+  cutoff="$(date -u -d "$retention_days days ago" +%Y-%m-%dT%H:%M:%SZ)"
+
+  gh api --paginate \
+    "/orgs/$PACKAGE_OWNER/packages/container/$package_name/versions?per_page=100" \
+    | jq -s 'add // []' >"$versions"
+  select_candidates "$versions" "$cutoff" >"$candidates"
+
+  deleted=0
+  while IFS= read -r version; do
+    id="$(jq -r '.id' <<<"$version")"
+    tags="$(jq -r '.metadata.container.tags | join(",")' <<<"$version")"
+    created_at="$(jq -r '.created_at' <<<"$version")"
+    echo "Deleting version $id (tags=${tags:-untagged}, created=$created_at)"
+    gh api --method DELETE \
+      "/orgs/$PACKAGE_OWNER/packages/container/$package_name/versions/$id"
+    deleted=$((deleted + 1))
+  done <"$candidates"
+
+  echo "Deleted $deleted expired $package_name image version(s)."
+}
+
+case "${1:-cleanup}" in
+  select)
+    [[ $# -eq 3 ]] || {
+      echo "usage: $0 select VERSIONS_FILE CUTOFF" >&2
+      exit 2
+    }
+    select_candidates "$2" "$3"
+    ;;
+  cleanup)
+    [[ $# -eq 0 || $# -eq 1 ]] || {
+      echo "usage: $0 [cleanup]" >&2
+      exit 2
+    }
+    cleanup_package
+    ;;
+  *)
+    echo "usage: $0 [cleanup] | select VERSIONS_FILE CUTOFF" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/resolve-localnet-image.sh
+++ b/.github/scripts/resolve-localnet-image.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output_file="${1:-${GITHUB_OUTPUT:-}}"
+: "${output_file:?pass an output file or set GITHUB_OUTPUT}"
+: "${EVENT_NAME:?EVENT_NAME is required}"
+: "${REF_NAME:?REF_NAME is required}"
+: "${EVENT_SHA:?EVENT_SHA is required}"
+
+branch_or_tag="${BRANCH_OR_TAG:-}"
+pr_number="${PR_NUMBER:-}"
+pr_head_sha="${PR_HEAD_SHA:-}"
+pr_head_ref="${PR_HEAD_REF:-}"
+
+sanitize_tag() {
+  local value="$1"
+  value="${value//[^a-zA-Z0-9._-]/-}"
+  if [[ ! "$value" =~ ^[a-zA-Z0-9_] ]]; then
+    value="ref-${value}"
+  fi
+  printf '%.128s' "$value"
+}
+
+if [[ -n "$pr_number" ]]; then
+  [[ "$pr_number" =~ ^[0-9]+$ ]] || {
+    echo "PR_NUMBER must contain digits only: $pr_number" >&2
+    exit 1
+  }
+  tag="pr-${pr_number}"
+  ref="${pr_head_sha:-${pr_head_ref:-${branch_or_tag:-main}}}"
+  latest_tag=false
+else
+  source_tag="${branch_or_tag:-$REF_NAME}"
+  tag="$(sanitize_tag "$source_tag")"
+  ref="${branch_or_tag:-$EVENT_SHA}"
+  if [[ "$tag" == main ]]; then
+    latest_tag=true
+  else
+    latest_tag=false
+  fi
+fi
+
+{
+  echo "tag=$tag"
+  echo "ref=$ref"
+  echo "latest_tag=$latest_tag"
+} >>"$output_file"

--- a/.github/scripts/test-cleanup-localnet-ci-images.sh
+++ b/.github/scripts/test-cleanup-localnet-ci-images.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cleanup_script="$repo_root/.github/scripts/cleanup-localnet-ci-images.sh"
+fixture="$(mktemp)"
+trap 'rm -f "$fixture"' EXIT
+
+cat >"$fixture" <<'JSON'
+[
+  {"id":1,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":[]}}},
+  {"id":2,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["ci-1111111111111111111111111111111111111111"]}}},
+  {"id":3,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["ci-2222222222222222222222222222222222222222","ci-3333333333333333333333333333333333333333"]}}},
+  {"id":4,"created_at":"2026-06-16T00:00:00Z","metadata":{"container":{"tags":["ci-4444444444444444444444444444444444444444"]}}},
+  {"id":5,"created_at":"2026-07-01T00:00:00Z","metadata":{"container":{"tags":["ci-5555555555555555555555555555555555555555"]}}},
+  {"id":6,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["ci-short"]}}},
+  {"id":7,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["ci-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]}}},
+  {"id":8,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["ci-8888888888888888888888888888888888888888","main"]}}},
+  {"id":9,"created_at":"2026-06-01T00:00:00Z","metadata":{"container":{"tags":["main"]}}}
+]
+JSON
+
+actual="$($cleanup_script select "$fixture" 2026-06-16T00:00:00Z | jq -r '.id' | paste -sd, -)"
+expected="1,2,3"
+[[ "$actual" == "$expected" ]] || {
+  echo "unexpected cleanup candidates: expected=$expected actual=$actual" >&2
+  exit 1
+}
+
+echo "localnet CI image cleanup policy tests passed"

--- a/.github/scripts/test-localnet-image.sh
+++ b/.github/scripts/test-localnet-image.sh
@@ -110,11 +110,12 @@ assert_rpc "$standard_container" 9944
 assert_rpc "$standard_container" 9945
 docker stop --time 40 "$standard_container" >/dev/null
 
-# The entrypoint supervises all three authorities. If one dies, the container
-# must fail instead of silently leaving CI connected to a partial network.
+# The entrypoint supervises all three authorities. Kill the newest process
+# (authority three), proving supervision is not accidentally limited to the
+# first child.
 docker run -d --name "$failure_container" "$image" True >/dev/null
 wait_healthy "$failure_container"
-docker exec "$failure_container" pkill -TERM -o node-subtensor
+docker exec "$failure_container" pkill -TERM -n node-subtensor
 for _ in {1..30}; do
   if [[ "$(docker inspect --format '{{.State.Running}}' "$failure_container")" == false ]]; then
     break

--- a/.github/scripts/test-localnet-image.sh
+++ b/.github/scripts/test-localnet-image.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+image="${1:?usage: test-localnet-image.sh IMAGE}"
+suffix="${GITHUB_RUN_ID:-local}-$$"
+fast_container="subtensor-localnet-fast-${suffix}"
+standard_container="subtensor-localnet-standard-${suffix}"
+persistent_container="subtensor-localnet-persistent-${suffix}"
+failure_container="subtensor-localnet-failure-${suffix}"
+state_volume="subtensor-localnet-state-${suffix}"
+
+cleanup() {
+  docker rm -f "$fast_container" "$standard_container" "$persistent_container" \
+    "$failure_container" \
+    >/dev/null 2>&1 || true
+  docker volume rm -f "$state_volume" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+show_failure() {
+  local container="$1"
+  echo "--- $container logs ---" >&2
+  docker logs "$container" >&2 || true
+  echo "--- $container inspect ---" >&2
+  docker inspect "$container" >&2 || true
+}
+
+wait_healthy() {
+  local container="$1"
+  local attempts="${2:-90}"
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    local running health
+    running="$(docker inspect --format '{{.State.Running}}' "$container")"
+    health="$(docker inspect --format '{{.State.Health.Status}}' "$container")"
+    if [[ "$running" != true ]]; then
+      show_failure "$container"
+      return 1
+    fi
+    if [[ "$health" == healthy ]]; then
+      return 0
+    fi
+    if [[ "$health" == unhealthy ]]; then
+      show_failure "$container"
+      return 1
+    fi
+    sleep 2
+  done
+
+  show_failure "$container"
+  return 1
+}
+
+assert_rpc() {
+  local container="$1"
+  local port="$2"
+  docker exec "$container" /scripts/localnet_healthcheck.sh "$port"
+}
+
+block_number() {
+  local container="$1"
+  local response hex
+  response="$(
+    docker exec "$container" curl --fail --silent --max-time 2 \
+      -H 'content-type: application/json' \
+      --data '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader","params":[]}' \
+      http://127.0.0.1:9944
+  )"
+  hex="$(sed -n 's/.*"number":"0x\([0-9a-fA-F]*\)".*/\1/p' <<<"$response")"
+  [[ -n "$hex" ]] || {
+    echo "could not parse block number from: $response" >&2
+    return 1
+  }
+  printf '%d\n' "$((16#$hex))"
+}
+
+block_hash() {
+  local container="$1"
+  local number="$2"
+  local response hash
+  response="$(
+    docker exec "$container" curl --fail --silent --max-time 2 \
+      -H 'content-type: application/json' \
+      --data "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"chain_getBlockHash\",\"params\":[$number]}" \
+      http://127.0.0.1:9944
+  )"
+  hash="$(sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p' <<<"$response")"
+  [[ -n "$hash" ]] || {
+    echo "could not parse block hash from: $response" >&2
+    return 1
+  }
+  printf '%s\n' "$hash"
+}
+
+docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor \
+  "$image" --help >/dev/null
+docker run --rm --entrypoint /target/non-fast-runtime/release/node-subtensor \
+  "$image" --help >/dev/null
+
+docker run -d --name "$fast_container" "$image" True >/dev/null
+wait_healthy "$fast_container"
+assert_rpc "$fast_container" 9944
+assert_rpc "$fast_container" 9945
+docker stop --time 40 "$fast_container" >/dev/null
+
+docker run -d --name "$standard_container" "$image" False >/dev/null
+wait_healthy "$standard_container"
+assert_rpc "$standard_container" 9944
+assert_rpc "$standard_container" 9945
+docker stop --time 40 "$standard_container" >/dev/null
+
+# The entrypoint supervises all three authorities. If one dies, the container
+# must fail instead of silently leaving CI connected to a partial network.
+docker run -d --name "$failure_container" "$image" True >/dev/null
+wait_healthy "$failure_container"
+docker exec "$failure_container" pkill -TERM -o node-subtensor
+for _ in {1..30}; do
+  if [[ "$(docker inspect --format '{{.State.Running}}' "$failure_container")" == false ]]; then
+    break
+  fi
+  sleep 1
+done
+if [[ "$(docker inspect --format '{{.State.Running}}' "$failure_container")" != false ]]; then
+  show_failure "$failure_container"
+  exit 1
+fi
+if [[ "$(docker inspect --format '{{.State.ExitCode}}' "$failure_container")" == 0 ]]; then
+  echo "localnet container succeeded after an authority exited" >&2
+  exit 1
+fi
+
+docker volume create "$state_volume" >/dev/null
+docker run -d --name "$persistent_container" -v "$state_volume:/tmp" \
+  "$image" True >/dev/null
+wait_healthy "$persistent_container"
+before_restart="$(block_number "$persistent_container")"
+before_hash="$(block_hash "$persistent_container" "$before_restart")"
+docker stop --time 40 "$persistent_container" >/dev/null
+docker rm "$persistent_container" >/dev/null
+
+docker run -d --name "$persistent_container" -v "$state_volume:/tmp" \
+  "$image" True --no-purge >/dev/null
+wait_healthy "$persistent_container"
+after_restart="$(block_number "$persistent_container")"
+if ((after_restart < before_restart)); then
+  echo "--no-purge lost chain state: before=$before_restart after=$after_restart" >&2
+  exit 1
+fi
+after_hash="$(block_hash "$persistent_container" "$before_restart")"
+if [[ "$after_hash" != "$before_hash" ]]; then
+  echo "--no-purge changed block $before_restart: before=$before_hash after=$after_hash" >&2
+  exit 1
+fi
+
+docker stop --time 40 "$persistent_container" >/dev/null
+echo "localnet image compatibility smoke tests passed"

--- a/.github/scripts/test-resolve-localnet-image.sh
+++ b/.github/scripts/test-resolve-localnet-image.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+resolver="$repo_root/.github/scripts/resolve-localnet-image.sh"
+
+assert_case() {
+  local description="$1"
+  local expected_tag="$2"
+  local expected_ref="$3"
+  local expected_latest="$4"
+  shift 4
+
+  local output
+  output="$(mktemp)"
+  env -i PATH="$PATH" HOME="${HOME:-/tmp}" "$@" "$resolver" "$output"
+
+  grep -qxF "tag=$expected_tag" "$output" || {
+    echo "$description: unexpected tag" >&2
+    sed -n '1,20p' "$output" >&2
+    exit 1
+  }
+  grep -qxF "ref=$expected_ref" "$output" || {
+    echo "$description: unexpected ref" >&2
+    sed -n '1,20p' "$output" >&2
+    exit 1
+  }
+  grep -qxF "latest_tag=$expected_latest" "$output" || {
+    echo "$description: unexpected latest policy" >&2
+    sed -n '1,20p' "$output" >&2
+    exit 1
+  }
+  rm -f "$output"
+}
+
+common=(EVENT_SHA=0123456789abcdef REF_NAME=main)
+
+assert_case "main push" main 0123456789abcdef true \
+  env EVENT_NAME=push "${common[@]}"
+assert_case "devnet push" devnet 0123456789abcdef false \
+  env EVENT_NAME=push EVENT_SHA=0123456789abcdef REF_NAME=devnet
+assert_case "testnet push" testnet 0123456789abcdef false \
+  env EVENT_NAME=push EVENT_SHA=0123456789abcdef REF_NAME=testnet
+assert_case "release" v431 0123456789abcdef false \
+  env EVENT_NAME=release EVENT_SHA=0123456789abcdef REF_NAME=v431
+assert_case "manual feature ref" feat-docker feat/docker false \
+  env EVENT_NAME=workflow_dispatch "${common[@]}" BRANCH_OR_TAG=feat/docker
+assert_case "manual invalid-leading ref" ref--candidate-x -candidate/x false \
+  env EVENT_NAME=workflow_dispatch "${common[@]}" BRANCH_OR_TAG=-candidate/x
+assert_case "manual main" main main true \
+  env EVENT_NAME=workflow_dispatch "${common[@]}" BRANCH_OR_TAG=main
+assert_case "PR build" pr-2898 fedcba9876543210 false \
+  env EVENT_NAME=workflow_dispatch "${common[@]}" PR_NUMBER=2898 \
+    PR_HEAD_SHA=fedcba9876543210 PR_HEAD_REF=feature/example
+
+if env -i PATH="$PATH" HOME="${HOME:-/tmp}" EVENT_NAME=workflow_dispatch \
+  EVENT_SHA=0123456789abcdef REF_NAME=main PR_NUMBER=not-a-number \
+  "$resolver" "$(mktemp)" >/dev/null 2>&1; then
+  echo "invalid PR number unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "localnet image tag policy tests passed"

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -3,7 +3,7 @@ name: Bittensor E2E Test
 permissions:
   pull-requests: write
   contents: read
-  # Push/pull the per-PR localnet image through a private, CI-only GHCR package.
+  # Push/pull the per-PR localnet image through a separate, CI-only GHCR package.
   # Fork PRs never reach the image jobs (they need the trusted-pr gate), so
   # this is non-fork only.
   packages: write
@@ -52,10 +52,10 @@ env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.event.inputs.verbose }}
   # The Rust SDK e2e harness reads LOCALNET_IMAGE from the environment. Test
-  # jobs retag the private image to this compatibility name locally; it is
+  # jobs retag the CI image to this compatibility name locally; it is
   # never pushed.
   LOCALNET_IMAGE: ghcr.io/raofoundation/subtensor-localnet:ci
-  # Per-commit tag in the private CI package: built once, pulled by every test
+  # Per-commit tag in the CI-only package: built once, pulled by every test
   # job. Keep these transport artifacts out of the public release package.
   LOCALNET_IMAGE_CI: ghcr.io/raofoundation/subtensor-localnet-ci:ci-${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -3,8 +3,9 @@ name: Bittensor E2E Test
 permissions:
   pull-requests: write
   contents: read
-  # Push/pull the per-PR localnet image on GHCR. Fork PRs never reach the
-  # image jobs (they need the trusted-pr gate), so this is non-fork only.
+  # Push/pull the per-PR localnet image through a private, CI-only GHCR package.
+  # Fork PRs never reach the image jobs (they need the trusted-pr gate), so
+  # this is non-fork only.
   packages: write
 
 concurrency:
@@ -50,12 +51,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
   VERBOSE: ${{ github.event.inputs.verbose }}
-  # The Rust SDK e2e harness reads LOCALNET_IMAGE from the environment.
+  # The Rust SDK e2e harness reads LOCALNET_IMAGE from the environment. Test
+  # jobs retag the private image to this compatibility name locally; it is
+  # never pushed.
   LOCALNET_IMAGE: ghcr.io/raofoundation/subtensor-localnet:ci
-  # Per-commit tag on GHCR: built once, pulled by every test job. Registry
-  # pulls beat the old artifact-tarball + docker-load path (~1-2 min/job)
-  # because layers download compressed and in parallel.
-  LOCALNET_IMAGE_CI: ghcr.io/raofoundation/subtensor-localnet:ci-${{ github.event.pull_request.head.sha || github.sha }}
+  # Per-commit tag in the private CI package: built once, pulled by every test
+  # job. Keep these transport artifacts out of the public release package.
+  LOCALNET_IMAGE_CI: ghcr.io/raofoundation/subtensor-localnet-ci:ci-${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   trusted-pr:
@@ -304,7 +306,23 @@ jobs:
           docker info | grep "Docker Root Dir"
 
       - name: Build Docker Image
-        run: docker build -f sdk/bittensor-core/tests/Dockerfile.localnet-fast -t "$LOCALNET_IMAGE_CI" .
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          docker build \
+            -f sdk/bittensor-core/tests/Dockerfile.localnet-fast \
+            --label "org.opencontainers.image.revision=$SOURCE_SHA" \
+            --label "org.opencontainers.image.version=ci-$SOURCE_SHA" \
+            -t "$LOCALNET_IMAGE_CI" \
+            .
+
+      - name: Verify CI image isolation and metadata
+        run: |
+          [[ "$LOCALNET_IMAGE_CI" == ghcr.io/raofoundation/subtensor-localnet-ci:ci-* ]]
+          test "$(docker image inspect "$LOCALNET_IMAGE_CI" --format '{{index .Config.Labels "org.opencontainers.image.title"}}')" = "Subtensor Localnet CI"
+          test "$(docker image inspect "$LOCALNET_IMAGE_CI" --format '{{index .Config.Labels "org.opencontainers.image.description"}}')" = "PR-specific Subtensor localnet image for repository E2E tests"
+          test "$(docker image inspect "$LOCALNET_IMAGE_CI" --format '{{index .Config.Labels "org.opencontainers.image.source"}}')" = "https://github.com/RaoFoundation/subtensor"
+          test "$(docker image inspect "$LOCALNET_IMAGE_CI" --format '{{index .Config.Labels "org.opencontainers.image.licenses"}}')" = "Apache-2.0"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/cleanup-localnet-ci-images.yml
+++ b/.github/workflows/cleanup-localnet-ci-images.yml
@@ -20,42 +20,16 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_NAME: subtensor-localnet-ci
       RETENTION_DAYS: 30
     steps:
+      - name: Check out cleanup policy
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate cleanup policy
+        run: ./.github/scripts/test-cleanup-localnet-ci-images.sh
+
       - name: Delete expired CI image versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_OWNER: ${{ github.repository_owner }}
-        run: |
-          set -euo pipefail
-
-          versions="$RUNNER_TEMP/localnet-ci-versions.json"
-          candidates="$RUNNER_TEMP/localnet-ci-candidates.jsonl"
-          cutoff="$(date -u -d "$RETENTION_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)"
-
-          gh api --paginate \
-            "/orgs/$PACKAGE_OWNER/packages/container/$PACKAGE_NAME/versions?per_page=100" \
-            | jq -s 'add // []' > "$versions"
-
-          jq -c --arg cutoff "$cutoff" '
-            .[]
-            | select(.created_at < $cutoff)
-            | select(
-                (.metadata.container.tags | length) == 0
-                or all(.metadata.container.tags[]; test("^ci-[0-9a-f]{40}$"))
-              )
-          ' "$versions" > "$candidates"
-
-          deleted=0
-          while IFS= read -r version; do
-            id="$(jq -r '.id' <<< "$version")"
-            tags="$(jq -r '.metadata.container.tags | join(",")' <<< "$version")"
-            created_at="$(jq -r '.created_at' <<< "$version")"
-            echo "Deleting version $id (tags=${tags:-untagged}, created=$created_at)"
-            gh api --method DELETE \
-              "/orgs/$PACKAGE_OWNER/packages/container/$PACKAGE_NAME/versions/$id"
-            deleted=$((deleted + 1))
-          done < "$candidates"
-
-          echo "Deleted $deleted expired $PACKAGE_NAME image version(s)."
+        run: ./.github/scripts/cleanup-localnet-ci-images.sh

--- a/.github/workflows/cleanup-localnet-ci-images.yml
+++ b/.github/workflows/cleanup-localnet-ci-images.yml
@@ -1,7 +1,7 @@
 name: Cleanup Localnet CI Images
 
 # PR-specific images are retained long enough for GitHub's workflow rerun
-# window, then removed from the private CI package. Public release images live
+# window, then removed from the CI-only package. Public release images live
 # in subtensor-localnet and are deliberately outside this workflow's scope.
 on:
   schedule:

--- a/.github/workflows/cleanup-localnet-ci-images.yml
+++ b/.github/workflows/cleanup-localnet-ci-images.yml
@@ -1,0 +1,61 @@
+name: Cleanup Localnet CI Images
+
+# PR-specific images are retained long enough for GitHub's workflow rerun
+# window, then removed from the private CI package. Public release images live
+# in subtensor-localnet and are deliberately outside this workflow's scope.
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: cleanup-localnet-ci-images
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: subtensor-localnet-ci
+      RETENTION_DAYS: 30
+    steps:
+      - name: Delete expired CI image versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          versions="$RUNNER_TEMP/localnet-ci-versions.json"
+          candidates="$RUNNER_TEMP/localnet-ci-candidates.jsonl"
+          cutoff="$(date -u -d "$RETENTION_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)"
+
+          gh api --paginate \
+            "/orgs/$PACKAGE_OWNER/packages/container/$PACKAGE_NAME/versions?per_page=100" \
+            | jq -s 'add // []' > "$versions"
+
+          jq -c --arg cutoff "$cutoff" '
+            .[]
+            | select(.created_at < $cutoff)
+            | select(
+                (.metadata.container.tags | length) == 0
+                or all(.metadata.container.tags[]; test("^ci-[0-9a-f]{40}$"))
+              )
+          ' "$versions" > "$candidates"
+
+          deleted=0
+          while IFS= read -r version; do
+            id="$(jq -r '.id' <<< "$version")"
+            tags="$(jq -r '.metadata.container.tags | join(",")' <<< "$version")"
+            created_at="$(jq -r '.created_at' <<< "$version")"
+            echo "Deleting version $id (tags=${tags:-untagged}, created=$created_at)"
+            gh api --method DELETE \
+              "/orgs/$PACKAGE_OWNER/packages/container/$PACKAGE_NAME/versions/$id"
+            deleted=$((deleted + 1))
+          done < "$candidates"
+
+          echo "Deleted $deleted expired $PACKAGE_NAME image version(s)."

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,17 +1,15 @@
 name: Publish Localnet Docker Image
 
-# Localnet images are the chain-in-a-box used by the SDK/btcli e2e harnesses.
-# Every push to main refreshes :main and :latest; releases publish the
-# version tag (dispatched by watch-mainnet-release.yml, since its
-# GITHUB_TOKEN-created releases never emit `release: published`); dispatch
-# with pr-number builds a throwaway :pr-N image for testing downstream
-# tooling against an open PR.
+# Localnet images are the chain-in-a-box used by SDK/btcli e2e harnesses.
+# Each long-lived branch publishes a matching tag because main, devnet, and
+# testnet can contain different runtimes. Only main also advances :latest.
+# Manual PR builds publish :pr-N without moving a branch tag or :latest.
 
 on:
   release:
     types: [published]
   push:
-    branches: [main]
+    branches: [main, devnet, testnet]
   workflow_dispatch:
     inputs:
       branch-or-tag:
@@ -39,8 +37,15 @@ jobs:
       tag: ${{ steps.vars.outputs.tag }}
       ref: ${{ steps.vars.outputs.ref }}
       latest_tag: ${{ steps.vars.outputs.latest_tag }}
+      sha: ${{ steps.source.outputs.sha }}
     steps:
-      - name: Get PR branch (if pr-number is specified)
+      - name: Check out workflow scripts
+        uses: actions/checkout@v4
+
+      - name: Validate image tag policy
+        run: ./.github/scripts/test-resolve-localnet-image.sh
+
+      - name: Get PR source (if pr-number is specified)
         id: pr-info
         if: ${{ github.event.inputs.pr-number != '' }}
         uses: actions/github-script@v7
@@ -49,55 +54,65 @@ jobs:
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;
+            if (!/^\d+$/.test(prNumber)) {
+              core.setFailed(`Invalid PR number: ${prNumber}`);
+              return;
+            }
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: parseInt(prNumber)
+              pull_number: Number(prNumber)
             });
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed('Fork PRs cannot run on the localnet publishing runners.');
+              return;
+            }
             core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
 
-      - name: Determine Docker tag and ref
+      - name: Determine Docker tag and source ref
         id: vars
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
           PR_NUMBER: ${{ github.event.inputs.pr-number }}
           PR_HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
+          PR_HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
           BRANCH_OR_TAG: ${{ github.event.inputs.branch-or-tag }}
           REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ -n "$PR_NUMBER" ]]; then
-            echo "tag=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
-            echo "ref=${PR_HEAD_REF:-${BRANCH_OR_TAG:-main}}" >> $GITHUB_OUTPUT
-            echo "latest_tag=false" >> $GITHUB_OUTPUT
-          else
-            ref="${BRANCH_OR_TAG:-$REF_NAME}"
-            # Docker tags cannot contain '/', so sanitize the ref into a valid
-            # tag while still checking out the real ref (e.g. `feat/x`).
-            tag="${ref//[^a-zA-Z0-9._-]/-}"
-            echo "tag=$tag" >> $GITHUB_OUTPUT
-            echo "ref=$ref" >> $GITHUB_OUTPUT
-            echo "latest_tag=true" >> $GITHUB_OUTPUT
-          fi
+        run: ./.github/scripts/resolve-localnet-image.sh
+
+      - name: Check out immutable source revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.vars.outputs.ref }}
+
+      - name: Record source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   # Build node binaries for both runtimes on both architectures.
   artifacts:
     name: Node • ${{ matrix.runtime }} • ${{ matrix.platform.arch }}
     needs: setup
+    timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         platform:
-          # triple names used in scripts/install_prebuilt_binaries.sh
+          # Triple names are also used by scripts/install_prebuilt_binaries.sh.
           - runner: [self-hosted, fireactions-turbo-8]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
           - runner: [ubuntu-24.04-arm]
             triple: aarch64-unknown-linux-gnu
             arch: arm64
-        runtime: ["fast-runtime", "non-fast-runtime"]
+        runtime: [fast-runtime, non-fast-runtime]
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: ${{ needs.setup.outputs.sha }}
 
       - name: Install Rust + dependencies
         run: |
@@ -124,7 +139,7 @@ jobs:
             ./scripts/localnet.sh False --build-only
           fi
 
-      # Use `ci_target` because .dockerignore excludes `target`.
+      # Use ci_target because .dockerignore excludes target.
       - name: Prepare artifacts for upload
         run: |
           RUNTIME="${{ matrix.runtime }}"
@@ -142,14 +157,72 @@ jobs:
           path: build/
           if-no-files-found: error
 
-  # Collect all binaries and publish the multi-arch image.
-  docker:
+  # Package each native architecture before publishing. The amd64 runner also
+  # exercises the public compatibility contract: True/False, both RPC ports,
+  # graceful stop, health, and --no-purge persistence.
+  validate-image:
+    name: Image smoke test • ${{ matrix.platform.arch }}
     needs: [setup, artifacts]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: [self-hosted, fireactions-turbo-8]
+            triple: x86_64-unknown-linux-gnu
+            arch: amd64
+          - runner: [ubuntu-24.04-arm]
+            triple: aarch64-unknown-linux-gnu
+            arch: arm64
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - name: Download architecture artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: binaries-${{ matrix.platform.triple }}-*
+          path: build/
+          merge-multiple: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build native image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile-localnet
+          target: subtensor-localnet-prebuilt
+          platforms: linux/${{ matrix.platform.arch }}
+          load: true
+          tags: subtensor-localnet-check:${{ matrix.platform.arch }}
+
+      - name: Verify architecture and bundled binaries
+        env:
+          IMAGE: subtensor-localnet-check:${{ matrix.platform.arch }}
+        run: |
+          test "$(docker image inspect "$IMAGE" --format '{{.Architecture}}')" = "${{ matrix.platform.arch }}"
+          docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor "$IMAGE" --help
+          docker run --rm --entrypoint /target/non-fast-runtime/release/node-subtensor "$IMAGE" --help
+
+      - name: Exercise localnet compatibility contract
+        if: ${{ matrix.platform.arch == 'amd64' }}
+        run: ./.github/scripts/test-localnet-image.sh subtensor-localnet-check:amd64
+
+  # Collect all binaries and publish one multi-architecture image.
+  docker:
+    needs: [setup, artifacts, validate-image]
     runs-on: [self-hosted, fireactions-turbo-8]
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.ref }}
+          ref: ${{ needs.setup.outputs.sha }}
 
       - name: Download all binary artifacts
         uses: actions/download-artifact@v5
@@ -172,18 +245,59 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine image name
-        # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor
-        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> $GITHUB_ENV
+        # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor.
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile-localnet
-          build-args: |
-            BUILT_IN_CI="Boom shakalaka"
+          target: subtensor-localnet-prebuilt
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.image }}:${{ needs.setup.outputs.tag }}
+            ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}
             ${{ needs.setup.outputs.latest_tag == 'true' && format('{0}:latest', env.image) || '' }}
+
+  # CI consumers pull anonymously. A successful authenticated push is not
+  # sufficient: fail if package visibility regresses to private.
+  verify-public:
+    needs: [setup, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine image name
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
+
+      - name: Verify anonymous pulls
+        env:
+          TAG: ${{ needs.setup.outputs.tag }}
+          SHA: ${{ needs.setup.outputs.sha }}
+          VERIFY_LATEST: ${{ needs.setup.outputs.latest_tag }}
+        run: |
+          DOCKER_CONFIG="$(mktemp -d)"
+          export DOCKER_CONFIG
+          tags=("$TAG" "sha-$SHA")
+          if [ "$VERIFY_LATEST" = true ]; then
+            tags+=(latest)
+          fi
+
+          for tag in "${tags[@]}"; do
+            for attempt in {1..12}; do
+              if docker manifest inspect "$image:$tag" >/dev/null; then
+                break
+              fi
+              if [ "$attempt" -eq 12 ]; then
+                echo "Anonymous pull failed for $image:$tag" >&2
+                exit 1
+              fi
+              sleep 10
+            done
+          done
+
+          # Match the anonymous CI consumer path, including layer downloads
+          # and execution, rather than treating manifest visibility as enough.
+          docker pull "$image:$TAG"
+          docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor \
+            "$image:$TAG" --help >/dev/null

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -267,13 +267,6 @@ jobs:
             ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}
             ${{ needs.setup.outputs.latest_tag == 'true' && format('{0}:latest', env.image) || '' }}
           labels: |
-            org.opencontainers.image.title=Subtensor Localnet
-            org.opencontainers.image.description=Subtensor local development network for CI and local testing
-            org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor
-            org.opencontainers.image.url=https://github.com/RaoFoundation/subtensor/pkgs/container/subtensor-localnet
-            org.opencontainers.image.documentation=https://github.com/RaoFoundation/subtensor/blob/main/docs/guides/local-development.mdx
-            org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.vendor=Rao Foundation
             org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
             org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
 

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -269,6 +269,12 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
             org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
+          # GHCR reads multi-architecture package metadata from the OCI index,
+          # while Dockerfile labels live on each platform image config.
+          annotations: |
+            index:org.opencontainers.image.description=Subtensor local development network for CI and local testing
+            index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor
+            index:org.opencontainers.image.licenses=Apache-2.0
 
   # CI consumers pull anonymously. A successful authenticated push is not
   # sufficient: fail if package visibility regresses to private.
@@ -304,6 +310,26 @@ jobs:
               sleep 10
             done
           done
+
+          repository="${GITHUB_REPOSITORY,,}-localnet"
+          registry_token="$(
+            curl -fsSL --get \
+              --data-urlencode "scope=repository:$repository:pull" \
+              https://ghcr.io/token \
+              | jq -er '.token // .access_token'
+          )"
+          manifest="$(
+            curl -fsSL \
+              -H "Authorization: Bearer $registry_token" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json' \
+              "https://ghcr.io/v2/$repository/manifests/$TAG"
+          )"
+          test "$(jq -r '.annotations["org.opencontainers.image.description"]' <<<"$manifest")" = \
+            "Subtensor local development network for CI and local testing"
+          test "$(jq -r '.annotations["org.opencontainers.image.source"]' <<<"$manifest")" = \
+            "https://github.com/RaoFoundation/subtensor"
+          test "$(jq -r '.annotations["org.opencontainers.image.licenses"]' <<<"$manifest")" = \
+            "Apache-2.0"
 
           # Match the anonymous CI consumer path, including layer downloads
           # and execution, rather than treating manifest visibility as enough.

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -210,6 +210,10 @@ jobs:
           IMAGE: subtensor-localnet-check:${{ matrix.platform.arch }}
         run: |
           test "$(docker image inspect "$IMAGE" --format '{{.Architecture}}')" = "${{ matrix.platform.arch }}"
+          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.title"}}')" = "Subtensor Localnet"
+          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.description"}}')" = "Subtensor local development network for CI and local testing"
+          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.source"}}')" = "https://github.com/RaoFoundation/subtensor"
+          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.licenses"}}')" = "Apache-2.0"
           docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor "$IMAGE" --help
           docker run --rm --entrypoint /target/non-fast-runtime/release/node-subtensor "$IMAGE" --help
 
@@ -262,6 +266,16 @@ jobs:
             ${{ env.image }}:${{ needs.setup.outputs.tag }}
             ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}
             ${{ needs.setup.outputs.latest_tag == 'true' && format('{0}:latest', env.image) || '' }}
+          labels: |
+            org.opencontainers.image.title=Subtensor Localnet
+            org.opencontainers.image.description=Subtensor local development network for CI and local testing
+            org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor
+            org.opencontainers.image.url=https://github.com/RaoFoundation/subtensor/pkgs/container/subtensor-localnet
+            org.opencontainers.image.documentation=https://github.com/RaoFoundation/subtensor/blob/main/docs/guides/local-development.mdx
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Rao Foundation
+            org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
 
   # CI consumers pull anonymously. A successful authenticated push is not
   # sufficient: fail if package visibility regresses to private.

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,9 +1,11 @@
 name: Publish Localnet Docker Image
 
 # Localnet images are the chain-in-a-box used by SDK/btcli e2e harnesses.
-# Each long-lived branch publishes a matching tag because main, devnet, and
-# testnet can contain different runtimes. Only main also advances :latest.
-# Manual PR builds publish :pr-N without moving a branch tag or :latest.
+# The release train force-moves the devnet/testnet mirror branch only after
+# that exact commit is verified on the corresponding live network; the mirror
+# push is therefore the publication hook for those tags. Main publishes its
+# candidate tag directly and is the only branch that advances :latest. Manual
+# PR builds publish :pr-N without moving a branch tag or :latest.
 
 on:
   release:

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -13,6 +13,8 @@ name: Release Train
 # is force-updated to the deployed commit, so those branches always contain
 # the code running on the respective chain. The `mainnet` branch is updated
 # by watch-mainnet-release.yml once the multisig executes on chain.
+# Moving a network mirror triggers both Docker publishers, updating the
+# matching tags in the regular `subtensor` and `subtensor-localnet` packages.
 # Those branches are locked by the "network-branch-mirrors (CI only)"
 # repository ruleset; the only bypass actor is the network-branch-mirror-ci
 # deploy key (secret MIRROR_DEPLOY_KEY), so the mirror pushes go over SSH.
@@ -172,9 +174,10 @@ jobs:
           [ "$chain" = "${{ needs.build.outputs.spec_version }}" ] || { echo "devnet still on $chain"; exit 1; }
 
       # Mirror: the devnet branch always points at the code now running on
-      # devnet. The branch is ruleset-locked; only the mirror deploy key may
-      # update it, so the push goes over SSH. Force push because deploys are
-      # not fast-forwards of the previous mirror.
+      # devnet. Its push event publishes both regular and localnet :devnet
+      # images from this exact commit. The branch is ruleset-locked; only the
+      # mirror deploy key may update it, so the push goes over SSH. Force push
+      # because deploys are not fast-forwards of the previous mirror.
       - name: Point devnet branch at deployed commit
         if: steps.guard.outputs.should_deploy == 'true'
         env:

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -47,7 +47,15 @@ LABEL com.bittensor.image.authors="operations@bittensor.com" \
   com.bittensor.image.vendor="Rao Foundation" \
   com.bittensor.image.title="raofoundation/subtensor-localnet" \
   com.bittensor.image.description="Bittensor Subtensor local development network" \
-  com.bittensor.image.documentation="https://bittensor.com/docs"
+  com.bittensor.image.documentation="https://bittensor.com/docs" \
+  org.opencontainers.image.authors="operations@bittensor.com" \
+  org.opencontainers.image.vendor="Rao Foundation" \
+  org.opencontainers.image.title="Subtensor Localnet" \
+  org.opencontainers.image.description="Subtensor local development network for CI and local testing" \
+  org.opencontainers.image.source="https://github.com/RaoFoundation/subtensor" \
+  org.opencontainers.image.url="https://github.com/RaoFoundation/subtensor/pkgs/container/subtensor-localnet" \
+  org.opencontainers.image.documentation="https://github.com/RaoFoundation/subtensor/blob/main/docs/guides/local-development.mdx" \
+  org.opencontainers.image.licenses="Apache-2.0"
 
 RUN set -eu; \
   if [ "${TARGETARCH}" = "arm64" ]; then \

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -41,6 +41,7 @@ RUN test -x /build/target/fast-runtime/release/node-subtensor \
 FROM ${BASE_IMAGE} AS runtime-base
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG TARGETARCH
 
 LABEL com.bittensor.image.authors="operations@bittensor.com" \
   com.bittensor.image.vendor="Rao Foundation" \
@@ -48,9 +49,26 @@ LABEL com.bittensor.image.authors="operations@bittensor.com" \
   com.bittensor.image.description="Bittensor Subtensor local development network" \
   com.bittensor.image.documentation="https://bittensor.com/docs"
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates curl procps \
-  && rm -rf /var/lib/apt/lists/*
+RUN set -eu; \
+  if [ "${TARGETARCH}" = "arm64" ]; then \
+    for sources in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+      [ ! -f "${sources}" ] || sed -i \
+        's|http://ports.ubuntu.com/ubuntu-ports|http://ftp.kaist.ac.kr/ubuntu-ports|g' \
+        "${sources}"; \
+    done; \
+  fi; \
+  apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true update; \
+  apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true install -y ca-certificates; \
+  if [ "${TARGETARCH}" = "arm64" ]; then \
+    for sources in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+      [ ! -f "${sources}" ] || sed -i \
+        's|http://ftp.kaist.ac.kr/ubuntu-ports|https://ftp.kaist.ac.kr/ubuntu-ports|g' \
+        "${sources}"; \
+    done; \
+    apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true update; \
+  fi; \
+  apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true install -y --no-install-recommends curl procps; \
+  rm -rf /var/lib/apt/lists/*
 
 COPY ./snapshot.json /snapshot.json
 COPY --chmod=0755 ./scripts/localnet.sh /scripts/localnet.sh

--- a/Dockerfile-localnet
+++ b/Dockerfile-localnet
@@ -1,79 +1,93 @@
-ARG BASE_IMAGE=ubuntu:latest
+# syntax=docker/dockerfile:1
 
-FROM $BASE_IMAGE AS builder
+ARG BASE_IMAGE=ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+
+# Source builds remain the default for developers running:
+#   docker build -f Dockerfile-localnet .
+FROM ${BASE_IMAGE} AS source-builder
 
 SHELL ["/bin/bash", "-c"]
+ARG DEBIAN_FRONTEND=noninteractive
 
-# Set noninteractive mode for apt-get
+COPY . /build
+WORKDIR /build
+
+RUN chmod +x ./scripts/install_build_env.sh \
+  && ./scripts/install_build_env.sh
+RUN ./scripts/localnet.sh --build-only
+RUN ./scripts/localnet.sh False --build-only
+
+RUN test -x /build/target/fast-runtime/release/node-subtensor \
+  && test -x /build/target/non-fast-runtime/release/node-subtensor
+
+# CI already compiles architecture-specific binaries on native runners. This
+# stage only normalizes the downloaded artifacts into the layout used by the
+# final image, avoiding a second Rust toolchain install inside Docker.
+FROM ${BASE_IMAGE} AS prebuilt-artifacts
+
+SHELL ["/bin/bash", "-c"]
+ARG TARGETARCH
+ENV BUILT_IN_CI=1
+
+WORKDIR /build
+COPY ./build/ ./build/
+COPY ./scripts/install_prebuilt_binaries.sh ./scripts/install_prebuilt_binaries.sh
+RUN chmod +x ./scripts/install_prebuilt_binaries.sh \
+  && ./scripts/install_prebuilt_binaries.sh
+
+RUN test -x /build/target/fast-runtime/release/node-subtensor \
+  && test -x /build/target/non-fast-runtime/release/node-subtensor
+
+FROM ${BASE_IMAGE} AS runtime-base
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL com.bittensor.image.authors="operations@bittensor.com" \
   com.bittensor.image.vendor="Rao Foundation" \
   com.bittensor.image.title="raofoundation/subtensor-localnet" \
-  com.bittensor.image.description="Bittensor Subtensor Blockchain" \
+  com.bittensor.image.description="Bittensor Subtensor local development network" \
   com.bittensor.image.documentation="https://bittensor.com/docs"
 
-# Copy repo first (you want this *before* RUN to enable layer cache reuse)
-COPY . /build
-WORKDIR /build
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl procps \
+  && rm -rf /var/lib/apt/lists/*
 
-# Set up env var
-ARG BUILT_IN_CI
-ARG TARGETARCH
+COPY ./snapshot.json /snapshot.json
+COPY --chmod=0755 ./scripts/localnet.sh /scripts/localnet.sh
+COPY --chmod=0755 ./scripts/localnet_healthcheck.sh /scripts/localnet_healthcheck.sh
+RUN mkdir -p /scripts/specs
 
-ENV BUILT_IN_CI=${BUILT_IN_CI}
-ENV RUST_BACKTRACE=1
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-## Ubdate certificates
-RUN apt-get update && apt-get install -y ca-certificates
-
-# Install requirements
-RUN chmod +x ./scripts/install_build_env.sh
-RUN ./scripts/install_build_env.sh
-
-## Build fast-runtime node
-RUN ./scripts/localnet.sh --build-only
-# Build non-fast-runtime
-RUN ./scripts/localnet.sh False --build-only
-
-# We will prepare the necessary binaries if they are created in CI
-RUN chmod +x ./scripts/install_prebuilt_binaries.sh
-RUN ./scripts/install_prebuilt_binaries.sh
-
-# Verify the binaries was produced
-RUN test -e /build/target/fast-runtime/release/node-subtensor
-RUN test -e /build/target/non-fast-runtime/release/node-subtensor
-
-FROM $BASE_IMAGE AS subtensor-localnet
-
-# Copy binaries
-COPY --from=builder /build/target/fast-runtime/release/node-subtensor target/fast-runtime/release/node-subtensor
-RUN chmod +x target/fast-runtime/release/node-subtensor
-
-COPY --from=builder /build/target/non-fast-runtime/release/node-subtensor target/non-fast-runtime/release/node-subtensor
-RUN chmod +x target/non-fast-runtime/release/node-subtensor
-
-COPY --from=builder /build/snapshot.json /snapshot.json
-
-COPY --from=builder /build/scripts/localnet.sh scripts/localnet.sh
-RUN chmod +x /scripts/localnet.sh
-
-# Copy WebAssembly artifacts
-COPY --from=builder /build/target/fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm target/fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
-COPY --from=builder /build/target/non-fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm target/non-fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
-
-# Update certificates for next layer
-RUN apt-get update && apt-get install -y ca-certificates
-
-# Do not build (just run)
 ENV BUILD_BINARY=0
-# Switch to local run with IP 0.0.0.0 within docker image
 ENV RUN_IN_DOCKER=1
-# Expose ports
-EXPOSE 30334 30335 9944 9945
+
+EXPOSE 30334 30335 30336 9944 9945 9946
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=90s --retries=6 \
+  CMD ["/scripts/localnet_healthcheck.sh"]
 
 ENTRYPOINT ["/scripts/localnet.sh"]
-# Fast blocks defaults to True, you can disable it by passing False to the docker command, e.g.:
-# docker run ghcr.io/raofoundation/subtensor-localnet False
+# Fast blocks remain the default. Pass False for the standard 12-second runtime.
 CMD ["True"]
+
+# CI target: package binaries produced by docker-localnet.yml.
+FROM runtime-base AS subtensor-localnet-prebuilt
+
+COPY --from=prebuilt-artifacts /build/target/fast-runtime/release/node-subtensor /target/fast-runtime/release/node-subtensor
+COPY --from=prebuilt-artifacts /build/target/non-fast-runtime/release/node-subtensor /target/non-fast-runtime/release/node-subtensor
+COPY --from=prebuilt-artifacts /build/target/fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm /target/fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+COPY --from=prebuilt-artifacts /build/target/non-fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm /target/non-fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+
+RUN chmod +x /target/fast-runtime/release/node-subtensor \
+  /target/non-fast-runtime/release/node-subtensor
+
+# Developer target: package binaries compiled by source-builder. Keep this
+# target last so a target-less local docker build retains its historic behavior.
+FROM runtime-base AS subtensor-localnet
+
+COPY --from=source-builder /build/target/fast-runtime/release/node-subtensor /target/fast-runtime/release/node-subtensor
+COPY --from=source-builder /build/target/non-fast-runtime/release/node-subtensor /target/non-fast-runtime/release/node-subtensor
+COPY --from=source-builder /build/target/fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm /target/fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+COPY --from=source-builder /build/target/non-fast-runtime/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm /target/non-fast-runtime/release/node_subtensor_runtime.compact.compressed.wasm
+
+RUN chmod +x /target/fast-runtime/release/node-subtensor \
+  /target/non-fast-runtime/release/node-subtensor

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ docker run --rm --name local_chain \
   ghcr.io/raofoundation/subtensor-localnet:devnet
 ```
 
+Use `:testnet` or `:main` to match those branches; `:latest` is an alias for
+`:main`. Immutable `:sha-<commit>` tags are also published for reproducible CI.
+
 Then connect with `btcli --network local query is-fast-blocks` or
 `bittensor.Client("local")`. See
 [local development](https://bittensor.com/docs/guides/local-development)

--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ docker run --rm --name local_chain \
   ghcr.io/raofoundation/subtensor-localnet:devnet
 ```
 
-Use `:testnet` or `:main` to match those branches; `:latest` is an alias for
-`:main`. Immutable `:sha-<commit>` tags are also published for reproducible CI.
+Use `:testnet` for the commit deployed to testnet or `:main` for the current
+main-branch candidate; `:latest` is an alias for `:main`. The `:devnet` and
+`:testnet` tags move only after the release train verifies that commit on the
+corresponding live network. Immutable `:sha-<commit>` tags are also published
+for reproducible CI.
 
 Then connect with `btcli --network local query is-fast-blocks` or
 `bittensor.Client("local")`. See

--- a/docs/guides/local-development.mdx
+++ b/docs/guides/local-development.mdx
@@ -16,9 +16,32 @@ docker run --rm --name local_chain \
 ```
 
 Append `False` to the command to run real 12-second blocks instead of the
-default fast-blocks mode (0.25 s). `--rm` discards chain state when the
-container exits; omit it to persist state across restarts. Re-pull the image
-regularly — it tracks mainnet behavior.
+default fast-blocks mode (0.25 s).
+
+Choose the image tag for the code you need to test:
+
+| Tag | Source |
+| --- | --- |
+| `devnet` | Current `devnet` branch |
+| `testnet` | Current `testnet` branch |
+| `main` / `latest` | Current `main` branch |
+| `sha-<commit>` | Immutable commit build for reproducible CI |
+| `v<spec_version>` | Immutable mainnet release build |
+
+The three branch tags are deliberately independent because their runtimes can
+differ. Re-pull a moving branch tag before testing changes that landed since
+your last run.
+
+To keep chain state, mount `/tmp` and pass `--no-purge` when starting a new
+container from that volume:
+
+```bash
+docker volume create subtensor-localnet-data
+docker run --rm --name local_chain \
+  -p 9944:9944 -p 9945:9945 \
+  -v subtensor-localnet-data:/tmp \
+  ghcr.io/raofoundation/subtensor-localnet:devnet True --no-purge
+```
 
 A fresh localnet ships with subnet 0 (root) and subnet 1 already created.
 

--- a/docs/guides/local-development.mdx
+++ b/docs/guides/local-development.mdx
@@ -22,15 +22,17 @@ Choose the image tag for the code you need to test:
 
 | Tag | Source |
 | --- | --- |
-| `devnet` | Current `devnet` branch |
-| `testnet` | Current `testnet` branch |
-| `main` / `latest` | Current `main` branch |
+| `devnet` | Exact commit deployed to devnet (the `devnet` mirror branch) |
+| `testnet` | Exact commit deployed to testnet (the `testnet` mirror branch) |
+| `main` / `latest` | Current `main` branch candidate |
 | `sha-<commit>` | Immutable commit build for reproducible CI |
 | `v<spec_version>` | Immutable mainnet release build |
 
-The three branch tags are deliberately independent because their runtimes can
-differ. Re-pull a moving branch tag before testing changes that landed since
-your last run.
+The three branch tags are deliberately independent because a candidate moves
+through the networks in stages. The release train updates `devnet` or `testnet`
+only after verifying the new runtime on that live network; those mirror pushes
+publish the corresponding image tags. Re-pull a moving tag before testing
+changes that landed since your last run.
 
 To keep chain state, mount `/tmp` and pass `--no-purge` when starting a new
 container from that volume:

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -90,7 +90,9 @@ mainnet*, not what was merged.
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another
 workflow event. The production build publishes both the immutable release tag
-and `:latest`; the localnet build does the same in its separate package.
+and `:latest`. The localnet build publishes the immutable release tag in its
+separate package; localnet `:latest` remains an alias for the current `:main`
+branch image, while `:devnet` and `:testnet` follow their respective branches.
 
 ## Hotfixes
 

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -53,10 +53,12 @@ Human approval lives in GitHub **environment settings**, not workflow code:
 
 Deploys to devnet and testnet are direct `setCode` transactions via the CI
 deploy key. After the on-chain `spec_version` is verified, the train moves the
-corresponding network mirror branch. That branch push builds the exact deployed
-commit and updates `ghcr.io/raofoundation/subtensor:devnet` or `:testnet`; it
-does not move `:latest`. The smoke suite then validates the live network while
-the independent image build runs.
+corresponding network mirror branch. That branch push triggers both Docker
+publishers from the exact deployed commit, updating the matching `:devnet` or
+`:testnet` tag in `ghcr.io/raofoundation/subtensor` and
+`ghcr.io/raofoundation/subtensor-localnet`. It does not move either package's
+`:latest` tag. The smoke suite then validates the live network while the
+independent image builds run.
 
 ### The mainnet multisig ceremony
 

--- a/scripts/install_build_env.sh
+++ b/scripts/install_build_env.sh
@@ -50,10 +50,19 @@ if [ "$OS" = "Linux" ]; then
     if [ -z "$SUDO" ] && [ "$(id -u)" -ne 0 ]; then
         echo "[!] Warning: No sudo and not root. Skipping apt install."
     else
-        $SUDO sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirrors.edge.kernel.org/ubuntu|g' /etc/apt/sources.list || true
-        $SUDO apt-get update
-        $SUDO apt-get install -y ca-certificates
-        $SUDO apt-get install -y --no-install-recommends \
+        # The canonical ports endpoint is intermittently unreachable from
+        # GitHub's ARM runners. KAIST is a registered Ubuntu Ports mirror
+        # serving the same signed archive. Start over HTTP so a minimal
+        # Ubuntu image can install CA roots, then upgrade it to HTTPS below.
+        $SUDO sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://ftp.kaist.ac.kr/ubuntu-ports|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources || true
+        $SUDO apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true update
+        $SUDO apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true install -y ca-certificates
+        $SUDO sed -i 's|http://archive.ubuntu.com/ubuntu|https://mirrors.edge.kernel.org/ubuntu|g' /etc/apt/sources.list || true
+        $SUDO sed -i 's|http://ftp.kaist.ac.kr/ubuntu-ports|https://ftp.kaist.ac.kr/ubuntu-ports|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources || true
+        $SUDO apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true update
+        $SUDO apt-get -o Acquire::Retries=5 -o Acquire::ForceIPv4=true install -y --no-install-recommends \
             curl build-essential protobuf-compiler clang git pkg-config libssl-dev llvm libudev-dev \
             python3 python3-dev \
             gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu

--- a/scripts/install_prebuilt_binaries.sh
+++ b/scripts/install_prebuilt_binaries.sh
@@ -47,8 +47,12 @@ for RUNTIME in fast-runtime non-fast-runtime; do
 #  echo "::endgroup::"
 
   mkdir -p /build/target/${RUNTIME}/release/wbuild/node-subtensor-runtime
-  cp -v /build/build/ci_target/${RUNTIME}/${BUILD_TRIPLE}/release/node-subtensor \
-        /build/target/${RUNTIME}/release/node-subtensor
-  cp -v /build/build/ci_target/${RUNTIME}/${BUILD_TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm \
-        /build/target/${RUNTIME}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm
+  # GitHub artifact downloads do not preserve executable mode bits. Install
+  # with explicit modes so packaging is independent of artifact transport.
+  install -v -m 0755 \
+    /build/build/ci_target/${RUNTIME}/${BUILD_TRIPLE}/release/node-subtensor \
+    /build/target/${RUNTIME}/release/node-subtensor
+  install -v -m 0644 \
+    /build/build/ci_target/${RUNTIME}/${BUILD_TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm \
+    /build/target/${RUNTIME}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm
 done

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -62,6 +62,37 @@ SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"
 PID_FILE="${LOCALNET_PID_FILE:-/tmp/subtensor-localnet.pids}"
 
+terminate_pids() {
+  local pids=("$@")
+  local any_running pid
+
+  [ "${#pids[@]}" -gt 0 ] || return 0
+
+  for pid in "${pids[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+
+  # Give node databases time to close cleanly before forcing termination.
+  for _ in {1..30}; do
+    any_running=0
+    for pid in "${pids[@]}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        any_running=1
+        break
+      fi
+    done
+    [ "$any_running" -eq 1 ] || break
+    sleep 1
+  done
+
+  for pid in "${pids[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+    # Only children of this shell can be reaped; stale recorded PIDs simply
+    # make wait return non-zero, which is intentionally ignored.
+    wait "$pid" 2>/dev/null || true
+  done
+}
+
 stop_recorded_nodes() {
   [ -f "$PID_FILE" ] || return 0
 
@@ -75,7 +106,6 @@ stop_recorded_nodes() {
     # signal a reused PID when it is still one of our node processes.
     if kill -0 "$pid" 2>/dev/null \
       && ps -p "$pid" -o comm= 2>/dev/null | grep -q 'node-subtensor'; then
-      kill -TERM "$pid" 2>/dev/null || true
       recorded_pids+=("$pid")
     fi
   done <"$PID_FILE"
@@ -86,22 +116,8 @@ stop_recorded_nodes() {
   fi
 
   # Never purge a database while a node from the previous run still has it
-  # open. Give recorded nodes time to close, then force only those exact PIDs.
-  for _ in {1..30}; do
-    any_running=0
-    for pid in "${recorded_pids[@]}"; do
-      if kill -0 "$pid" 2>/dev/null; then
-        any_running=1
-        break
-      fi
-    done
-    [ "$any_running" -eq 1 ] || break
-    sleep 1
-  done
-  for pid in "${recorded_pids[@]}"; do
-    kill -KILL "$pid" 2>/dev/null || true
-  done
-
+  # open. Terminate only the validated PIDs before touching chain state.
+  terminate_pids "${recorded_pids[@]}"
   rm -f "$PID_FILE"
 }
 
@@ -167,27 +183,7 @@ if [ $BUILD_ONLY -eq 0 ]; then
     SHUTDOWN_STARTED=1
     trap - EXIT INT TERM
 
-    for pid in "${NODE_PIDS[@]}"; do
-      kill -TERM "$pid" 2>/dev/null || true
-    done
-
-    # Give the databases time to close cleanly before forcing termination.
-    for _ in {1..30}; do
-      any_running=0
-      for pid in "${NODE_PIDS[@]}"; do
-        if kill -0 "$pid" 2>/dev/null; then
-          any_running=1
-          break
-        fi
-      done
-      [ "$any_running" -eq 1 ] || break
-      sleep 1
-    done
-
-    for pid in "${NODE_PIDS[@]}"; do
-      kill -KILL "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
-    done
+    terminate_pids "${NODE_PIDS[@]}"
     rm -f "$PID_FILE"
   }
 

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -80,6 +80,11 @@ stop_recorded_nodes() {
     fi
   done <"$PID_FILE"
 
+  if [ "${#recorded_pids[@]}" -eq 0 ]; then
+    rm -f "$PID_FILE"
+    return 0
+  fi
+
   # Never purge a database while a node from the previous run still has it
   # open. Give recorded nodes time to close, then force only those exact PIDs.
   for _ in {1..30}; do
@@ -193,6 +198,26 @@ if [ $BUILD_ONLY -eq 0 ]; then
     exit 143
   }
 
+  wait_for_node_exit() {
+    local active_pids pid
+
+    # Bash 3.2 (the system Bash on macOS) has no `wait -n`. The job table is
+    # portable across every supported Bash version and lets us identify and
+    # reap whichever authority exits first.
+    while true; do
+      # `jobs -p` retains completed jobs in some non-interactive shells. Union
+      # running and stopped jobs instead, so only truly exited children vanish.
+      active_pids="$(jobs -pr; jobs -ps)"
+      for pid in "${NODE_PIDS[@]}"; do
+        if ! grep -qx "$pid" <<<"$active_pids"; then
+          wait "$pid"
+          return $?
+        fi
+      done
+      sleep 1
+    done
+  }
+
   one_start=(
     "$NODE_BINARY"
     --base-path /tmp/one
@@ -267,14 +292,8 @@ if [ $BUILD_ONLY -eq 0 ]; then
   NODE_PIDS+=("$!")
   printf '%s\n' "${NODE_PIDS[@]}" >"$PID_FILE"
 
-  # Modern container Bash supports wait -n, which makes the container fail
-  # promptly if any node exits. Retain a portable fallback for macOS Bash 3.2.
   set +e
-  if help wait 2>&1 | grep -q -- '-n'; then
-    wait -n "${NODE_PIDS[@]}"
-  else
-    wait "${NODE_PIDS[0]}"
-  fi
+  wait_for_node_exit
   node_status=$?
   set -e
 

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -60,9 +60,49 @@ fi
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"
+PID_FILE="${LOCALNET_PID_FILE:-/tmp/subtensor-localnet.pids}"
 
-# Kill any existing nodes which may have not exited correctly after a previous run.
-pkill -9 'node-subtensor' || true
+stop_recorded_nodes() {
+  [ -f "$PID_FILE" ] || return 0
+
+  local recorded_pids=()
+  while IFS= read -r pid; do
+    case "$pid" in
+      ''|*[!0-9]*) continue ;;
+    esac
+
+    # PID files can survive a container restart through a /tmp volume. Only
+    # signal a reused PID when it is still one of our node processes.
+    if kill -0 "$pid" 2>/dev/null \
+      && ps -p "$pid" -o comm= 2>/dev/null | grep -q 'node-subtensor'; then
+      kill -TERM "$pid" 2>/dev/null || true
+      recorded_pids+=("$pid")
+    fi
+  done <"$PID_FILE"
+
+  # Never purge a database while a node from the previous run still has it
+  # open. Give recorded nodes time to close, then force only those exact PIDs.
+  for _ in {1..30}; do
+    any_running=0
+    for pid in "${recorded_pids[@]}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        any_running=1
+        break
+      fi
+    done
+    [ "$any_running" -eq 1 ] || break
+    sleep 1
+  done
+  for pid in "${recorded_pids[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+
+  rm -f "$PID_FILE"
+}
+
+if [ "$BUILD_ONLY" -eq 0 ]; then
+  stop_recorded_nodes
+fi
 
 if [ ! -d "$SPEC_PATH" ]; then
   echo "*** Creating directory ${SPEC_PATH}..."
@@ -74,6 +114,7 @@ if [[ "$BUILD_BINARY" == "1" ]]; then
 
   BUILD_CMD=(
     cargo build
+    --locked
     --workspace
     --profile=release
     --features "$FEATURES"
@@ -112,6 +153,45 @@ fi
 
 if [ $BUILD_ONLY -eq 0 ]; then
   echo "*** Starting localnet nodes..."
+
+  NODE_PIDS=()
+  SHUTDOWN_STARTED=0
+
+  shutdown_nodes() {
+    [ "$SHUTDOWN_STARTED" -eq 0 ] || return 0
+    SHUTDOWN_STARTED=1
+    trap - EXIT INT TERM
+
+    for pid in "${NODE_PIDS[@]}"; do
+      kill -TERM "$pid" 2>/dev/null || true
+    done
+
+    # Give the databases time to close cleanly before forcing termination.
+    for _ in {1..30}; do
+      any_running=0
+      for pid in "${NODE_PIDS[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+          any_running=1
+          break
+        fi
+      done
+      [ "$any_running" -eq 1 ] || break
+      sleep 1
+    done
+
+    for pid in "${NODE_PIDS[@]}"; do
+      kill -KILL "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    done
+    rm -f "$PID_FILE"
+  }
+
+  # Called indirectly by the signal trap below.
+  # shellcheck disable=SC2329
+  handle_signal() {
+    shutdown_nodes
+    exit 143
+  }
 
   one_start=(
     "$NODE_BINARY"
@@ -176,12 +256,31 @@ if [ $BUILD_ONLY -eq 0 ]; then
     three_start+=(--unsafe-rpc-external)
   fi
 
-  trap 'pkill -P $$' EXIT SIGINT SIGTERM
+  trap shutdown_nodes EXIT
+  trap handle_signal INT TERM
 
-  (
-    ("${one_start[@]}" 2>&1) &
-    ("${two_start[@]}" 2>&1) &
-    ("${three_start[@]}" 2>&1)
-    wait
-  )
+  "${one_start[@]}" 2>&1 &
+  NODE_PIDS+=("$!")
+  "${two_start[@]}" 2>&1 &
+  NODE_PIDS+=("$!")
+  "${three_start[@]}" 2>&1 &
+  NODE_PIDS+=("$!")
+  printf '%s\n' "${NODE_PIDS[@]}" >"$PID_FILE"
+
+  # Modern container Bash supports wait -n, which makes the container fail
+  # promptly if any node exits. Retain a portable fallback for macOS Bash 3.2.
+  set +e
+  if help wait 2>&1 | grep -q -- '-n'; then
+    wait -n "${NODE_PIDS[@]}"
+  else
+    wait "${NODE_PIDS[0]}"
+  fi
+  node_status=$?
+  set -e
+
+  # A node exiting by itself, even with status zero, leaves a broken partial
+  # network. Stop its peers and make that visible to Docker/CI.
+  [ "$node_status" -ne 0 ] || node_status=1
+  shutdown_nodes
+  exit "$node_status"
 fi

--- a/scripts/localnet_healthcheck.sh
+++ b/scripts/localnet_healthcheck.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -eu
+
+rpc_port="${1:-9944}"
+response=$(
+  curl --fail --silent --show-error --max-time 2 \
+    -H 'content-type: application/json' \
+    --data '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader","params":[]}' \
+    "http://127.0.0.1:${rpc_port}"
+)
+
+# A listening RPC endpoint is not enough for CI: require at least one authored
+# block so callers do not race the chain during startup.
+printf '%s\n' "$response" \
+  | grep -Eq '"number":"0x[0-9a-fA-F]*[1-9a-fA-F][0-9a-fA-F]*"'

--- a/sdk/bittensor-core/tests/Dockerfile.localnet-fast
+++ b/sdk/bittensor-core/tests/Dockerfile.localnet-fast
@@ -1,8 +1,19 @@
-ARG BASE_IMAGE=ubuntu:latest
+# Keep the E2E transport image aligned with Dockerfile-localnet so tests and
+# published images exercise the same userspace.
+ARG BASE_IMAGE=ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 FROM $BASE_IMAGE
 
 ARG BUILD_TRIPLE=x86_64-unknown-linux-gnu
+
+LABEL org.opencontainers.image.authors="operations@bittensor.com" \
+    org.opencontainers.image.vendor="Rao Foundation" \
+    org.opencontainers.image.title="Subtensor Localnet CI" \
+    org.opencontainers.image.description="PR-specific Subtensor localnet image for repository E2E tests" \
+    org.opencontainers.image.source="https://github.com/RaoFoundation/subtensor" \
+    org.opencontainers.image.url="https://github.com/RaoFoundation/subtensor" \
+    org.opencontainers.image.documentation="https://github.com/RaoFoundation/subtensor/blob/main/docs/guides/local-development.mdx" \
+    org.opencontainers.image.licenses="Apache-2.0"
 
 ENV RUST_BACKTRACE=1
 


### PR DESCRIPTION
## Summary

- publish `subtensor-localnet` from the deployment-mirror pushes for devnet and testnet, matching the existing regular `subtensor` image flow
- publish main/localnet candidate tags directly from main, retain `latest` as the main-compatible tag, and add immutable SHA tags
- build and smoke-test native amd64 and arm64 images before publishing
- harden the existing localnet runtime, shutdown behavior, health check, and documentation without introducing a replacement public image
- keep PR-specific E2E transport images out of the public package and provide correct OCI package metadata

## Release linkage

After the release train verifies a runtime on devnet or testnet, it force-moves that network mirror branch to the exact deployed main commit. That push already publishes `ghcr.io/raofoundation/subtensor` and now also publishes `ghcr.io/raofoundation/subtensor-localnet` with the matching network tag.

## Tag policy

- main push: `main`, `latest`, SHA
- devnet mirror push: `devnet`, SHA
- testnet mirror push: `testnet`, SHA
- other manual branches: sanitized branch, SHA
- releases: version, SHA

## E2E image isolation

The Bittensor E2E workflow builds one PR-specific localnet image and shares it across roughly 112 runner shards through GHCR. Those temporary images now publish to the separate, CI-only `subtensor-localnet-ci` package instead of appearing as permanent `ci-*` versions in the public release package. A scheduled cleanup removes only CI SHA versions older than 30 days, preserving GitHub's workflow rerun window.

Both the public and CI images now provide standard `org.opencontainers.image.*` labels, so GHCR displays Subtensor metadata instead of inherited Ubuntu marketing text. The fast E2E image is pinned to the same Ubuntu 24.04 digest as the public localnet image; the bundled node binary, entrypoint, ports, and authority behavior are unchanged.

## Validation

- tag resolver contract tests
- YAML parsing, shell syntax, BuildKit Dockerfile checks, and clean-diff checks
- real builds of the public runtime-base and fast E2E images with exact OCI label assertions
- CI package isolation assertion before push
- cleanup retention-filter edge cases, including protected and malformed tags
- live CI-package push plus successful login, pull, retag, and test execution across E2E shards
- native amd64 and arm64 binary builds
- native architecture image validation
- full amd64 localnet startup, RPC, persistence, and shutdown smoke test
- multi-platform GHCR publish and anonymous manifest/pull/execution verification
- local Skeptic security review and Auditor domain review

Successful publication run: https://github.com/RaoFoundation/subtensor/actions/runs/29431577113
