### PR TITLE
Publish tested localnet images and restore clippy

### DIFF
--- a/.github/scripts/publish-localnet-manifest.sh
+++ b/.github/scripts/publish-localnet-manifest.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${IMAGE:?IMAGE is required}"
+: "${TAG:?TAG is required}"
+: "${SHA:?SHA is required}"
+: "${PUBLISH_LATEST:?PUBLISH_LATEST is required}"
+
+descriptor_dir="${1:-image-descriptors}"
+
+[[ "$SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "SHA must be a full lowercase commit SHA: $SHA" >&2
+  exit 1
+}
+
+read_source() {
+  local arch="$1"
+  local descriptor="$descriptor_dir/$arch.txt"
+  local source digest
+
+  [[ -s "$descriptor" ]] || {
+    echo "missing $arch image descriptor: $descriptor" >&2
+    return 1
+  }
+
+  IFS= read -r source < "$descriptor"
+  digest="${source#"$IMAGE@"}"
+  [[ "$source" == "$IMAGE@$digest" && "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+    echo "invalid $arch image descriptor: $source" >&2
+    return 1
+  }
+
+  printf '%s' "$source"
+}
+
+amd64_source="$(read_source amd64)"
+arm64_source="$(read_source arm64)"
+
+tags=(
+  --tag "$IMAGE:$TAG"
+  --tag "$IMAGE:sha-$SHA"
+)
+case "$PUBLISH_LATEST" in
+  true)
+    tags+=(--tag "$IMAGE:latest")
+    ;;
+  false)
+    ;;
+  *)
+    echo "PUBLISH_LATEST must be true or false: $PUBLISH_LATEST" >&2
+    exit 1
+    ;;
+esac
+
+docker buildx imagetools create \
+  "${tags[@]}" \
+  --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing" \
+  --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor" \
+  --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+  "$amd64_source" \
+  "$arm64_source"

--- a/.github/scripts/test-publish-localnet-manifest.sh
+++ b/.github/scripts/test-publish-localnet-manifest.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+publisher="$repo_root/.github/scripts/publish-localnet-manifest.sh"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+image="ghcr.io/raofoundation/subtensor-localnet"
+sha="0123456789abcdef0123456789abcdef01234567"
+descriptor_dir="$workdir/descriptors"
+fake_docker="$workdir/docker"
+args_file="$workdir/docker-args"
+mkdir -p "$descriptor_dir"
+
+printf '%s@sha256:%064d\n' "$image" 0 > "$descriptor_dir/amd64.txt"
+printf '%s@sha256:%064d\n' "$image" 1 > "$descriptor_dir/arm64.txt"
+
+cat > "$fake_docker" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$DOCKER_ARGS_FILE"
+SCRIPT
+chmod +x "$fake_docker"
+
+assert_case() {
+  local publish_latest="$1"
+  local argument index
+  local -a expected actual
+
+  expected=(
+    buildx imagetools create
+    --tag "$image:pr-2928"
+    --tag "$image:sha-$sha"
+  )
+  if [[ "$publish_latest" == true ]]; then
+    expected+=(--tag "$image:latest")
+  fi
+  expected+=(
+    --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing"
+    --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor"
+    --annotation "index:org.opencontainers.image.licenses=Apache-2.0"
+    "$image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    "$image@sha256:0000000000000000000000000000000000000000000000000000000000000001"
+  )
+
+  IMAGE="$image" TAG=pr-2928 SHA="$sha" PUBLISH_LATEST="$publish_latest" \
+    PATH="$workdir:$PATH" DOCKER_ARGS_FILE="$args_file" \
+    "$publisher" "$descriptor_dir"
+
+  actual=()
+  while IFS= read -r argument; do
+    actual+=("$argument")
+  done < "$args_file"
+  [[ "${#actual[@]}" -eq "${#expected[@]}" ]] || {
+    echo "unexpected argument count for latest=$publish_latest" >&2
+    exit 1
+  }
+  for index in "${!expected[@]}"; do
+    [[ "${actual[$index]}" == "${expected[$index]}" ]] || {
+      echo "argument $index mismatch for latest=$publish_latest" >&2
+      echo "expected: ${expected[$index]}" >&2
+      echo "actual:   ${actual[$index]}" >&2
+      exit 1
+    }
+  done
+}
+
+assert_case false
+assert_case true
+
+if IMAGE="$image" TAG=pr-2928 SHA="$sha" PUBLISH_LATEST=invalid \
+  PATH="$workdir:$PATH" DOCKER_ARGS_FILE="$args_file" \
+  "$publisher" "$descriptor_dir" >/dev/null 2>&1; then
+  echo "invalid latest policy unexpectedly succeeded" >&2
+  exit 1
+fi
+
+printf '%s\n' "$image:not-a-digest" > "$descriptor_dir/amd64.txt"
+if IMAGE="$image" TAG=pr-2928 SHA="$sha" PUBLISH_LATEST=false \
+  PATH="$workdir:$PATH" DOCKER_ARGS_FILE="$args_file" \
+  "$publisher" "$descriptor_dir" >/dev/null 2>&1; then
+  echo "invalid image descriptor unexpectedly succeeded" >&2
+  exit 1
+fi
+
+echo "localnet manifest publication contract tests passed"

