### PR TITLE
Fix MaxWeightTooLow on final upgrade sudo approval

### DIFF
--- a/sdk/python/bittensor/cli/commands/upgrade.py
+++ b/sdk/python/bittensor/cli/commands/upgrade.py
@@ -486,13 +486,19 @@ def upgrade_sign(
         if signer_address in approvals:
             return None, sudo_layer
         others = uh.sorted_other_signatories(sudo_signatories, signer_address)
+        # Outer sudo max_weight must cover the finalizing call's real weight
+        # (~65B/21k for a 2MB setCode); FINALIZE_WEIGHT is only the *inner*
+        # as_multi argument and is too low here (MaxWeightTooLow).
+        max_weight = await uh.sudo_layer_max_weight(
+            client, finalizing, app_ctx.wallet().coldkeypub
+        )
         if sudo_layer is None:
             call = calls.Multisig.approve_as_multi(
                 threshold=sudo_threshold,
                 other_signatories=others,
                 maybe_timepoint=None,
                 call_hash=finalizing.call_hash,
-                max_weight=uh.FINALIZE_WEIGHT,
+                max_weight=max_weight,
             )
         elif len(approvals) < sudo_threshold - 1:
             call = calls.Multisig.approve_as_multi(
@@ -500,7 +506,7 @@ def upgrade_sign(
                 other_signatories=others,
                 maybe_timepoint=sudo_layer["timepoint"],
                 call_hash=finalizing.call_hash,
-                max_weight=uh.FINALIZE_WEIGHT,
+                max_weight=max_weight,
             )
         else:
             call = calls.Multisig.as_multi(
@@ -508,7 +514,7 @@ def upgrade_sign(
                 other_signatories=others,
                 maybe_timepoint=sudo_layer["timepoint"],
                 call=finalizing,
-                max_weight=uh.FINALIZE_WEIGHT,
+                max_weight=max_weight,
             )
         result = await client.submit_call(
             call, signing, signer="coldkey", wait_for_finalization=False

--- a/sdk/python/bittensor/cli/upgrade_helpers.py
+++ b/sdk/python/bittensor/cli/upgrade_helpers.py
@@ -41,9 +41,12 @@ SUDO_PROXY_TYPE = "SudoUncheckedSetCode"
 # Weight literals of the CI deployment pipeline (.github/scripts/deploy).
 # PROPOSAL_WEIGHT is an argument of the proposed call itself
 # (sudoUncheckedWeight) — changing it changes the call hash CI registered.
-# FINALIZE_WEIGHT is an argument of the finalizing as_multi call, whose hash
-# the sudo multisig operates on, so every triumvirate approval must repeat it
-# exactly. Both must stay in lockstep with propose-upgrade-multisig.js /
+# FINALIZE_WEIGHT is an argument of the *inner* finalizing as_multi (deployment
+# multisig → setCode). It is baked into the call the sudo multisig signs, so
+# every triumvirate approval must repeat it exactly. It is NOT the max_weight
+# of the outer sudo-layer as_multi — that must be estimated at sign time from
+# the finalizing call's real dispatch weight (a 2MB setCode blob exceeds these
+# numbers). Keep in lockstep with propose-upgrade-multisig.js /
 # approve-upgrade-multisig.js.
 PROPOSAL_WEIGHT = {"ref_time": 50_000_000_000, "proof_size": 0}
 FINALIZE_WEIGHT = {"ref_time": 60_000_000_000, "proof_size": 10_000}
@@ -443,6 +446,16 @@ async def compose_finalizing_call(
             max_weight=FINALIZE_WEIGHT,
         )
     )
+
+
+async def sudo_layer_max_weight(client, finalizing_call, keypair) -> dict[str, int]:
+    """``max_weight`` for the outer sudo Multisig approval / execution.
+
+    Must be ≥ the finalizing call's real dispatch weight (``payment_queryInfo``).
+    Distinct from ``FINALIZE_WEIGHT``, which is an *argument of* that call and
+    cannot change without invalidating the sudo-layer call hash.
+    """
+    return await client._substrate.estimate_weight(finalizing_call, keypair)
 
 
 def sorted_other_signatories(signatories: list[str], self_address: str) -> list[str]:


### PR DESCRIPTION
## Summary
- Final `btcli upgrade sign` failed with `MaxWeightTooLow` because the outer sudo `as_multi` reused pinned `FINALIZE_WEIGHT` (60B/10k).
- Live estimate for the v432 finalizing call is ~65.1B ref_time / 21k proof_size.
- Estimate outer `max_weight` at sign time; keep `FINALIZE_WEIGHT` only inside the call-hash-bound finalizing call.

## Test plan
- [ ] Co-signer installs this revision and re-runs `btcli upgrade sign --url https://github.com/RaoFoundation/subtensor/releases/tag/v432 -w <wallet>`
- [ ] Extrinsic succeeds; Finney `spec_version` becomes 432

Made with [Cursor](https://cursor.com)