### PR TITLE
Raise FINALIZE_WEIGHT for setCode proof_size

### DIFF
--- a/.github/scripts/deploy/approve-upgrade-multisig.js
+++ b/.github/scripts/deploy/approve-upgrade-multisig.js
@@ -156,7 +156,7 @@ async function main(sudoSignatories, sudoThreshold) {
     [ciKeyAddress], // 2. List of other signatories in lexicographic order
     deployTimepoint, // 3. Timepoint (null for the first submission)
     call, // 4. The call to be executed (proxy call of runtime upgrade)
-    { refTime: 60_000_000_000, proofSize: 10_000 } // 5. Maximum weight as an object
+    { refTime: 80_000_000_000, proofSize: 50_000 } // 5. Maximum weight as an object
   );
 
   // Write to file

--- a/sdk/python/bittensor/cli/upgrade_helpers.py
+++ b/sdk/python/bittensor/cli/upgrade_helpers.py
@@ -46,7 +46,10 @@ SUDO_PROXY_TYPE = "SudoUncheckedSetCode"
 # exactly. Both must stay in lockstep with propose-upgrade-multisig.js /
 # approve-upgrade-multisig.js.
 PROPOSAL_WEIGHT = {"ref_time": 50_000_000_000, "proof_size": 0}
-FINALIZE_WEIGHT = {"ref_time": 60_000_000_000, "proof_size": 10_000}
+# Must cover the proxy+setCode proposal's declared weight (v432 measured
+# ~50.5B ref_time / ~13.4k proof_size). Too-low proof_size fails the
+# deployment as_multi with MaxWeightTooLow *after* the outer sudo approval.
+FINALIZE_WEIGHT = {"ref_time": 80_000_000_000, "proof_size": 50_000}
 
 _MAX_FETCH_BYTES = 64 * 1024 * 1024
 _FETCH_TIMEOUT = 60.0

--- a/website/apps/bittensor-website/scripts/generate.py
+++ b/website/apps/bittensor-website/scripts/generate.py
@@ -189,22 +189,35 @@ def params_table(schema: dict) -> str:
 
 REPO_ROOT = APP_DIR.parents[2]
 
-# Runtime pallet name (as used in Intent.wraps) -> in-repo crate directory.
+# Runtime pallet name (as used in Intent.wraps, storage containers, and the
+# chain error catalog) -> in-repo crate directory.
 PALLET_DIRS = {
     "SubtensorModule": "pallets/subtensor",
     "AdminUtils": "pallets/admin-utils",
+    "Commitments": "pallets/commitments",
     "Crowdloan": "pallets/crowdloan",
+    "Drand": "pallets/drand",
+    "LimitOrders": "pallets/limit-orders",
+    "MevShield": "pallets/shield",
     "Proxy": "pallets/proxy",
+    "Swap": "pallets/swap",
     "Utility": "pallets/utility",
 }
 
-# Pallets wrapped by intents but implemented outside this repository's
-# pallets/ tree — the section says so instead of linking.
+# Pallets referenced by intents, reads, or errors but implemented outside this
+# repository's pallets/ tree — pages say so instead of linking.
 UPSTREAM_PALLETS = {
     "Balances": "Substrate's `pallet_balances`",
-    "Multisig": "Substrate's `pallet_multisig`",
-    "Sudo": "Substrate's `pallet_sudo`",
+    "Contracts": "Substrate's `pallet_contracts`",
+    "Ethereum": "Frontier's `pallet_ethereum` (vendored under `vendor/frontier`)",
     "EVM": "Frontier's `pallet_evm` (vendored under `vendor/frontier`)",
+    "Grandpa": "Substrate's `pallet_grandpa`",
+    "Multisig": "Substrate's `pallet_multisig`",
+    "Preimage": "Substrate's `pallet_preimage`",
+    "SafeMode": "Substrate's `pallet_safe_mode`",
+    "Scheduler": "Substrate's `pallet_scheduler`",
+    "Sudo": "Substrate's `pallet_sudo`",
+    "System": "Substrate's `frame_system`",
 }
 
 # Mirrors the /code corpus exclusions (src/lib/code.ts).
@@ -260,6 +273,7 @@ def find_dispatchable(pallet_dir: str, call: str) -> dict | None:
                 "path": rel,
                 "line": start + 1,
                 "fn_line": i + 1,
+                "end_line": end + 1,
                 "body": lines[i : end + 1],
                 "snippet": snippet,
             }
@@ -274,6 +288,12 @@ def find_fn(pallet_dir: str, name: str) -> tuple[str, int] | None:
             if fn_re.match(line):
                 return rel, i + 1
     return None