--- a/.github/workflows/check-localnet-publication.yml
+++ b/.github/workflows/check-localnet-publication.yml
@@ -1,0 +1,30 @@
+name: Localnet Publication Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/docker-localnet.yml"
+      - ".github/workflows/check-localnet-publication.yml"
+      - ".github/scripts/resolve-localnet-image.sh"
+      - ".github/scripts/test-resolve-localnet-image.sh"
+      - ".github/scripts/publish-localnet-manifest.sh"
+      - ".github/scripts/test-publish-localnet-manifest.sh"
+
+concurrency:
+  group: check-localnet-publication-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test image tag policy
+        run: ./.github/scripts/test-resolve-localnet-image.sh
+
+      - name: Test immutable manifest publication
+        run: ./.github/scripts/test-publish-localnet-manifest.sh

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -159,9 +159,10 @@ jobs:
           path: build/
           if-no-files-found: error
 
-  # Package each native architecture before publishing. The amd64 runner also
-  # exercises the public compatibility contract: True/False, both RPC ports,
-  # graceful stop, health, and --no-purge persistence.
+  # Package and test each native architecture before pushing that exact image.
+  # The amd64 runner also exercises the public compatibility contract:
+  # True/False, both RPC ports, graceful stop, health, and --no-purge
+  # persistence.
   validate-image:
     name: Image smoke test • ${{ matrix.platform.arch }}
     needs: [setup, artifacts]
@@ -189,8 +190,9 @@ jobs:
           path: build/
           merge-multiple: true
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Determine image name
+        # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor.
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -203,11 +205,14 @@ jobs:
           target: subtensor-localnet-prebuilt
           platforms: linux/${{ matrix.platform.arch }}
           load: true
-          tags: subtensor-localnet-check:${{ matrix.platform.arch }}
+          tags: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
+          labels: |
+            org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
+            org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
 
       - name: Verify architecture and bundled binaries
         env:
-          IMAGE: subtensor-localnet-check:${{ matrix.platform.arch }}
+          IMAGE: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
         run: |
           test "$(docker image inspect "$IMAGE" --format '{{.Architecture}}')" = "${{ matrix.platform.arch }}"
           test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.title"}}')" = "Subtensor Localnet"
@@ -219,27 +224,26 @@ jobs:
 
       - name: Exercise localnet compatibility contract
         if: ${{ matrix.platform.arch == 'amd64' }}
-        run: ./.github/scripts/test-localnet-image.sh subtensor-localnet-check:amd64
+        run: ./.github/scripts/test-localnet-image.sh "$image:sha-${{ needs.setup.outputs.sha }}-amd64"
 
-  # Collect all binaries and publish one multi-architecture image.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push tested platform image
+        env:
+          IMAGE: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
+        run: docker push "$IMAGE"
+
+  # Publish a multi-architecture manifest composed only of the platform images
+  # that passed the smoke tests above.
   docker:
-    needs: [setup, artifacts, validate-image]
+    needs: [setup, validate-image]
     runs-on: [self-hosted, fireactions-turbo-8]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.setup.outputs.sha }}
