### PR TITLE
Future-proof FINALIZE_WEIGHT headroom

### DIFF
--- a/.github/scripts/deploy/approve-upgrade-multisig.js
+++ b/.github/scripts/deploy/approve-upgrade-multisig.js
@@ -41,7 +41,7 @@ async function getSudoMultisigProposal(
       // 60e9/10k max_weight argument plus multisig+proxy overhead (measured
       // ~65e9/21k on v431). Too-low values fail the executing approval with
       // MaxWeightTooLow.
-      { refTime: 80_000_000_000, proofSize: 50_000 } // 5. Maximum weight as an object
+      { refTime: 200_000_000_000, proofSize: 1_000_000 } // 5. Maximum weight as an object
     );
 
     return sudoMultiApprove;
@@ -54,7 +54,7 @@ async function getSudoMultisigProposal(
         remainingSignatories, // 2. List of other signatories in lexicographic order
         timePointAndBlockHeight, // 3. Timepoint (null for the first submission)
         multisigProposal.method.hash.toHex(), // 4. The call to be executed (proxy call of runtime upgrade)
-        { refTime: 80_000_000_000, proofSize: 50_000 } // 5. Maximum weight as an object
+        { refTime: 200_000_000_000, proofSize: 1_000_000 } // 5. Maximum weight as an object
       );
 
       return sudoMultiApprove;
@@ -72,7 +72,7 @@ async function getSudoMultisigProposal(
         // chain rejects it with MaxWeightTooLow. The 60e9/10k literal at
         // the deploymentMultisigProposal below is different: it is *inside*
         // the finalizing call's encoding and must never change.
-        { refTime: 80_000_000_000, proofSize: 50_000 } // 5. Maximum weight as an object
+        { refTime: 200_000_000_000, proofSize: 1_000_000 } // 5. Maximum weight as an object
       );
 
       return sudoMultiApprove;
@@ -156,7 +156,7 @@ async function main(sudoSignatories, sudoThreshold) {
     [ciKeyAddress], // 2. List of other signatories in lexicographic order
     deployTimepoint, // 3. Timepoint (null for the first submission)
     call, // 4. The call to be executed (proxy call of runtime upgrade)
-    { refTime: 80_000_000_000, proofSize: 50_000 } // 5. Maximum weight as an object
+    { refTime: 200_000_000_000, proofSize: 1_000_000 } // 5. Maximum weight as an object
   );
 
   // Write to file

--- a/sdk/python/bittensor/cli/upgrade_helpers.py
+++ b/sdk/python/bittensor/cli/upgrade_helpers.py
@@ -49,7 +49,9 @@ PROPOSAL_WEIGHT = {"ref_time": 50_000_000_000, "proof_size": 0}
 # Must cover the proxy+setCode proposal's declared weight (v432 measured
 # ~50.5B ref_time / ~13.4k proof_size). Too-low proof_size fails the
 # deployment as_multi with MaxWeightTooLow *after* the outer sudo approval.
-FINALIZE_WEIGHT = {"ref_time": 80_000_000_000, "proof_size": 50_000}
+# Sized for headroom as runtimes grow, well under normal max_extrinsic
+# (~2.6T ref_time) so the outer sudo approval still fits a block.
+FINALIZE_WEIGHT = {"ref_time": 200_000_000_000, "proof_size": 1_000_000}
 
 _MAX_FETCH_BYTES = 64 * 1024 * 1024
 _FETCH_TIMEOUT = 60.0


### PR DESCRIPTION
## Summary
- Raise `FINALIZE_WEIGHT` (and matching JS literals) from 80B/50k to **200B ref_time / 1M proof_size**.
- Keeps headroom for larger runtimes without approaching normal `max_extrinsic` (~2.6T).
- **Call hash changes** — re-open v432 sudo-layer approvals after this lands.

## Test plan
- [ ] `btcli upgrade sign` prints a new call hash (not `0x3f56183c…` / prior 80B hash)
- [ ] Final approval executes; Finney → 432

Made with [Cursor](https://cursor.com)