### PR TITLE
fix(commitments): unreserve deposit before dropping registration

### DIFF
--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -538,6 +538,10 @@ impl<T: Config> Pallet<T> {
 
             match registration.info.fields.is_empty() {
                 true => {
+                    // Unreserve the deposit before dropping the Registration: the
+                    // only tracking record of reserved funds is being removed, so
+                    // failing to release here would permanently lock the deposit.
+                    let _ = T::Currency::unreserve(&who, registration.deposit);
                     <CommitmentOf<T>>::remove(netuid, &who);
                     total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
 
@@ -587,6 +591,13 @@ impl<T: Config> Pallet<T> {
 
     pub fn purge_netuid(netuid: NetUid, weight_meter: &mut WeightMeter) -> bool {
         let write_weight = T::DbWeight::get().writes(1);
+
+        // Unreserve deposits before clearing commitment storage: `clear_prefix`
+        // drops every Registration without releasing the funds that were reserved
+        // in `set_commitment`, which would permanently lock them.
+        for (who, reg) in CommitmentOf::<T>::iter_prefix(netuid) {
+            let _ = T::Currency::unreserve(&who, reg.deposit);
+        }
 
         let result = clear_prefix_with_meter(weight_meter, write_weight, |limit| {
             CommitmentOf::<T>::clear_prefix(netuid, limit, None)

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -491,6 +491,42 @@ fn reveal_timelocked_commitment_single_field_entry_is_removed_after_reveal() {
     });
 }
 
+#[test]
+fn audit_probe_reveal_removal_leaves_deposit_reserved() {
+    new_test_ext().execute_with(|| {
+        let who = 555;
+        let netuid = NetUid::from(777);
+        let reveal_round = 1000;
+        let deposit = TaoBalance::from(100);
+        Balances::make_free_balance_be(&who, 1_000.into());
+        assert_ok!(Balances::reserve(&who, deposit));
+
+        let timelock = Data::TimelockEncrypted {
+            encrypted: BoundedVec::try_from(vec![1_u8]).unwrap(),
+            reveal_round,
+        };
+        let registration = Registration::<TaoBalance, TestMaxFields, u64> {
+            deposit,
+            info: CommitmentInfo {
+                fields: BoundedVec::try_from(vec![timelock]).unwrap(),
+            },
+            block: 1,
+        };
+        CommitmentOf::<Test>::insert(netuid, who, registration);
+        TimelockedIndex::<Test>::mutate(|index| {
+            index.insert((netuid, who));
+        });
+        let signature = hex::decode(DRAND_QUICKNET_SIG_HEX).unwrap();
+        insert_drand_pulse(reveal_round, &signature);
+
+        assert_ok!(Pallet::<Test>::reveal_timelocked_commitments());
+
+        assert!(CommitmentOf::<Test>::get(netuid, who).is_none());
+        // After the fix: the deposit is unreserved when the Registration is removed.
+        assert_eq!(Balances::reserved_balance(who), 0u64.into());
+    });
+}
+
 #[allow(clippy::indexing_slicing)]
 #[test]
 fn reveal_timelocked_multiple_fields_only_correct_ones_removed() {


### PR DESCRIPTION
Hi! 👋 I am Loom Agent — an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome — I will do my best to address review comments promptly.

## Release Notes

- Fixed permanently locked deposits in the commitments pallet by unreserving before dropping a Registration in both `reveal_timelocked_commitments` and `purge_netuid`.

## Problem

When `reveal_timelocked_commitments` removes a fully-revealed Registration via `CommitmentOf::remove`, or when `purge_netuid` calls `clear_prefix` on commitment storage, the deposit that was reserved in `set_commitment` is never released. Since the Registration (the only tracking record of the reserved funds) is dropped, the deposit is permanently locked.

## Root Cause

In `pallets/commitments/src/lib.rs`, both `reveal_timelocked_commitments` (empty-fields branch) and `purge_netuid` remove CommitmentOf entries without first calling `T::Currency::unreserve` to release the associated deposit.

## The Fix

- In `reveal_timelocked_commitments`: call `T::Currency::unreserve` before `CommitmentOf::remove` when the fields are empty.
- In `purge_netuid`: iterate all registrations under the netuid prefix and unreserve each deposit before `clear_prefix` drops them.

## Testing

Added `audit_probe_reveal_removal_leaves_deposit_reserved` which verifies that after a timelocked commitment is revealed and removed, the reserved balance is zero. This test fails without the fix (the deposit remains reserved).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Notes

This is a security fix for a silent fund-locking bug. The `purge_netuid` path was also fixed preemptively even though it is not currently called, because it shares the same pattern and would lock deposits if ever invoked.

<!-- loom-pr-create:3a4f971b0d3f08afa6ac39cf30be2bc9d895a8715dc02c2a95f74f1a91b44da0 -->