-
-      - name: Download all binary artifacts
-        uses: actions/download-artifact@v5
-        with:
-          pattern: binaries-*
-          path: build/
-          merge-multiple: true
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -254,27 +258,27 @@ jobs:
         # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor.
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile-localnet
-          target: subtensor-localnet-prebuilt
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.image }}:${{ needs.setup.outputs.tag }}
-            ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}
-            ${{ needs.setup.outputs.latest_tag == 'true' && format('{0}:latest', env.image) || '' }}
-          labels: |
-            org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
-            org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
-          # GHCR reads multi-architecture package metadata from the OCI index,
-          # while Dockerfile labels live on each platform image config.
-          annotations: |
-            index:org.opencontainers.image.description=Subtensor local development network for CI and local testing
-            index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor
-            index:org.opencontainers.image.licenses=Apache-2.0
+      - name: Publish tested image manifest
+        env:
+          TAG: ${{ needs.setup.outputs.tag }}
+          SHA: ${{ needs.setup.outputs.sha }}
+          PUBLISH_LATEST: ${{ needs.setup.outputs.latest_tag }}
+        run: |
+          tags=(
+            --tag "$image:$TAG"
+            --tag "$image:sha-$SHA"
+          )
+          if [ "$PUBLISH_LATEST" = true ]; then
+            tags+=(--tag "$image:latest")
+          fi
+
+          docker buildx imagetools create \
+            "${tags[@]}" \
+            --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor" \
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+            "$image:sha-$SHA-amd64" \
+            "$image:sha-$SHA-arm64"
 
   # CI consumers pull anonymously. A successful authenticated push is not
   # sufficient: fail if package visibility regresses to private.

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -40,12 +40,18 @@ jobs:
       ref: ${{ steps.vars.outputs.ref }}
       latest_tag: ${{ steps.vars.outputs.latest_tag }}
       sha: ${{ steps.source.outputs.sha }}
+      image: ${{ steps.image.outputs.image }}
+      repository: ${{ steps.image.outputs.repository }}
+      publication_id: ${{ steps.image.outputs.publication_id }}
     steps:
       - name: Check out workflow scripts
         uses: actions/checkout@v4
 
       - name: Validate image tag policy
         run: ./.github/scripts/test-resolve-localnet-image.sh
+
+      - name: Validate image publication contract
+        run: ./.github/scripts/test-publish-localnet-manifest.sh
 
       - name: Get PR source (if pr-number is specified)
         id: pr-info
@@ -83,6 +89,14 @@ jobs:
           BRANCH_OR_TAG: ${{ github.event.inputs.branch-or-tag }}
           REF_NAME: ${{ github.ref_name }}
         run: ./.github/scripts/resolve-localnet-image.sh
+
+      - name: Determine image identity
+        id: image
+        run: |
+          repository="${GITHUB_REPOSITORY,,}-localnet"
+          echo "image=ghcr.io/$repository" >> "$GITHUB_OUTPUT"
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "publication_id=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
       - name: Check out immutable source revision
         uses: actions/checkout@v4
@@ -190,10 +204,6 @@ jobs:
           path: build/
           merge-multiple: true
 
-      - name: Determine image name
-        # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor.
-        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -205,26 +215,28 @@ jobs:
           target: subtensor-localnet-prebuilt
           platforms: linux/${{ matrix.platform.arch }}
           load: true
-          tags: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
+          # Run-scoped tags retain the platform manifests in GHCR. Only the
+          # immutable digests recorded below are used for final publication.
+          tags: ${{ needs.setup.outputs.image }}:build-${{ needs.setup.outputs.publication_id }}-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
             org.opencontainers.image.version=${{ needs.setup.outputs.tag }}
 
       - name: Verify architecture and bundled binaries
         env:
-          IMAGE: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
+          PLATFORM_IMAGE: ${{ needs.setup.outputs.image }}:build-${{ needs.setup.outputs.publication_id }}-${{ matrix.platform.arch }}
         run: |