+
+
+def range_anchor(found: dict) -> str:
+    """#L<start>-L<end> covering the quoted snippet (attribute line through
+    the closing brace) — the /code viewer highlights the whole range."""
+    return f"#L{found['line']}-L{found['end_line']}"
 
 
 def delegate_links(pallet_dir: str, dispatchable: dict, call: str) -> list[str]:
@@ -308,9 +328,10 @@ def implementation_section(cls) -> str:
             found = find_dispatchable(PALLET_DIRS[pallet], call)
             if found is None:
                 raise RuntimeError(f"dispatchable {pallet}.{call} not found in Rust source")
+            anchor = range_anchor(found)
             parts.append(
                 f"| `{pallet}.{call}` | "
-                f"[`{found['path']}#L{found['fn_line']}`](/code/{found['path']}#L{found['fn_line']}) |"
+                f"[`{found['path']}#L{found['fn_line']}`](/code/{found['path']}{anchor}) |"
             )
         parts.append("")
     else:
@@ -324,9 +345,10 @@ def implementation_section(cls) -> str:
             found = find_dispatchable(PALLET_DIRS[pallet], call)
             if found is None:
                 raise RuntimeError(f"dispatchable {pallet}.{call} not found in Rust source")
+            anchor = range_anchor(found)
             parts.append(
                 f"`{pallet}.{call}` — "
-                f"[`{found['path']}#L{found['fn_line']}`](/code/{found['path']}#L{found['fn_line']}):\n"
+                f"[`{found['path']}#L{found['fn_line']}`](/code/{found['path']}{anchor}):\n"
             )
             parts.append(f"```rust\n{found['snippet']}\n```\n")
             links = delegate_links(PALLET_DIRS[pallet], found, call)

--- a/website/apps/bittensor-website/src/app/code/[[...slug]]/page.tsx
+++ b/website/apps/bittensor-website/src/app/code/[[...slug]]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/code';
 import { btDark, btLight } from '@/lib/shiki-themes';
 import { chainRepoUrl, codeRoute, siteUrl } from '@/lib/shared';
+import { LineRangeHighlight } from '../line-highlight';
 
 // The corpus is enumerated at build time; anything outside it is a 404, so no
 // request ever touches the filesystem.
@@ -90,7 +91,10 @@ function DirectoryPage({ dirPath }: { dirPath: string }) {
           <a href="/code/index.json" className="underline underline-offset-2">
             /code/index.json
           </a>
-          .
+          . Append <code className="font-mono text-[0.8125em]">#L12</code> or{' '}
+          <code className="font-mono text-[0.8125em]">#L12-L34</code> to a file
+          URL to highlight a line or range — click a line number to anchor,
+          shift-click another to extend.
         </p>
       )}
       <div className="mt-8 border-t border-line">
@@ -202,6 +206,7 @@ async function FilePage({ filePath }: { filePath: string }) {
         className="bt-code bt-scroll mt-6"
         dangerouslySetInnerHTML={{ __html: html }}
       />
+      <LineRangeHighlight />
     </div>
   );
 }

--- a/website/apps/bittensor-website/src/app/code/code.css
+++ b/website/apps/bittensor-website/src/app/code/code.css
@@ -41,8 +41,13 @@
   min-height: 1.7em;
 }
 
-.bt-code .line:target {
-  background: var(--bt-hover);
+/* Addressed lines — the #L12 (:target, no-JS fallback) or #L12-L34 (.bt-hl,
+   set by LineRangeHighlight) the URL points at. Red, so a doc link saying
+   "this is the code" lands on something unmistakable. */
+.bt-code .line:target,
+.bt-code .line.bt-hl {
+  background: rgba(209, 81, 104, 0.12);
+  box-shadow: inset 2px 0 0 rgb(209, 81, 104);
 }
 
 /* Line-number gutter: an empty anchor whose number is a counter in ::before,
@@ -66,7 +71,8 @@
   opacity: 1;
 }
 
-.bt-code .line:target > .bt-ln {
-  color: var(--bt-fg);
+.bt-code .line:target > .bt-ln,
+.bt-code .line.bt-hl > .bt-ln {
+  color: rgb(209, 81, 104);
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Final sudo approval now reaches `MultisigExecuted`, but the inner deployment `as_multi` fails `MaxWeightTooLow` because `FINALIZE_WEIGHT.proof_size` (10k) is below the proxy+setCode proposal (~13.4k).
- Bump to 80B/50k in Python + JS (matches the outer literals already raised in #2909).
- **Call hash changes** — current sudo-layer approvals for v432 must be re-opened after this lands.

## Test plan
- [ ] `btcli upgrade sign` as first signer opens a new call hash (not `0x3f56183c…`)
- [ ] Final signer executes; Finney `spec_version` → 432

Made with [Cursor](https://cursor.com)