### PR TITLE
Add GARM Incus pilot validation

### DIFF
--- a/.github/workflows/garm-incus-pilot-validation.yml
+++ b/.github/workflows/garm-incus-pilot-validation.yml
@@ -24,7 +24,9 @@ jobs:
   representative-workload:
     name: Docker and Rust workload
     needs: trusted-source
-    runs-on: [self-hosted, garm-incus-turbo-8]
+    # GitHub runner scale sets route on their system label; unlike classic
+    # self-hosted runners, the JIT runner does not advertise `self-hosted`.
+    runs-on: garm-incus-turbo-8
     timeout-minutes: 45
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/garm-incus-pilot-validation.yml
+++ b/.github/workflows/garm-incus-pilot-validation.yml
@@ -1,0 +1,65 @@
+name: GARM Incus pilot validation
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/garm-incus-pilot-validation.yml
+  workflow_dispatch:
+
+concurrency:
+  group: garm-incus-pilot-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  trusted-source:
+    name: Trusted PR source (non-fork)
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Trusted source; the isolated pilot runner may execute checkout."
+
+  representative-workload:
+    name: Docker and Rust workload
+    needs: trusted-source
+    runs-on: [self-hosted, garm-incus-turbo-8]
+    timeout-minutes: 45
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      SKIP_WASM_BUILD: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify ephemeral VM isolation and capacity
+        run: |
+          set -euo pipefail
+          test "$(systemd-detect-virt)" = "kvm"
+          test "$(nproc)" -ge 8
+          test "$(awk '/MemTotal/ { print int($2 / 1024 / 1024) }' /proc/meminfo)" -ge 22
+          printf 'runner=%s virtualization=%s cpus=%s\n' \
+            "$RUNNER_NAME" "$(systemd-detect-virt)" "$(nproc)" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Exercise Docker runtime
+        run: |
+          set -euo pipefail
+          docker version
+          docker info
+          docker run --rm --pull=always ubuntu:24.04 \
+            bash -ceu 'test "$(uname -m)" = x86_64; echo docker-smoke-ok'
+
+      - uses: ./.github/actions/rust-setup
+        with:
+          cache-key: garm-incus-pilot-safe-math
+          sccache-credential-mode: reader
+
+      - name: Compile a representative Subtensor workspace crate
+        run: |
+          set -euo pipefail
+          started_at=$(date +%s)
+          cargo check -p safe-math --all-targets
+          finished_at=$(date +%s)
+          printf 'Rust check duration: %ss\n' "$((finished_at - started_at))" \
+            | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Add a narrowly scoped same-repository workflow that validates the GARM + Incus pilot on its dedicated `garm-incus-turbo-8` runner label.

The representative job verifies KVM VM isolation and capacity, exercises Docker, runs the repository Rust setup action, and compiles the `safe-math` workspace crate.

## Safety

- fork PRs are rejected before the self-hosted job
- workflow token is read-only
- runner is an ephemeral Incus VM
- workflow only auto-triggers when this pilot workflow file changes

## Validation

- targeted `actionlint`
- live GARM controller, idle runner, Incus VM, firewall, vmagent targets, and central Prometheus ingestion validated before opening this PR