-          test "$(docker image inspect "$IMAGE" --format '{{.Architecture}}')" = "${{ matrix.platform.arch }}"
-          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.title"}}')" = "Subtensor Localnet"
-          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.description"}}')" = "Subtensor local development network for CI and local testing"
-          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.source"}}')" = "https://github.com/RaoFoundation/subtensor"
-          test "$(docker image inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.licenses"}}')" = "Apache-2.0"
-          docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor "$IMAGE" --help
-          docker run --rm --entrypoint /target/non-fast-runtime/release/node-subtensor "$IMAGE" --help
+          test "$(docker image inspect "$PLATFORM_IMAGE" --format '{{.Architecture}}')" = "${{ matrix.platform.arch }}"
+          test "$(docker image inspect "$PLATFORM_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.title"}}')" = "Subtensor Localnet"
+          test "$(docker image inspect "$PLATFORM_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.description"}}')" = "Subtensor local development network for CI and local testing"
+          test "$(docker image inspect "$PLATFORM_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.source"}}')" = "https://github.com/RaoFoundation/subtensor"
+          test "$(docker image inspect "$PLATFORM_IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.licenses"}}')" = "Apache-2.0"
+          docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor "$PLATFORM_IMAGE" --help
+          docker run --rm --entrypoint /target/non-fast-runtime/release/node-subtensor "$PLATFORM_IMAGE" --help
 
       - name: Exercise localnet compatibility contract
         if: ${{ matrix.platform.arch == 'amd64' }}
-        run: ./.github/scripts/test-localnet-image.sh "$image:sha-${{ needs.setup.outputs.sha }}-amd64"
+        run: ./.github/scripts/test-localnet-image.sh "${{ needs.setup.outputs.image }}:build-${{ needs.setup.outputs.publication_id }}-amd64"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -235,8 +247,22 @@ jobs:
 
       - name: Push tested platform image
         env:
-          IMAGE: ${{ env.image }}:sha-${{ needs.setup.outputs.sha }}-${{ matrix.platform.arch }}
-        run: docker push "$IMAGE"
+          IMAGE: ${{ needs.setup.outputs.image }}
+          PLATFORM_IMAGE: ${{ needs.setup.outputs.image }}:build-${{ needs.setup.outputs.publication_id }}-${{ matrix.platform.arch }}
+          ARCH: ${{ matrix.platform.arch }}
+        run: |
+          docker push "$PLATFORM_IMAGE"
+          manifest="$(docker buildx imagetools inspect "$PLATFORM_IMAGE" --format '{{json .Manifest}}')"
+          digest="$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$manifest")"
+          mkdir -p image-descriptors
+          printf '%s@%s\n' "$IMAGE" "$digest" > "image-descriptors/$ARCH.txt"
+
+      - name: Upload tested image descriptor
+        uses: actions/upload-artifact@v4
+        with:
+          name: localnet-image-${{ needs.setup.outputs.publication_id }}-${{ matrix.platform.arch }}
+          path: image-descriptors/${{ matrix.platform.arch }}.txt
+          if-no-files-found: error
 
   # Publish a multi-architecture manifest composed only of the platform images
   # that passed the smoke tests above.
@@ -244,6 +270,15 @@ jobs:
     needs: [setup, validate-image]
     runs-on: [self-hosted, fireactions-turbo-8]
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Download tested image descriptors
+        uses: actions/download-artifact@v5
+        with:
+          pattern: localnet-image-${{ needs.setup.outputs.publication_id }}-*
+          path: image-descriptors/
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -254,31 +289,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine image name
-        # Docker requires lowercase image names; github.repository is RaoFoundation/subtensor.
-        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
-
       - name: Publish tested image manifest
         env:
+          IMAGE: ${{ needs.setup.outputs.image }}
           TAG: ${{ needs.setup.outputs.tag }}
           SHA: ${{ needs.setup.outputs.sha }}
           PUBLISH_LATEST: ${{ needs.setup.outputs.latest_tag }}
-        run: |
-          tags=(
-            --tag "$image:$TAG"
-            --tag "$image:sha-$SHA"
-          )
-          if [ "$PUBLISH_LATEST" = true ]; then
-            tags+=(--tag "$image:latest")
-          fi
-
-          docker buildx imagetools create \
-            "${tags[@]}" \
-            --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing" \
-            --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor" \
-            --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
-            "$image:sha-$SHA-amd64" \
-            "$image:sha-$SHA-arm64"
+        run: ./.github/scripts/publish-localnet-manifest.sh image-descriptors
 
   # CI consumers pull anonymously. A successful authenticated push is not
   # sufficient: fail if package visibility regresses to private.
