### PR TITLE
reuse canonical alpha iterator helper 

### DIFF
--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -27,20 +27,8 @@ impl<T: Config> Pallet<T> {
     /// Read and merge the old hotkey's V1/V2 stake rows once. V2 keeps the
     /// existing precedence over a duplicate legacy row.
     fn prepare_hotkey_stake(old_hotkey: &T::AccountId) -> PreparedHotkeyStake<T::AccountId> {
-        let mut merged: BTreeMap<(T::AccountId, NetUid), SafeFloat> = BTreeMap::new();
-
-        for ((coldkey, netuid), alpha) in Alpha::<T>::iter_prefix((old_hotkey,)) {
-            merged.insert((coldkey, netuid), alpha.into());
-        }
-
-        for ((coldkey, netuid), alpha) in AlphaV2::<T>::iter_prefix((old_hotkey,)) {
-            merged.insert((coldkey, netuid), alpha);
-        }
-
-        let positions: Vec<(T::AccountId, NetUid, SafeFloat)> = merged
-            .into_iter()
-            .map(|((coldkey, netuid), alpha)| (coldkey, netuid, alpha))
-            .collect();
+        let positions: Vec<(T::AccountId, NetUid, SafeFloat)> =
+            Self::alpha_iter_single_prefix(old_hotkey).collect();
         let mut coldkeys_by_netuid: BTreeMap<NetUid, Vec<T::AccountId>> = BTreeMap::new();
 
         for (coldkey, netuid, _) in &positions {


### PR DESCRIPTION
## Motivation

`prepare_hotkey_stake` duplicated the legacy/V2 alpha-row merge already implemented by `alpha_iter_single_prefix`. Keeping two copies of this logic risks their precedence or conversion behavior diverging over time.

## Changes

- Replaced the local `Alpha`/`AlphaV2` merge in `pallets/subtensor/src/swap/swap_hotkey.rs` with `Self::alpha_iter_single_prefix(old_hotkey)`.
- Preserved the existing output type, deterministic ordering, and V2 precedence when both storage versions contain the same `(coldkey, netuid)` key.

## Behavioral impact

This is a behavior-preserving refactor. Hotkey swaps continue to collect the same stake positions and group the same coldkeys by subnet; no storage layout or economic logic changes.

## Migration and runtime version

No migration is required. The PR targets `staging`, which has no network spec-version check, so no `spec_version` bump is needed.

## Testing

Static equivalence was verified against the implementation of `alpha_iter_single_prefix`. No targeted runtime test was required because the change delegates to the existing canonical helper without altering its inputs or outputs.