### PR TITLE
suppress warnings

### DIFF
--- a/vendor/frontier/client/rpc/src/eth/pending.rs
+++ b/vendor/frontier/client/rpc/src/eth/pending.rs
@@ -61,6 +61,7 @@ where
 	P: TransactionPool<Block = B, Hash = B::Hash> + 'static,
 {
 	/// Creates a pending runtime API.
+	#[allow(mismatched_lifetime_syntaxes)]
 	pub(crate) async fn pending_runtime_api(&self) -> Result<(B::Hash, ApiRef<C::Api>), Error> {
 		let api = self.client.runtime_api();
 

--- a/vendor/frontier/precompiles/src/evm/handle.rs
+++ b/vendor/frontier/precompiles/src/evm/handle.rs
@@ -49,6 +49,7 @@ pub trait PrecompileHandleExt: PrecompileHandle {
 	fn read_u32_selector(&self) -> MayRevert<u32>;
 
 	/// Returns a reader of the input, skipping the selector.
+	#[allow(mismatched_lifetime_syntaxes)]
 	fn read_after_selector(&self) -> MayRevert<Reader>;
 }
 
@@ -96,6 +97,7 @@ impl<T: PrecompileHandle> PrecompileHandleExt for T {
 	}
 
 	/// Returns a reader of the input, skipping the selector.
+	#[allow(mismatched_lifetime_syntaxes)]
 	fn read_after_selector(&self) -> MayRevert<Reader> {
 		Reader::new_skip_selector(self.input())
 	}

--- a/vendor/w3f-bls/src/double_pop.rs
+++ b/vendor/w3f-bls/src/double_pop.rs
@@ -17,6 +17,7 @@ use ark_ec::Group;
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
 
 const PROOF_OF_POSSESSION_CONTEXT: &'static [u8] = b"POP_";
+#[allow(dead_code)]
 const BLS_CONTEXT: &'static [u8] = b"BLS_";
 
 /// Proof Of Possession of the secret key as the secret scaler genarting both public

--- a/vendor/w3f-bls/src/verifiers.rs
+++ b/vendor/w3f-bls/src/verifiers.rs
@@ -268,6 +268,7 @@ pub fn verify_using_aggregated_auxiliary_public_keys<
 
     //Simplify from here on.
     for (m, pk) in itr {
+        #[allow(noop_method_call)]
         publickeys.push(pk.borrow().0.clone());
         messages.push(
             m.hash_to_signature_curve::<E>()


### PR DESCRIPTION
## Description

Suppresses five compiler warnings emitted by vendored Frontier and `w3f-bls` sources. The warnings concern elided lifetime syntax, an unused BLS context constant, and a no-op clone.

## Files of interest

- `vendor/frontier/client/rpc/src/eth/pending.rs`
- `vendor/frontier/precompiles/src/evm/handle.rs`
- `vendor/w3f-bls/src/double_pop.rs`
- `vendor/w3f-bls/src/verifiers.rs`

## Behavioral impact

No runtime behavior or public API is intended to change; this PR adds lint-suppression attributes only.

## Migration and spec version

No migration or runtime spec-version bump is required.

## Testing

Not performed; the changes are lint attributes only.