### PR TITLE
fix(drand): verify pulse randomness matches sha256(signature)

### DIFF
--- a/pallets/drand/src/tests.rs
+++ b/pallets/drand/src/tests.rs
@@ -141,6 +141,61 @@ fn it_rejects_invalid_pulse_due_to_bad_signature() {
 }
 
 #[test]
+fn audit_probe_forged_randomness_rejected() {
+    // A valid BLS signature alone does NOT prove the `randomness` field was
+    // derived from it as drand specifies (randomness = sha256(signature)).
+    // Without the verifier's second check, an attacker can pair a real signature
+    // with a forged randomness and have the pallet store and publish the forged
+    // value. The verifier now returns Ok(false) on the mismatch, so write_pulse
+    // skips storing the forged pulse entirely (the call still succeeds; it is
+    // the absence of storage that proves rejection).
+    new_test_ext().execute_with(|| {
+        let block_number = 100_000_000;
+        let alice = sp_keyring::Sr25519Keyring::Alice;
+        System::set_block_number(block_number);
+
+        let info: BeaconInfoResponse = serde_json::from_str(DRAND_INFO_RESPONSE).unwrap();
+        let config_payload = BeaconConfigurationPayload {
+            block_number,
+            config: info.clone().try_into_beacon_config().unwrap(),
+            public: alice.public(),
+        };
+        assert_ok!(Drand::set_beacon_config(
+            RuntimeOrigin::root(),
+            config_payload,
+            None,
+        ));
+
+        // Seed a baseline so round 1000 is the legitimate next round (== last + 1);
+        // this isolates the test to the randomness check alone.
+        LastStoredRound::<Test>::put(ROUND_NUMBER - 1);
+        OldestStoredRound::<Test>::put(ROUND_NUMBER - 1);
+
+        let response: DrandResponseBody = serde_json::from_str(DRAND_PULSE).unwrap();
+        let mut pulse = response.try_into_pulse().unwrap();
+        // Forge the randomness while keeping the real (BLS-valid) signature.
+        pulse.randomness = BoundedVec::try_from(vec![0x42; 32]).unwrap();
+
+        let pulses_payload = PulsesPayload {
+            pulses: vec![pulse.clone()],
+            block_number,
+            public: alice.public(),
+        };
+
+        // Dispatch reaches the verifier (its only call site). The forged
+        // randomness makes it return Ok(false), so the pulse is not stored.
+        assert_ok!(Drand::write_pulse(
+            RuntimeOrigin::none(),
+            pulses_payload,
+            None,
+        ));
+        assert!(Pulses::<Test>::get(ROUND_NUMBER).is_none());
+        // No state advanced for the rejected pulse.
+        assert_eq!(LastStoredRound::<Test>::get(), ROUND_NUMBER - 1);
+    });
+}
+
+#[test]
 fn it_rejects_pulses_with_non_incremental_round_numbers() {
     new_test_ext().execute_with(|| {
         let block_number = 100_000_000;

--- a/pallets/drand/src/verifier.rs
+++ b/pallets/drand/src/verifier.rs
@@ -93,6 +93,17 @@ impl Verifier for QuicknetVerifier {
 
         let g2 = G2AffineOpt::generator();
 
+        // The BLS pairing check only validates that `signature` is a valid
+        // signature for the round number.  It does NOT verify that the
+        // `randomness` field was derived from the signature as drand specifies
+        // (randomness = sha256(signature)).  Without this second check, an
+        // attacker can submit a real signature with a forged `randomness` and
+        // bias the pallet's published randomness.
+        let expected_randomness: [u8; 32] = Sha256::digest(pulse.signature.into_inner().as_slice()).into();
+        if pulse.randomness.as_slice() != expected_randomness.as_slice() {
+            return Ok(false);
+        }
+
         Ok(bls12_381::fast_pairing_opt(
             signature.0,
             g2,


### PR DESCRIPTION
Hi! 👋 I am Loom Agent — an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome — I will do my best to address review comments promptly.

## Release Notes

- Fixed a randomness-injection attack on the drand pallet where a valid BLS signature paired with a forged `randomness` field could bias the pallet's published randomness.

## Problem

The drand protocol specifies that `randomness = sha256(signature)`. The pallet's `QuicknetVerifier` only checks the BLS signature validity against the round number; it does not verify that the `randomness` field was derived from the signature. An attacker can submit a real drand signature with a forged `randomness` value, and the pallet will accept and store it, biasing or fully controlling the randomness used by downstream consumers.

## Root Cause

In `pallets/drand/src/verifier.rs`, the `QuicknetVerifier::verify` method returns `Ok(true)` based solely on the BLS pairing check. The `randomness` field is never validated against `sha256(signature)`.

## The Fix

Add a second check in `QuicknetVerifier::verify`: compute `sha256(signature)` and compare it against `pulse.randomness`. Return `Ok(false)` on mismatch, which causes `write_pulse` to skip storing the forged pulse without erroring the extrinsic.

## Testing

Added `audit_probe_forged_randomness_rejected` which submits a valid drand signature paired with a forged `randomness` (32 bytes of 0x42). The test verifies that the pulse is NOT stored in `Pulses` and `LastStoredRound` is not advanced, confirming the forged pulse was rejected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- loom-pr-create:1a7498b87f5368c2ba4164cb5253a25f1704998e0ce67dbb8ee79e8985c463f3 -->