@@ -286,11 +303,10 @@ jobs:
     needs: [setup, docker]
     runs-on: ubuntu-latest
     steps:
-      - name: Determine image name
-        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}-localnet" >> "$GITHUB_ENV"
-
       - name: Verify anonymous pulls
         env:
+          IMAGE: ${{ needs.setup.outputs.image }}
+          REPOSITORY: ${{ needs.setup.outputs.repository }}
           TAG: ${{ needs.setup.outputs.tag }}
           SHA: ${{ needs.setup.outputs.sha }}
           VERIFY_LATEST: ${{ needs.setup.outputs.latest_tag }}
@@ -304,21 +320,20 @@ jobs:
 
           for tag in "${tags[@]}"; do
             for attempt in {1..12}; do
-              if docker manifest inspect "$image:$tag" >/dev/null; then
+              if docker manifest inspect "$IMAGE:$tag" >/dev/null; then
                 break
               fi
               if [ "$attempt" -eq 12 ]; then
-                echo "Anonymous pull failed for $image:$tag" >&2
+                echo "Anonymous pull failed for $IMAGE:$tag" >&2
                 exit 1
               fi
               sleep 10
             done
           done
 
-          repository="${GITHUB_REPOSITORY,,}-localnet"
           registry_token="$(
             curl -fsSL --get \
-              --data-urlencode "scope=repository:$repository:pull" \
+              --data-urlencode "scope=repository:$REPOSITORY:pull" \
               https://ghcr.io/token \
               | jq -er '.token // .access_token'
           )"
@@ -326,7 +341,7 @@ jobs:
             curl -fsSL \
               -H "Authorization: Bearer $registry_token" \
               -H 'Accept: application/vnd.oci.image.index.v1+json' \
-              "https://ghcr.io/v2/$repository/manifests/$TAG"
+              "https://ghcr.io/v2/$REPOSITORY/manifests/$TAG"
           )"
           test "$(jq -r '.annotations["org.opencontainers.image.description"]' <<<"$manifest")" = \
             "Subtensor local development network for CI and local testing"
@@ -337,6 +352,6 @@ jobs:
 
           # Match the anonymous CI consumer path, including layer downloads
           # and execution, rather than treating manifest visibility as enough.
-          docker pull "$image:$TAG"
+          docker pull "$IMAGE:$TAG"
           docker run --rm --entrypoint /target/fast-runtime/release/node-subtensor \
-            "$image:$TAG" --help >/dev/null
+            "$IMAGE:$TAG" --help >/dev/null

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -270,7 +270,13 @@ jobs:
     needs: [setup, validate-image]
     runs-on: [self-hosted, fireactions-turbo-8]
     steps:
-      - uses: actions/checkout@v4
+      # Publication tooling belongs to the workflow revision, not the selected
+      # application source. Manual runs may intentionally build an older ref or
+      # a PR whose copy of this script is missing or incompatible.
+      - name: Check out publication tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
 
       - name: Download tested image descriptors
         uses: actions/download-artifact@v5

--- a/pallets/subtensor/src/tests/leasing.rs
+++ b/pallets/subtensor/src/tests/leasing.rs
@@ -33,7 +33,7 @@ fn test_register_leased_network_works() {
             emissions_share,
             Some(end_block),
         )
-        .expect("leased network registration should succeed");
+        .unwrap_or_else(|error| panic!("leased network registration failed: {error:?}"));
 
         let contributors_count = 1 + contributions.len() as u32;
         assert_eq!(
@@ -274,7 +274,8 @@ fn test_terminate_lease_works() {
     });
 
     // Commit the lease setup so clear_prefix reports the same backend removals as on-chain.
