### PR TITLE
ci: publish main Docker image on merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,17 @@
 name: Publish Docker Image
 
-# Node images publish when a network mirror moves, on runtime releases, and on
-# demand. Releases cut by watch-mainnet-release.yml use the default
-# GITHUB_TOKEN, which never emits `release: published`; the watcher therefore
-# dispatches this workflow directly with the release tag. Release-version tags
-# (vN) move :latest; network mirror tags do not.
+# Node images publish whenever main or a network mirror moves, on runtime
+# releases, and on demand. Main advances the development-facing :main tag.
+# Releases cut by watch-mainnet-release.yml use the default GITHUB_TOKEN, which
+# never emits `release: published`; the watcher therefore dispatches this
+# workflow directly with the release tag. Release-version tags (vN) move
+# :latest; branch tags do not.
 
 on:
   release:
     types: [published]
   push:
-    branches: [devnet, testnet]
+    branches: [main, devnet, testnet]
   workflow_dispatch:
     inputs:
       tag:

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -92,9 +92,12 @@ mainnet*, not what was merged.
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another
 workflow event. The production build publishes both the immutable release tag
-and `:latest`. The localnet build publishes the immutable release tag in its
-separate package; localnet `:latest` remains an alias for the current `:main`
-branch image, while `:devnet` and `:testnet` follow their respective branches.
+and `:latest`. Independently, every merge to `main` publishes the moving
+production `:main` tag, so developers can prepare against merged features
+before they reach mainnet without changing the deployed `:latest` image. The
+localnet build publishes the immutable release tag in its separate package;
+localnet `:latest` remains an alias for the current `:main` branch image, while
+`:devnet` and `:testnet` follow their respective branches.
 
 ## Hotfixes
 


### PR DESCRIPTION
## Summary

- publish `ghcr.io/raofoundation/subtensor:main` on every push to `main`
- keep `:latest` tied to runtime release/deployment publication
- document the distinction between merged-development and deployed image tags

## Why

Developers need an image containing features already merged to `main` while `:latest` must continue to represent the code released after mainnet deployment. The two moving tags now carry those separate contracts.

## Validation

- parsed `.github/workflows/docker.yml` as YAML
- verified tag policy cases: `main` does not move `latest`; release and dispatched `vN` tags do
- `git diff --check`