### PR TITLE
Fix Vercel deploys: archive uploads that exceed the 15k-file limit

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -56,12 +56,14 @@ jobs:
           if [ "${{ inputs.production }}" = "true" ]; then
             npx --yes vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
             npx --yes vercel build --prod --token "$VERCEL_TOKEN"
-            npx --yes vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN"
+            # --archive=tgz: the prebuilt output exceeds Vercel's 15k-file
+            # upload limit (the generated docs tree alone is >30k files).
+            npx --yes vercel deploy --prebuilt --prod --archive=tgz --token "$VERCEL_TOKEN"
             echo "Deployed to https://$DOCS_DOMAIN (production)" >> $GITHUB_STEP_SUMMARY
           else
             npx --yes vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
             npx --yes vercel build --token "$VERCEL_TOKEN"
-            url=$(npx --yes vercel deploy --prebuilt --token "$VERCEL_TOKEN")
+            url=$(npx --yes vercel deploy --prebuilt --archive=tgz --token "$VERCEL_TOKEN")
             echo "Deployed: $url"
             # `vercel alias set` only accepts domains in the team-level domain
             # registry; staging.$DOCS_DOMAIN is attached (and verified) at the

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -367,4 +367,6 @@ jobs:
         run: |
           npx --yes vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
           npx --yes vercel build --prod --token "$VERCEL_TOKEN"
-          npx --yes vercel deploy --prebuilt --prod --token "$VERCEL_TOKEN"
+          # --archive=tgz: the prebuilt output exceeds Vercel's 15k-file
+          # upload limit (the generated docs tree alone is >30k files).
+          npx --yes vercel deploy --prebuilt --prod --archive=tgz --token "$VERCEL_TOKEN"


### PR DESCRIPTION
## Summary

- Every `deploy-docs.yml` staging deploy since #2895 and the `promote-website` job in the v432 release run fail with `files should NOT have more than 15000 items, received 31633` — the generated docs tree has outgrown Vercel's per-file upload limit.
- Adds `--archive=tgz` to all three `vercel deploy --prebuilt` invocations (staging, docs production, post-release promotion), per Vercel's own guidance in the error message.

## Test plan

- [ ] Merge, then re-dispatch `deploy-docs.yml` with `production=true` to complete the v432 website promotion

Made with [Cursor](https://cursor.com)