### PR TITLE
Stop publishing workspace crates to crates.io

### DIFF
--- a/pallets/limit-orders/Cargo.toml
+++ b/pallets/limit-orders/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-limit-orders"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/pallets/proxy/Cargo.toml
+++ b/pallets/proxy/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-subtensor-proxy"
+publish = false
 version = "40.1.0"
 authors = ["Bittensor Nucleus Team"]
 edition.workspace = true

--- a/pallets/swap/Cargo.toml
+++ b/pallets/swap/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-subtensor-swap"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/pallets/swap/rpc/Cargo.toml
+++ b/pallets/swap/rpc/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-subtensor-swap-rpc"
+publish = false
 version = "1.0.0"
 description = "RPC interface for the Swap pallet"
 edition.workspace = true

--- a/pallets/swap/runtime-api/Cargo.toml
+++ b/pallets/swap/runtime-api/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-subtensor-swap-runtime-api"
+publish = false
 version = "1.0.0"
 description = "Runtime API for the Swap pallet"
 edition.workspace = true

--- a/pallets/transaction-fee/Cargo.toml
+++ b/pallets/transaction-fee/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-transaction-fee"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/pallets/utility/Cargo.toml
+++ b/pallets/utility/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pallet-subtensor-utility"
+publish = false
 version = "40.0.0"
 edition.workspace = true
 license = "Apache-2.0"

--- a/primitives/safe-math/Cargo.toml
+++ b/primitives/safe-math/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "safe-math"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/primitives/share-pool/Cargo.toml
+++ b/primitives/share-pool/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "share-pool"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/primitives/swap-interface/Cargo.toml
+++ b/primitives/swap-interface/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-swap-interface"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/support/linting/Cargo.toml
+++ b/support/linting/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-linting"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 

--- a/support/macros/Cargo.toml
+++ b/support/macros/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-macros"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"

--- a/support/procedural-fork/Cargo.toml
+++ b/support/procedural-fork/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "procedural-fork"
+publish = false
 version = "1.10.0-rc3"
 edition.workspace = true
 

--- a/support/tools/Cargo.toml
+++ b/support/tools/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-tools"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"

--- a/support/weight-tools/Cargo.toml
+++ b/support/weight-tools/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "subtensor-weight-tools"
+publish = false
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"


### PR DESCRIPTION
## Summary

- The `publish-crates` job in `watch-mainnet-release.yml` fails on every release: after `subtensor-macros`, the next crate (`pallet-subtensor-utility`) is rejected with `dependency frame-benchmarking does not specify a version` — all remaining publishable crates depend on the patched `RaoFoundation/polkadot-sdk` fork via git, which crates.io categorically refuses.
- The workflow's own design comment says crates should stay `publish = false` while they depend on the fork; 15 crates violated that. This sets `publish = false` on all of them, making the release job a clean no-op ("No publishable crates in the workspace; skipping.").
- No consumer impact: Rust users build against this repo as a git dependency; `subtensor-macros 0.1.0` remains on crates.io as already published.

## Test plan

- [x] `cargo metadata` confirms no package remains publishable

Made with [Cursor](https://cursor.com)