### PR TITLE
One-time v432 recovery: stamp SDK 11.0.0 in the stable PyPI publish

### DIFF
--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -238,6 +238,19 @@ jobs:
         with:
           ref: ${{ needs.check.outputs.sha }}
 
+      # One-time v432 recovery: the deployed commit was tagged with the SDK
+      # version still at its 11.0.0.dev0 placeholder, so building it as-is
+      # cannot produce the intended stable release. Stamp 11.0.0 before the
+      # build. Scoped to the exact released commit so this is inert for every
+      # other release; remove once v432 is published.
+      - name: Stamp stable SDK version (v432 recovery)
+        if: needs.check.outputs.spec_version == '432' && needs.check.outputs.sha == '8586e65ec279644a6837cf25b12333064c77474e'
+        run: |
+          sed -i '0,/^version = ".*"/s//version = "11.0.0"/' sdk/python/pyproject.toml
+          grep -qx 'version = "11.0.0"' sdk/python/pyproject.toml \
+            || { echo "failed to stamp sdk/python/pyproject.toml"; exit 1; }
+          echo "bittensor version stamped to 11.0.0"
+
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
@@ -253,6 +266,24 @@ jobs:
       - name: Build SDK wheel and sdist
         working-directory: sdk/python
         run: uv build --out-dir ../../dist
+
+      # Second half of the v432 recovery: refuse to publish anything but the
+      # intended stable artifacts, so a failed stamp can never leak
+      # 11.0.0.dev0 to PyPI.
+      - name: Verify stable artifacts (v432 recovery)
+        if: needs.check.outputs.spec_version == '432' && needs.check.outputs.sha == '8586e65ec279644a6837cf25b12333064c77474e'
+        run: |
+          ls -la dist
+          test -f dist/bittensor-11.0.0-py3-none-any.whl
+          test -f dist/bittensor-11.0.0.tar.gz
+          compgen -G 'dist/bittensor_core-0.1.0-*.whl' >/dev/null
+          test -f dist/bittensor_core-0.1.0.tar.gz
+          for f in dist/*; do
+            # *0rc* not *rc*: "aarch64" in wheel platform tags contains "rc"
+            case "$f" in
+              *dev*|*0rc*) echo "unexpected pre-release artifact: $f"; exit 1 ;;
+            esac
+          done
 
       # PEP 740 provenance: sign every dist with this job's OIDC identity.
       # Must happen here, not in build-core-wheels.yml — PyPI only accepts


### PR DESCRIPTION
## Summary

- Mainnet runtime v432 shipped from 8586e65e, but the SDK source at that commit still says `version = "11.0.0.dev0"`, so the watcher's `publish-sdk` job can only produce a dev version — PyPI never received the stable `bittensor==11.0.0`.
- Adds a stamp step to `publish-sdk` that rewrites the SDK version to `11.0.0` after checking out the released commit, hard-scoped to spec 432 at exactly sha 8586e65e (inert for every other release).
- Adds a verify step (same scope) that asserts `dist/` contains exactly the stable `bittensor 11.0.0` and `bittensor_core 0.1.0` artifacts and fails on any dev/rc file, so a broken stamp can never leak `11.0.0.dev0`.
- `bittensor-core` needs no stamping: it is committed at `0.1.0`.
- Temporary by design; remove after v432 publishes. The permanent flow fix is #2944.

## Test plan

- [x] actionlint: no new findings (remaining SC2086 infos are pre-existing)
- [x] Rehearsed the stamp + `uv build` locally against the extracted 8586e65e SDK source: wheel/sdist metadata reads `bittensor 11.0.0`, `Requires-Dist: bittensor-core<0.2.0,>=0.1.0`
- [x] Verified guard patterns accept the real wheel names (incl. `aarch64`, which contains "rc") and reject dev/rc versions
- [ ] Dispatch watcher from main, approve mainnet environment, confirm `bittensor==11.0.0` and `bittensor-core==0.1.0` land on PyPI and v432 is promoted to a full release

Made with [Cursor](https://cursor.com)