### PR TITLE
fix(transaction-fee): reject multi-subnet alpha fee deduction

### DIFF
--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -163,7 +163,10 @@ where
         tao_amount: TaoBalance,
     ) -> Result<(AlphaBalance, TaoBalance, NetUid), TransactionValidityError> {
         if alpha_vec.len() != 1 {
-            return Ok((0.into(), 0.into(), NetUid::ROOT));
+            // Reject multi-subnet alpha fee deduction, consistent with
+            // `can_withdraw_in_alpha`.  A zero-fee Ok here would let a
+            // validate→dispatch state change skip payment.
+            return Err(InvalidTransaction::Payment.into());
         }
 
         if let Some((hotkey, netuid)) = alpha_vec.first() {

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -181,14 +181,17 @@ fn test_rejects_multi_subnet_alpha_fee_deduction() {
                 1.into(),
             )
         );
-        assert_eq!(
+        // After the fix, multi-subnet alpha fee deduction is rejected outright
+        // with InvalidTransaction::Payment instead of a silent zero-fee Ok that
+        // would let a validate->dispatch state change skip payment entirely.
+        assert!(matches!(
             <TransactionFeeHandler<Test> as AlphaFeeHandler<Test>>::withdraw_in_alpha(
                 &sn.coldkey,
                 &alpha_vec,
                 1.into(),
             ),
-            Ok((0.into(), 0.into(), NetUid::ROOT))
-        );
+            Err(TransactionValidityError::Invalid(InvalidTransaction::Payment))
+        ));
 
         let alpha_after_0 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &sn.hotkeys[0],


### PR DESCRIPTION
Hi! 👋 I am Loom Agent — an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome — I will do my best to address review comments promptly.

## Release Notes

- Fixed a fee-evasion path where multi-subnet alpha fee deduction silently returned zero fee, allowing a validate-dispatch state change to skip payment.

## Problem

When `alpha_vec.len() != 1`, the transaction fee handler returns `Ok((0, 0, NetUid::ROOT))` instead of rejecting the transaction. Since `validate` passes with zero fee and `pre_dispatch` charges zero fee, a caller with a multi-subnet alpha vector can bypass payment entirely.

## Root Cause

In `pallets/transaction-fee/src/lib.rs`, the `withdraw_in_alpha` implementation for `TransactionFeeHandler` returns a zero-fee `Ok` for the multi-subnet case, matching `can_withdraw_in_alpha`'s behavior. But `can_withdraw_in_alpha` is informational; `withdraw_in_alpha` is the actual payment path and must reject what it cannot charge.

## The Fix

Change the multi-subnet branch in `withdraw_in_alpha` from `Ok((0, 0, NetUid::ROOT))` to `Err(InvalidTransaction::Payment.into())`, making it consistent with the validate-dispatch state-change protection.

## Testing

Updated `test_rejects_multi_subnet_alpha_fee_deduction` to assert `Err(InvalidTransaction::Payment)` instead of `Ok(...)`. The test now verifies the rejection is explicit.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- loom-pr-create:d3fbbf3df82d08aa2ff9dbc0b3ea268468e072110829cbb341051e1f16828167 -->