-    ext.commit_all().expect("lease setup should commit");
+    ext.commit_all()
+        .unwrap_or_else(|error| panic!("lease setup failed to commit: {error:?}"));
 
     ext.execute_with(|| {
 
@@ -296,7 +297,7 @@ fn test_terminate_lease_works() {
             lease_id,
             hotkey,
         )
-        .expect("lease termination should succeed");
+        .unwrap_or_else(|error| panic!("lease termination failed: {error:?}"));
 
         let contributors_count = 1 + contributions.len() as u32;
         assert_eq!(

--- a/pallets/subtensor/src/tests/leasing.rs
+++ b/pallets/subtensor/src/tests/leasing.rs
@@ -28,16 +28,14 @@ fn test_register_leased_network_works() {
         // Register the leased network
         let end_block = 500;
         let emissions_share = Percent::from_percent(30);
-        let post_info = SubtensorModule::register_leased_network(
-            RuntimeOrigin::signed(beneficiary),
-            emissions_share,
-            Some(end_block),
-        )
-        .unwrap_or_else(|error| panic!("leased network registration failed: {error:?}"));
-
         let contributors_count = 1 + contributions.len() as u32;
-        assert_eq!(
-            post_info.actual_weight,
+        assert_ok!(
+            SubtensorModule::register_leased_network(
+                RuntimeOrigin::signed(beneficiary),
+                emissions_share,
+                Some(end_block),
+            )
+            .map(|post_info| post_info.actual_weight),
             Some(
                 <<Test as crate::Config>::WeightInfo as crate::weights::WeightInfo>::register_leased_network(
                     contributors_count,
@@ -274,8 +272,7 @@ fn test_terminate_lease_works() {
     });
 
     // Commit the lease setup so clear_prefix reports the same backend removals as on-chain.
-    ext.commit_all()
-        .unwrap_or_else(|error| panic!("lease setup failed to commit: {error:?}"));
+    assert_ok!(ext.commit_all());
 
     ext.execute_with(|| {
 
@@ -292,16 +289,14 @@ fn test_terminate_lease_works() {
         );
 
         // Terminate the lease
-        let post_info = SubtensorModule::terminate_lease(
-            RuntimeOrigin::signed(beneficiary),
-            lease_id,
-            hotkey,
-        )
-        .unwrap_or_else(|error| panic!("lease termination failed: {error:?}"));
-
         let contributors_count = 1 + contributions.len() as u32;
-        assert_eq!(
-            post_info.actual_weight,
+        assert_ok!(
+            SubtensorModule::terminate_lease(
+                RuntimeOrigin::signed(beneficiary),
+                lease_id,
+                hotkey,
+            )
+            .map(|post_info| post_info.actual_weight),
             Some(
                 <<Test as crate::Config>::WeightInfo as crate::weights::WeightInfo>::terminate_lease(
                     contributors_count,


### PR DESCRIPTION
## Summary

- build, smoke-test, and push each native localnet platform image on the same runner
- scope intermediate image tags to the workflow run and attempt, then hand immutable registry digest descriptors to the publication job
- assemble the multi-architecture manifest exclusively from those tested digest references
- centralize image identity in the setup job so validation and publication cannot drift
- replace the leasing weight tests' lint-denied panic wrappers with direct `assert_ok!` assertions
- run a non-pushing localnet publication contract check on relevant pull requests

## Root cause

The localnet workflow validated locally loaded images, then discarded them and performed a second independent multi-platform build for publication. Runtime package installation in `Dockerfile-localnet` means that rebuild was not guaranteed to produce the artifact that passed the smoke tests.

The initial fix used SHA-and-architecture intermediate tags. Because mirror branches can publish the same SHA concurrently, one run could overwrite another run's intermediate tag before manifest assembly. The workflow now records each run-scoped platform image's registry digest and publishes only from immutable digest references.

The leasing weight tests also added panic wrappers that violated the workspace's denied clippy policy. Direct assertions preserve the failure semantics without suppressing or laundering the lint.

## Impact

Published localnet manifests now reference the exact amd64 and arm64 registry digests that passed their native smoke tests. Concurrent mirror-branch runs cannot substitute platform images during final manifest assembly.

The final publication job no longer downloads binary artifacts, sets up QEMU, or rebuilds the image. A lightweight pull-request workflow exercises the manifest publication contract without pushing images or requiring registry credentials.

Both workspace clippy configurations are restored without weakening lint policy.

## Validation

- `cargo fmt --all -- --check`
- `SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings`
- `SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `SKIP_WASM_BUILD=1 cargo test -p pallet-subtensor --lib tests::leasing` — 20 passed
- `./.github/scripts/test-resolve-localnet-image.sh`
- `./.github/scripts/test-publish-localnet-manifest.sh`
- syntax-checked both publication scripts with `bash -n`
- parsed both localnet workflow files as YAML
- `git diff --check`
