### PR TITLE
ci: harden trusted docs-preview deployment

### DIFF
--- a/.github/docs-preview-vercel/package-lock.json
+++ b/.github/docs-preview-vercel/package-lock.json
@@ -1,0 +1,4350 @@
+{
+  "name": "subtensor-docs-preview-vercel-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "subtensor-docs-preview-vercel-cli",
+      "version": "1.0.0",
+      "dependencies": {
+        "vercel": "56.4.1"
+      }
+    },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.6.tgz",
+      "integrity": "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==",
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@edge-runtime/format": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
+      "integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/node-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
+      "integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/ponyfill": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
+      "integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/vm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.2.0.tgz",
+      "integrity": "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.2.0",
+        "@napi-rs/keyring-darwin-x64": "1.2.0",
+        "@napi-rs/keyring-freebsd-x64": "1.2.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.2.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.2.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.2.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.2.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.2.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.2.0.tgz",
+      "integrity": "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.2.0.tgz",
+      "integrity": "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.2.0.tgz",
+      "integrity": "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.2.0.tgz",
+      "integrity": "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.2.0.tgz",
+      "integrity": "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.2.0.tgz",
+      "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.2.0.tgz",
+      "integrity": "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.2.0.tgz",
+      "integrity": "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.2.0.tgz",
+      "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.2.0.tgz",
+      "integrity": "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.2.0.tgz",
+      "integrity": "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.2.0.tgz",
+      "integrity": "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.110.0.tgz",
+      "integrity": "sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-transform/binding-android-arm-eabi": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.111.0.tgz",
+      "integrity": "sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-android-arm64": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.111.0.tgz",
+      "integrity": "sha512-J2v9ajarD2FYlhHtjbgZUFsS2Kvi27pPxDWLGCy7i8tO60xBoozX9/ktSgbiE/QsxKaUhfv4zVKppKWUo71PmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-arm64": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.111.0.tgz",
+      "integrity": "sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-x64": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.111.0.tgz",
+      "integrity": "sha512-c4YRwfLV8Pj/ToiTCbndZaHxM2BD4W3bltr/fjXZcGypEK+U2RZFDL7tIZYT/tyneAC9hCORZKDaKhLLNuzPtA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-freebsd-x64": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.111.0.tgz",
+      "integrity": "sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.111.0.tgz",
+      "integrity": "sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.111.0.tgz",
+      "integrity": "sha512-8faC99pStqaSDPK/vBgaagAHUeL0LcIzfeSjSiDTtvPGc3AwZIeqC1tx3CP15a6tWXjdgS/IUw4IjfD5HweBlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.111.0.tgz",
+      "integrity": "sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-musl": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.111.0.tgz",
+      "integrity": "sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.111.0.tgz",
+      "integrity": "sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.111.0.tgz",
+      "integrity": "sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.111.0.tgz",
+      "integrity": "sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.111.0.tgz",
+      "integrity": "sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-gnu": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.111.0.tgz",
+      "integrity": "sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-musl": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.111.0.tgz",
+      "integrity": "sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-openharmony-arm64": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.111.0.tgz",
+      "integrity": "sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-wasm32-wasi": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.111.0.tgz",
+      "integrity": "sha512-HtyIZO8IwuZgXkyb56rysLz1OLbfLhEu8A3BeuyJXzUseAj96yuxgGt3cu3QYX9AXb9pfRfA3c/fvlhsDugyTQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.111.0.tgz",
+      "integrity": "sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.111.0.tgz",
+      "integrity": "sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-x64-msvc": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.111.0.tgz",
+      "integrity": "sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@renovatebot/pep440": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@renovatebot/pep440/-/pep440-4.2.1.tgz",
+      "integrity": "sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0 || ^24",
+        "pnpm": "^10.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.1.tgz",
+      "integrity": "sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.1.tgz",
+      "integrity": "sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.1.tgz",
+      "integrity": "sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.1.tgz",
+      "integrity": "sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.1.tgz",
+      "integrity": "sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.1.tgz",
+      "integrity": "sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.1.tgz",
+      "integrity": "sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.1.tgz",
+      "integrity": "sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.1.tgz",
+      "integrity": "sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.1.tgz",
+      "integrity": "sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.1.tgz",
+      "integrity": "sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.1.tgz",
+      "integrity": "sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.1.tgz",
+      "integrity": "sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.1.tgz",
+      "integrity": "sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vercel/backends": {
+      "version": "0.8.25",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.25.tgz",
+      "integrity": "sha512-x+Amcl3weuQ0nUk3UcVpdD++jHoHbI1YZDLSJCXVC9iLrtUy1QzSJRb29cWMHtX+ixAjWXhVqd720xcU7PZfTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/build-utils": "13.34.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
+        "execa": "3.2.0",
+        "fs-extra": "11.1.0",
+        "get-port": "5.1.1",
+        "oxc-transform": "0.111.0",
+        "path-to-regexp": "8.3.0",
+        "resolve.exports": "2.0.3",
+        "rolldown": "1.0.0-rc.1",
+        "srvx": "0.11.16",
+        "ts-morph": "12.0.0",
+        "tsx": "4.21.0",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@vercel/backends/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/build-utils": {
+      "version": "13.34.0",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.34.0.tgz",
+      "integrity": "sha512-DhbYXymwjO6N3prqBf7UzQFNpQIcHabe1qbiXxqqfjDJ5Tca9+MMYnU/+uObHrPBfR9FAXMxAwmkIUw59zJ7cw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/python-analysis": "0.11.1",
+        "cjs-module-lexer": "1.2.3",
+        "es-module-lexer": "1.5.0"
+      }
+    },
+    "node_modules/@vercel/cervel": {
+      "version": "0.1.33",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.33.tgz",
+      "integrity": "sha512-osM85mDIVLOUt+ngSBRXpruKuxPgRFi7JR0JbFzdF95VwFsDo2fryUyqPis5yRJA4SkteZK6eADtrj6Vj9W76Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/backends": "0.8.25"
+      },
+      "bin": {
+        "cervel": "bin/cervel.mjs"
+      }
+    },
+    "node_modules/@vercel/cli-auth": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-auth/-/cli-auth-0.3.0.tgz",
+      "integrity": "sha512-9nsdxUpV/L+9CBVGeRw/Qby2azhi2lk01jp0aTH+Hxx2U61+mAmbi5qChHnrbEmQdx2Ih7dp4LxO3nj1Q7f/5Q==",
+      "dependencies": {
+        "@napi-rs/keyring": "1.2.0",
+        "@vercel/cli-config": "0.2.0",
+        "async-listen": "3.0.0",
+        "open": "8.4.0",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/container": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@vercel/container/-/container-0.0.5.tgz",
+      "integrity": "sha512-kYggcjyTsBKbQi3wM647x6g174OrriK9oNQ/KI9LGAwBKqZ75g4zir88cNO3FcLiA6RJ4pQe74wyAisxhDgR5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/detect-agent": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.3.tgz",
+      "integrity": "sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@vercel/elysia": {
+      "version": "0.1.102",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.102.tgz",
+      "integrity": "sha512-FyYhX6UKcRaBhsR1wsn6nGxKif406ymQkvbYXsMvBBIB1SXbvLVcczINJrG525kjcffWk+28VttJG8jzQsWP6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0"
+      }
+    },
+    "node_modules/@vercel/error-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.0.tgz",
+      "integrity": "sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/express": {
+      "version": "0.1.116",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.116.tgz",
+      "integrity": "sha512-gedcLxHIE4PIJa3iLMiSt5XDd85/1k/5Fp+jmuoh/MZh9aNqZLLC9LpgJRmFGHffKp6C1YeDL+WUVEiLRBqarA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cervel": "0.1.33",
+        "@vercel/nft": "1.10.0",
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0",
+        "fs-extra": "11.1.0",
+        "path-to-regexp": "8.3.0",
+        "ts-morph": "12.0.0",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@vercel/express/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/fastify": {
+      "version": "0.1.105",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.105.tgz",
+      "integrity": "sha512-GQshcPm/4zQQhq3c+ZOQALoURFxWiYjt8mxQdBB8jADP0pkXGQqAL7Lah7sMq9JDTAjO7fp0m9QTnolTwlUomA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0"
+      }
+    },
+    "node_modules/@vercel/fun": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/fun/-/fun-1.3.0.tgz",
+      "integrity": "sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tootallnate/once": "2.0.0",
+        "async-listen": "1.2.0",
+        "debug": "4.3.4",
+        "generic-pool": "3.4.2",
+        "micro": "9.3.5-canary.3",
+        "ms": "2.1.1",
+        "node-fetch": "2.6.7",
+        "path-to-regexp": "8.2.0",
+        "promisepipe": "3.0.0",
+        "semver": "7.5.4",
+        "stat-mode": "0.3.0",
+        "stream-to-promise": "2.2.0",
+        "tar": "7.5.7",
+        "tinyexec": "0.3.2",
+        "tree-kill": "1.2.2",
+        "uid-promise": "1.0.0",
+        "xdg-app-paths": "5.1.0",
+        "yauzl-promise": "2.1.3"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/fun/node_modules/async-listen": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-1.2.0.tgz",
+      "integrity": "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/fun/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/fun/node_modules/xdg-app-paths": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
+      "integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "xdg-portable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/gatsby-plugin-vercel-analytics": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-analytics/-/gatsby-plugin-vercel-analytics-1.0.11.tgz",
+      "integrity": "sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "web-vitals": "0.2.4"
+      }
+    },
+    "node_modules/@vercel/gatsby-plugin-vercel-builder": {
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.28.tgz",
+      "integrity": "sha512-bchletKw9NBeTkShh8qrr+MmHomPSw4VtYVYB+T2KsDXuMOdTTDAB2txYXRAyVqnOLAwG+GWjVdyXB9mGdWOHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sinclair/typebox": "0.25.24",
+        "@vercel/build-utils": "13.34.0",
+        "esbuild": "0.27.0",
+        "etag": "1.8.1",
+        "fs-extra": "11.1.0"
+      }
+    },
+    "node_modules/@vercel/go": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.10.2.tgz",
+      "integrity": "sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/h3": {
+      "version": "0.1.111",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.111.tgz",
+      "integrity": "sha512-k/klevIqGcn+p1j0uNWf1UskbZATwubNXpSwaZXb+HW3zGx6sgoSlR4L0+fIUSWlWwBroHhNauKeG0ZoTFHobg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0"
+      }
+    },
+    "node_modules/@vercel/hono": {
+      "version": "0.2.105",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.105.tgz",
+      "integrity": "sha512-F8QHB2gAL/zXaNj2peVkrwpkqlUgkV0DCb4fOYt1CuCesHFLSPfhkl/gO6wjGOmqDIpBAE9lOaWm8AzLWunZ1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/nft": "1.10.0",
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0",
+        "fs-extra": "11.1.0",
+        "path-to-regexp": "8.3.0",
+        "ts-morph": "12.0.0",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@vercel/hono/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/hydrogen": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.4.0.tgz",
+      "integrity": "sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/static-config": "3.4.0",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/koa": {
+      "version": "0.1.85",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.85.tgz",
+      "integrity": "sha512-9388s1YZuPlrmcTyZiJ1EKikab1o4h8C/TKi7uqvSMPDT4q829QdiAmVpjdKl06FcuypzibMsZlB5XZbosxtfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0"
+      }
+    },
+    "node_modules/@vercel/nestjs": {
+      "version": "0.2.106",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.106.tgz",
+      "integrity": "sha512-dg1ld/FCYUnfiMUwf5P+Z87V2chVLgwETeQTSDocI3gIztIlqHBoPw5CCboprsjHs39TRSFhugYQMJJlq9C3hg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/node": "5.8.26",
+        "@vercel/static-config": "3.4.0"
+      }
+    },
+    "node_modules/@vercel/next": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.20.4.tgz",
+      "integrity": "sha512-8m39IHTAgO5yE9xAW8lnjv01z8qQ/qm1FWqyg46qBH2GPtn0MHEME2tAbRy+XzV0Q2J/KGSwmH4xFq8FgECAfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/nft": "1.10.0"
+      }
+    },
+    "node_modules/@vercel/nft": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.0.tgz",
+      "integrity": "sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@vercel/node": {
+      "version": "5.8.26",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.26.tgz",
+      "integrity": "sha512-Vh7V6aWgUtzMLqd+n7K4O4KzXjB9UxV71OGCp5NODPqHvjpbavwjUfPlnKAXyZTZxQrbp+HHv+mL/6J8ezB8Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edge-runtime/node-utils": "2.3.0",
+        "@edge-runtime/primitives": "4.1.0",
+        "@edge-runtime/vm": "3.2.0",
+        "@types/node": "20.11.0",
+        "@vercel/build-utils": "13.34.0",
+        "@vercel/error-utils": "2.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
+        "async-listen": "3.0.0",
+        "cjs-module-lexer": "1.2.3",
+        "edge-runtime": "2.5.9",
+        "es-module-lexer": "1.4.1",
+        "esbuild": "0.27.0",
+        "etag": "1.8.1",
+        "mime-types": "2.1.35",
+        "node-fetch": "2.6.9",
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
+        "ts-morph": "12.0.0",
+        "tsx": "4.21.0",
+        "typescript": "npm:typescript@5.9.3",
+        "undici": "5.28.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/node/node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/prepare-flags-definitions": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vercel/prepare-flags-definitions/-/prepare-flags-definitions-0.3.0.tgz",
+      "integrity": "sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/python": {
+      "version": "6.51.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.51.0.tgz",
+      "integrity": "sha512-81n05giwRNXwp7UZQbDoSHv8XhQTsFRfQnlFSaITmsWA8MVl1t1XJrrHSNswiRm+hceWzHxBZxE0ysfWXs4AQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/python-analysis": "0.11.1"
+      }
+    },
+    "node_modules/@vercel/python-analysis": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.1.tgz",
+      "integrity": "sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "0.17.6",
+        "@renovatebot/pep440": "4.2.1",
+        "fs-extra": "11.1.1",
+        "js-yaml": "4.1.1",
+        "minimatch": "10.1.1",
+        "smol-toml": "1.5.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@vercel/python-analysis/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@vercel/python-analysis/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/redwood": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.5.0.tgz",
+      "integrity": "sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
+        "semver": "6.3.1",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/redwood/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@vercel/remix-builder": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.9.1.tgz",
+      "integrity": "sha512-s0SpfV640nmQ1BsKCPMYugGrH/V+319onTo2ZILSmsy6NTBlmeN0zJU9nPcP8dBEotGqtp68NfOlOUUdrVBzkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/error-utils": "2.2.0",
+        "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.0",
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/remix-builder/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/ruby": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.5.1.tgz",
+      "integrity": "sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/rust": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.4.0.tgz",
+      "integrity": "sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5",
+        "get-port": "5.1.1",
+        "smol-toml": "1.5.2"
+      }
+    },
+    "node_modules/@vercel/rust/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@vercel/rust/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/rust/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@vercel/rust/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/sandbox": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.4.0.tgz",
+      "integrity": "sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0",
+        "@workflow/serde": "4.1.0-beta.2",
+        "async-retry": "1.3.3",
+        "jose": "6.2.3",
+        "jsonlines": "0.1.1",
+        "ms": "2.1.3",
+        "picocolors": "^1.1.1",
+        "tar-stream": "3.1.7",
+        "undici": "^7.27.1",
+        "xdg-app-paths": "5.1.0",
+        "zod": "^4.1.1"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/sandbox/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/sandbox/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/xdg-app-paths": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
+      "integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "xdg-portable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/static-build": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.11.8.tgz",
+      "integrity": "sha512-5XpF+D61dwJIXA7eBLNLtVWyiZYqGFBwLsWnK694yp6Yg0eu/q5trqHLxSvIcpR/DbWDbfJiyVQy/r2UIIAblg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
+        "@vercel/gatsby-plugin-vercel-builder": "2.2.28",
+        "@vercel/static-config": "3.4.0",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/static-config": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.0.tgz",
+      "integrity": "sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.6.3",
+        "json-schema-to-ts": "1.6.4",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
+      "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "license": "MIT"
+    },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/edge-runtime": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
+      "integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/format": "2.2.1",
+        "@edge-runtime/ponyfill": "2.4.2",
+        "@edge-runtime/vm": "3.2.0",
+        "async-listen": "3.0.1",
+        "mri": "1.2.0",
+        "picocolors": "1.0.0",
+        "pretty-ms": "7.0.1",
+        "signal-exit": "4.0.2",
+        "time-span": "4.0.0"
+      },
+      "bin": {
+        "edge-runtime": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/async-listen": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
+      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-intercept": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/events-intercept/-/events-intercept-2.0.0.tgz",
+      "integrity": "sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==",
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-3.2.0.tgz",
+      "integrity": "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.4.2.tgz",
+      "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
+      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ts-toolbelt": "^6.15.5"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micro": {
+      "version": "9.3.5-canary.3",
+      "resolved": "https://registry.npmjs.org/micro/-/micro-9.3.5-canary.3.tgz",
+      "integrity": "sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==",
+      "license": "MIT",
+      "dependencies": {
+        "arg": "4.1.0",
+        "content-type": "1.0.4",
+        "raw-body": "2.4.1"
+      },
+      "bin": {
+        "micro": "bin/micro.js"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/oxc-transform": {
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.111.0.tgz",
+      "integrity": "sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-transform/binding-android-arm-eabi": "0.111.0",
+        "@oxc-transform/binding-android-arm64": "0.111.0",
+        "@oxc-transform/binding-darwin-arm64": "0.111.0",
+        "@oxc-transform/binding-darwin-x64": "0.111.0",
+        "@oxc-transform/binding-freebsd-x64": "0.111.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.111.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.111.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.111.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.111.0",
+        "@oxc-transform/binding-linux-ppc64-gnu": "0.111.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.111.0",
+        "@oxc-transform/binding-linux-riscv64-musl": "0.111.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.111.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.111.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.111.0",
+        "@oxc-transform/binding-openharmony-arm64": "0.111.0",
+        "@oxc-transform/binding-wasm32-wasi": "0.111.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.111.0",
+        "@oxc-transform/binding-win32-ia32-msvc": "0.111.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.111.0"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/promisepipe": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/promisepipe/-/promisepipe-3.0.0.tgz",
+      "integrity": "sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.1.tgz",
+      "integrity": "sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.110.0",
+        "@rolldown/pluginutils": "1.0.0-rc.1"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.1",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.1",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.1",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.1"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sandbox": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.4.0.tgz",
+      "integrity": "sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/sandbox": "2.4.0",
+        "async-retry": "1.3.3",
+        "debug": "^4.4.1",
+        "ws": "^8.21.0",
+        "zod": "^4.1.1"
+      },
+      "bin": {
+        "sandbox": "bin/sandbox.mjs",
+        "sbx": "bin/sandbox.mjs"
+      }
+    },
+    "node_modules/sandbox/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sandbox/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/srvx": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
+      "integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
+      "license": "MIT",
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
+      "integrity": "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==",
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "node_modules/stream-to-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-2.2.0.tgz",
+      "integrity": "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==",
+      "deprecated": "Deprecated. Use node:stream/promises and node:stream/consumers instead.",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "~1.3.0",
+        "end-of-stream": "~1.1.0",
+        "stream-to-array": "~2.3.0"
+      }
+    },
+    "node_modules/stream-to-promise/node_modules/end-of-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+      "integrity": "sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/stream-to-promise/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
+      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uid-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid-promise/-/uid-promise-1.0.0.tgz",
+      "integrity": "sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vercel": {
+      "version": "56.4.1",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-56.4.1.tgz",
+      "integrity": "sha512-+CIEa0qcKm1RNBRhOvpo2l/yz28LMKSDuGeAYGx4/EkYyR5VOrXJZYV52WvqVARcxBAbH3Un2RRin8YGXMlcNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/backends": "0.8.25",
+        "@vercel/blob": "2.4.0",
+        "@vercel/build-utils": "13.34.0",
+        "@vercel/cli-auth": "0.3.0",
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/container": "0.0.5",
+        "@vercel/detect-agent": "1.2.3",
+        "@vercel/elysia": "0.1.102",
+        "@vercel/express": "0.1.116",
+        "@vercel/fastify": "0.1.105",
+        "@vercel/fun": "1.3.0",
+        "@vercel/go": "3.10.2",
+        "@vercel/h3": "0.1.111",
+        "@vercel/hono": "0.2.105",
+        "@vercel/hydrogen": "1.4.0",
+        "@vercel/koa": "0.1.85",
+        "@vercel/nestjs": "0.2.106",
+        "@vercel/next": "4.20.4",
+        "@vercel/node": "5.8.26",
+        "@vercel/prepare-flags-definitions": "0.3.0",
+        "@vercel/python": "6.51.0",
+        "@vercel/redwood": "2.5.0",
+        "@vercel/remix-builder": "5.9.1",
+        "@vercel/ruby": "2.5.1",
+        "@vercel/rust": "1.4.0",
+        "@vercel/static-build": "2.11.8",
+        "chokidar": "4.0.0",
+        "esbuild": "0.27.0",
+        "jose": "5.9.6",
+        "jsonc-parser": "3.3.1",
+        "luxon": "^3.4.0",
+        "sandbox": "3.4.0",
+        "smol-toml": "1.5.2",
+        "undici": "5.29.0",
+        "zod": "4.1.11"
+      },
+      "bin": {
+        "vc": "dist/vc.js",
+        "vercel": "dist/vc.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@vercel/backends": "0.8.25",
+        "@vercel/container": "0.0.5",
+        "@vercel/elysia": "0.1.102",
+        "@vercel/express": "0.1.116",
+        "@vercel/fastify": "0.1.105",
+        "@vercel/go": "3.10.2",
+        "@vercel/h3": "0.1.111",
+        "@vercel/hono": "0.2.105",
+        "@vercel/hydrogen": "1.4.0",
+        "@vercel/koa": "0.1.85",
+        "@vercel/nestjs": "0.2.106",
+        "@vercel/next": "4.20.4",
+        "@vercel/node": "5.8.26",
+        "@vercel/python": "6.51.0",
+        "@vercel/redwood": "2.5.0",
+        "@vercel/remix-builder": "5.9.1",
+        "@vercel/ruby": "2.5.1",
+        "@vercel/rust": "1.4.0",
+        "@vercel/static-build": "2.11.8"
+      },
+      "peerDependenciesMeta": {
+        "@vercel/backends": {
+          "optional": true
+        },
+        "@vercel/container": {
+          "optional": true
+        },
+        "@vercel/elysia": {
+          "optional": true
+        },
+        "@vercel/express": {
+          "optional": true
+        },
+        "@vercel/fastify": {
+          "optional": true
+        },
+        "@vercel/go": {
+          "optional": true
+        },
+        "@vercel/h3": {
+          "optional": true
+        },
+        "@vercel/hono": {
+          "optional": true
+        },
+        "@vercel/hydrogen": {
+          "optional": true
+        },
+        "@vercel/koa": {
+          "optional": true
+        },
+        "@vercel/nestjs": {
+          "optional": true
+        },
+        "@vercel/next": {
+          "optional": true
+        },
+        "@vercel/node": {
+          "optional": true
+        },
+        "@vercel/python": {
+          "optional": true
+        },
+        "@vercel/redwood": {
+          "optional": true
+        },
+        "@vercel/remix-builder": {
+          "optional": true
+        },
+        "@vercel/ruby": {
+          "optional": true
+        },
+        "@vercel/rust": {
+          "optional": true
+        },
+        "@vercel/static-build": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl-clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/yauzl-clone/-/yauzl-clone-1.0.4.tgz",
+      "integrity": "sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-intercept": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yauzl-promise": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl-promise/-/yauzl-promise-2.1.3.tgz",
+      "integrity": "sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==",
+      "license": "MIT",
+      "dependencies": {
+        "yauzl": "^2.9.1",
+        "yauzl-clone": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.github/docs-preview-vercel/package.json
+++ b/.github/docs-preview-vercel/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "subtensor-docs-preview-vercel-cli",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Locked Vercel CLI dependency graph for docs-preview workflows",
+  "dependencies": {
+    "vercel": "56.4.1"
+  },
+  "overrides": {
+    "@vercel/fun": {
+      "path-to-regexp": "6.3.0"
+    },
+    "@vercel/node": {
+      "path-to-regexp": "8.4.2"
+    },
+    "@vercel/python-analysis": {
+      "minimatch": "10.2.5"
+    },
+    "@vercel/remix-builder": {
+      "path-to-regexp": "6.3.0"
+    },
+    "ajv": "8.18.0",
+    "js-yaml": "4.3.0",
+    "path-to-regexp": "8.4.2",
+    "smol-toml": "1.7.0",
+    "tar": "7.5.22",
+    "undici": "6.28.0"
+  }
+}

--- a/.github/scripts/docs_preview_artifact.py
+++ b/.github/scripts/docs_preview_artifact.py
@@ -40,6 +40,12 @@ EOCD_STRUCT = struct.Struct("<4s4H2LH")
 COPY_CHUNK_BYTES = 1024 * 1024
 
 
+@dataclass(frozen=True)
+class ArtifactIntent:
+    action: str
+    pr_number: str
+
+
 def _write_all(fd: int, data: bytes) -> None:
     view = memoryview(data)
     while view:
@@ -186,6 +192,54 @@ def extract_artifact(
         if isinstance(error, ArtifactError):
             raise
         raise ArtifactError(f"failed to extract artifact ZIP: {error}") from error
+
+
+def read_intent(directory: Path, expected_pr_number: str) -> ArtifactIntent:
+    """Read the already-extracted control files as a strict two-value contract."""
+
+    expected_files = {
+        "deploy": ALLOWED_FILES,
+        "cleanup": {
+            "docs-preview-action.txt",
+            "docs-preview-pr-number.txt",
+        },
+    }
+    actual_files = {
+        path.relative_to(directory).as_posix()
+        for path in directory.rglob("*")
+        if path.is_file()
+    }
+
+    def one_line(name: str, maximum: int) -> str:
+        path = directory / name
+        try:
+            raw = path.read_bytes()
+        except OSError as error:
+            raise ArtifactError(f"cannot read artifact control file {name}") from error
+        if not raw or len(raw) > maximum or b"\0" in raw:
+            raise ArtifactError(f"invalid artifact control file {name}")
+        lines = raw.splitlines()
+        if len(lines) != 1:
+            raise ArtifactError(f"artifact control file {name} must contain one line")
+        try:
+            value = lines[0].decode("ascii")
+        except UnicodeDecodeError as error:
+            raise ArtifactError(f"artifact control file {name} is not ASCII") from error
+        if not value:
+            raise ArtifactError(f"artifact control file {name} is empty")
+        return value
+
+    action = one_line("docs-preview-action.txt", 16)
+    pr_number = one_line("docs-preview-pr-number.txt", 32)
+    if action not in expected_files:
+        raise ArtifactError(f"invalid docs-preview action: {action}")
+    if not pr_number.isdigit() or pr_number != expected_pr_number:
+        raise ArtifactError(
+            f"artifact PR {pr_number} does not match workflow PR {expected_pr_number}"
+        )
+    if actual_files != expected_files[action]:
+        raise ArtifactError("artifact contains an unexpected file set")
+    return ArtifactIntent(action=action, pr_number=pr_number)
 
 
 def _parse_args(arguments: Optional[Iterable[str]] = None) -> argparse.Namespace:

--- a/.github/scripts/docs_preview_artifact.py
+++ b/.github/scripts/docs_preview_artifact.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Safely unpack the GitHub artifact ZIP produced by an untrusted PR run."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import struct
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class ArtifactError(RuntimeError):
+    """The GitHub artifact ZIP is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class Limits:
+    max_zip_bytes: int = 2_200_000_000
+    max_entries: int = 3
+    max_central_directory_bytes: int = 64 * 1024
+    max_total_bytes: int = 2_000_000_128
+    max_bundle_bytes: int = 2_000_000_000
+    max_control_bytes: int = 32
+
+
+ALLOWED_FILES = {
+    "docs-preview-action.txt",
+    "docs-preview-pr-number.txt",
+    "docs-preview-sealed.tgz",
+}
+EOCD_SIGNATURE = b"PK\x05\x06"
+EOCD_STRUCT = struct.Struct("<4s4H2LH")
+COPY_CHUNK_BYTES = 1024 * 1024
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise ArtifactError("short write while extracting artifact")
+        view = view[written:]
+
+
+def _validate_eocd(path: Path, limits: Limits) -> int:
+    size = path.stat().st_size
+    if size > limits.max_zip_bytes:
+        raise ArtifactError(f"artifact ZIP exceeds {limits.max_zip_bytes} bytes")
+    tail_size = min(size, 65_535 + EOCD_STRUCT.size)
+    with path.open("rb") as handle:
+        handle.seek(size - tail_size)
+        tail = handle.read()
+    offset = tail.rfind(EOCD_SIGNATURE)
+    if offset < 0 or len(tail) - offset < EOCD_STRUCT.size:
+        raise ArtifactError("artifact ZIP has no valid end-of-central-directory record")
+    fields = EOCD_STRUCT.unpack_from(tail, offset)
+    (
+        _,
+        disk_number,
+        central_disk,
+        disk_entries,
+        total_entries,
+        central_size,
+        central_offset,
+        comment_size,
+    ) = fields
+    if offset + EOCD_STRUCT.size + comment_size != len(tail):
+        raise ArtifactError("artifact ZIP has a malformed comment or trailing data")
+    if disk_number or central_disk or disk_entries != total_entries:
+        raise ArtifactError("multi-disk artifact ZIPs are forbidden")
+    if total_entries > limits.max_entries:
+        raise ArtifactError(f"artifact ZIP has more than {limits.max_entries} entries")
+    if (
+        total_entries == 0xFFFF
+        or central_size == 0xFFFFFFFF
+        or central_offset == 0xFFFFFFFF
+    ):
+        raise ArtifactError("ZIP64 artifact metadata is forbidden")
+    if central_size > limits.max_central_directory_bytes:
+        raise ArtifactError("artifact ZIP central directory is too large")
+    eocd_file_offset = size - tail_size + offset
+    if central_offset + central_size != eocd_file_offset:
+        raise ArtifactError("artifact ZIP central-directory bounds are inconsistent")
+    return total_entries
+
+
+def extract_artifact(
+    archive: Path,
+    destination: Path,
+    limits: Optional[Limits] = None,
+) -> None:
+    limits = limits or Limits()
+    archive = archive.resolve()
+    destination = destination.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        raise ArtifactError(f"destination already exists: {destination}")
+    try:
+        expected_entries = _validate_eocd(archive, limits)
+    except ArtifactError:
+        raise
+    except Exception as error:
+        raise ArtifactError(f"cannot read artifact ZIP: {error}") from error
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.", dir=str(destination.parent))
+    )
+    try:
+        try:
+            artifact = zipfile.ZipFile(archive, mode="r")
+        except (OSError, zipfile.BadZipFile) as error:
+            raise ArtifactError(f"cannot open artifact ZIP: {error}") from error
+        with artifact:
+            infos = artifact.infolist()
+            if len(infos) != expected_entries:
+                raise ArtifactError("artifact ZIP entry counts disagree")
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)):
+                raise ArtifactError("artifact ZIP contains duplicate names")
+            if not set(names).issubset(ALLOWED_FILES):
+                raise ArtifactError("artifact ZIP contains an unexpected path")
+            if set(names) not in (
+                {"docs-preview-action.txt", "docs-preview-pr-number.txt"},
+                ALLOWED_FILES,
+            ):
+                raise ArtifactError("artifact ZIP has an unexpected file set")
+
+            total_bytes = 0
+            for info in infos:
+                file_type = (info.external_attr >> 16) & 0o170000
+                if info.is_dir() or file_type not in (0, stat.S_IFREG):
+                    raise ArtifactError(
+                        "artifact ZIP directories, links, and special files are forbidden"
+                    )
+                if info.flag_bits & 0x1:
+                    raise ArtifactError("encrypted artifact ZIP entries are forbidden")
+                if info.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED):
+                    raise ArtifactError("unsupported artifact ZIP compression")
+                limit = (
+                    limits.max_bundle_bytes
+                    if info.filename == "docs-preview-sealed.tgz"
+                    else limits.max_control_bytes
+                )
+                if info.file_size < 0 or info.file_size > limit:
+                    raise ArtifactError(
+                        f"artifact entry {info.filename} exceeds {limit} bytes"
+                    )
+                total_bytes += info.file_size
+                if total_bytes > limits.max_total_bytes:
+                    raise ArtifactError("artifact ZIP expands beyond its total limit")
+
+                target = staging / info.filename
+                flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                fd = os.open(target, flags, 0o600)
+                copied = 0
+                try:
+                    with artifact.open(info, mode="r") as source:
+                        while True:
+                            chunk = source.read(COPY_CHUNK_BYTES)
+                            if not chunk:
+                                break
+                            copied += len(chunk)
+                            if copied > limit:
+                                raise ArtifactError(
+                                    f"artifact entry {info.filename} exceeded its limit"
+                                )
+                            _write_all(fd, chunk)
+                finally:
+                    os.close(fd)
+                if copied != info.file_size:
+                    raise ArtifactError(
+                        f"artifact entry {info.filename} size does not match metadata"
+                    )
+        os.replace(staging, destination)
+    except Exception as error:
+        shutil.rmtree(staging, ignore_errors=True)
+        if isinstance(error, ArtifactError):
+            raise
+        raise ArtifactError(f"failed to extract artifact ZIP: {error}") from error
+
+
+def _parse_args(arguments: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("destination", type=Path)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Optional[Iterable[str]] = None) -> int:
+    args = _parse_args(arguments)
+    try:
+        extract_artifact(args.archive, args.destination)
+    except ArtifactError as error:
+        print(f"docs preview artifact rejected: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/docs_preview_bundle.py
+++ b/.github/scripts/docs_preview_bundle.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Validate and extract an untrusted docs-preview bundle.
+
+The archive is produced by pull-request code and consumed by a workflow that
+later receives deployment credentials.  Treat every tar header and every path
+inside Vercel's Build Output as attacker controlled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import shutil
+import stat
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class BundleError(RuntimeError):
+    """The bundle is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class Limits:
+    max_archive_bytes: int = 2 * 1024 * 1024 * 1024
+    max_members: int = 400_000
+    max_total_bytes: int = 4 * 1024 * 1024 * 1024
+    max_file_bytes: int = 512 * 1024 * 1024
+    max_path_bytes: int = 4_096
+    max_metadata_member_bytes: int = 1024 * 1024
+    max_metadata_total_bytes: int = 32 * 1024 * 1024
+    max_json_bytes: int = 5 * 1024 * 1024
+    max_trace_references: int = 400_000
+
+
+ALLOWED_ROOTS = (".vercel/output", "website/node_modules")
+COPY_CHUNK_BYTES = 1024 * 1024
+TAR_BLOCK_BYTES = 512
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise BundleError("short write while extracting bundle")
+        view = view[written:]
+
+
+def _normalise_member_name(raw_name: str, max_path_bytes: int) -> str:
+    if not raw_name or "\x00" in raw_name or "\\" in raw_name:
+        raise BundleError(f"unsafe archive path: {raw_name!r}")
+    if len(raw_name.encode("utf-8", errors="surrogateescape")) > max_path_bytes:
+        raise BundleError(f"archive path is too long: {raw_name!r}")
+
+    name = raw_name
+    while name.startswith("./"):
+        name = name[2:]
+    if name.endswith("/"):
+        name = name[:-1]
+    if not name or name.startswith("/"):
+        raise BundleError(f"unsafe archive path: {raw_name!r}")
+
+    parts = name.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise BundleError(f"unsafe archive path: {raw_name!r}")
+    if any(len(part.encode("utf-8", errors="surrogateescape")) > 255 for part in parts):
+        raise BundleError(f"archive path component is too long: {raw_name!r}")
+    if not any(name == root or name.startswith(root + "/") for root in ALLOWED_ROOTS):
+        raise BundleError(f"unexpected archive path: {raw_name!r}")
+    return name
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _tar_octal(field: bytes, label: str) -> int:
+    # Base-256 numeric fields are unnecessary within our quotas and have caused
+    # parser differentials in tar implementations. The producer emits octal.
+    if field and field[0] & 0x80:
+        raise BundleError(f"base-256 {label} fields are forbidden")
+    value = field.rstrip(b"\0 ").lstrip(b" ")
+    if not value:
+        return 0
+    if any(byte < ord("0") or byte > ord("7") for byte in value):
+        raise BundleError(f"invalid tar {label} field")
+    return int(value, 8)
+
+
+def _read_exact(handle: object, size: int, label: str) -> bytes:
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = handle.read(min(COPY_CHUNK_BYTES, remaining))
+        if not chunk:
+            raise BundleError(f"truncated tar {label}")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _skip_exact(handle: object, size: int, label: str) -> None:
+    remaining = size
+    while remaining:
+        chunk = handle.read(min(COPY_CHUNK_BYTES, remaining))
+        if not chunk:
+            raise BundleError(f"truncated tar {label}")
+        remaining -= len(chunk)
+
+
+def _parse_pax(payload: bytes, limits: Limits) -> None:
+    offset = 0
+    keys = set()
+    while offset < len(payload):
+        separator = payload.find(b" ", offset)
+        if separator < 0:
+            raise BundleError("invalid PAX record length")
+        length_bytes = payload[offset:separator]
+        if not length_bytes.isdigit():
+            raise BundleError("invalid PAX record length")
+        length = int(length_bytes)
+        end = offset + length
+        if length <= separator - offset + 2 or end > len(payload):
+            raise BundleError("invalid PAX record boundary")
+        record = payload[separator + 1 : end]
+        if not record.endswith(b"\n") or b"=" not in record:
+            raise BundleError("invalid PAX record")
+        key_bytes, value = record[:-1].split(b"=", 1)
+        try:
+            key = key_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise BundleError("invalid PAX key encoding") from error
+        if not key or key in keys:
+            raise BundleError("empty or duplicate PAX key")
+        keys.add(key)
+        if key == "size" or key == "linkpath" or key.startswith("GNU.sparse."):
+            raise BundleError(f"unsafe PAX override: {key}")
+        if key == "path":
+            try:
+                path = value.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise BundleError("invalid PAX path encoding") from error
+            _normalise_member_name(path, limits.max_path_bytes)
+        elif key in {"mtime", "atime", "ctime"}:
+            if len(value) > 64 or re.fullmatch(rb"-?[0-9]+(?:\.[0-9]+)?", value) is None:
+                raise BundleError(f"invalid PAX timestamp: {key}")
+        else:
+            raise BundleError(f"unsupported PAX key: {key}")
+        offset = end
+    if offset != len(payload):
+        raise BundleError("invalid PAX payload")
+
+
+def _preflight_tar(archive: Path, limits: Limits) -> None:
+    """Bound tar metadata before tarfile is allowed to interpret it."""
+
+    raw_members = 0
+    content_bytes = 0
+    metadata_bytes = 0
+    decompressed_bytes = 0
+    zero_blocks = 0
+    allowed_types = {b"\0", b"0", b"5", b"x", b"L"}
+    try:
+        compressed = archive.open("rb")
+        stream = gzip.GzipFile(fileobj=compressed, mode="rb")
+    except OSError as error:
+        raise BundleError(f"cannot open gzip archive {archive}: {error}") from error
+
+    with compressed, stream:
+        while True:
+            header = stream.read(TAR_BLOCK_BYTES)
+            decompressed_bytes += len(header)
+            if not header:
+                break
+            if len(header) != TAR_BLOCK_BYTES:
+                raise BundleError("truncated tar header")
+            if header == b"\0" * TAR_BLOCK_BYTES:
+                zero_blocks += 1
+                if zero_blocks == 2:
+                    break
+                continue
+            if zero_blocks:
+                raise BundleError("tar archive has only one end-of-archive block")
+
+            raw_members += 1
+            if raw_members > limits.max_members:
+                raise BundleError(f"archive has more than {limits.max_members} headers")
+            expected_checksum = _tar_octal(header[148:156], "checksum")
+            checksum_header = header[:148] + (b" " * 8) + header[156:]
+            if sum(checksum_header) != expected_checksum:
+                raise BundleError("invalid tar header checksum")
+
+            size = _tar_octal(header[124:136], "size")
+            type_flag = header[156:157]
+            if type_flag not in allowed_types:
+                raise BundleError("tar links and special entry types are forbidden")
+            if type_flag in (b"x", b"L"):
+                if size > limits.max_metadata_member_bytes:
+                    raise BundleError("tar metadata member is too large")
+                metadata_bytes += size
+                if metadata_bytes > limits.max_metadata_total_bytes:
+                    raise BundleError("tar metadata exceeds its total limit")
+                payload = _read_exact(stream, size, "metadata")
+                decompressed_bytes += size
+                if type_flag == b"x":
+                    _parse_pax(payload, limits)
+                else:
+                    try:
+                        long_name = payload.rstrip(b"\0\n").decode("utf-8")
+                    except UnicodeDecodeError as error:
+                        raise BundleError("invalid GNU long-name encoding") from error
+                    _normalise_member_name(long_name, limits.max_path_bytes)
+            else:
+                if type_flag in (b"\0", b"0"):
+                    if size > limits.max_file_bytes:
+                        raise BundleError(f"tar member exceeds {limits.max_file_bytes} bytes")
+                    content_bytes += size
+                    if content_bytes > limits.max_total_bytes:
+                        raise BundleError(
+                            f"tar content exceeds {limits.max_total_bytes} bytes"
+                        )
+                elif size:
+                    raise BundleError("tar directory has a non-zero size")
+                _skip_exact(stream, size, "member data")
+                decompressed_bytes += size
+
+            padding = (-size) % TAR_BLOCK_BYTES
+            if padding:
+                _skip_exact(stream, padding, "member padding")
+                decompressed_bytes += padding
+            maximum_tar_bytes = (
+                limits.max_total_bytes
+                + limits.max_metadata_total_bytes
+                + limits.max_members * TAR_BLOCK_BYTES * 2
+                + TAR_BLOCK_BYTES * 2
+            )
+            if decompressed_bytes > maximum_tar_bytes:
+                raise BundleError("decompressed tar exceeds its structural limit")
+        if zero_blocks != 2:
+            raise BundleError("tar archive is missing its end-of-archive blocks")
+
+        while True:
+            trailing = stream.read(COPY_CHUNK_BYTES)
+            if not trailing:
+                break
+            decompressed_bytes += len(trailing)
+            if any(trailing):
+                raise BundleError("tar archive has non-zero trailing data")
+            if decompressed_bytes > (
+                limits.max_total_bytes
+                + limits.max_metadata_total_bytes
+                + limits.max_members * TAR_BLOCK_BYTES * 2
+                + TAR_BLOCK_BYTES * 20
+            ):
+                raise BundleError("tar archive has excessive trailing padding")
+
+
+def _load_json(path: Path, limits: Limits) -> object:
+    size = path.stat().st_size
+    if size > limits.max_json_bytes:
+        raise BundleError(f"JSON metadata is too large: {path} ({size} bytes)")
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise BundleError(f"invalid JSON metadata in {path}: {error}") from error
+
+
+def _validate_vercel_paths(root: Path, limits: Limits) -> None:
+    output = root / ".vercel" / "output"
+    node_modules = root / "website" / "node_modules"
+    if not output.is_dir():
+        raise BundleError("bundle is missing .vercel/output")
+    if not node_modules.is_dir():
+        raise BundleError("bundle is missing website/node_modules")
+
+    configs = sorted(output.rglob(".vc-config.json"))
+    if not configs:
+        raise BundleError("bundle has no Vercel function configuration")
+
+    for config_path in configs:
+        config = _load_json(config_path, limits)
+        if not isinstance(config, dict):
+            raise BundleError(f"function configuration is not an object: {config_path}")
+        handler = config.get("handler")
+        if handler is None:
+            continue
+        if not isinstance(handler, str) or not handler or "\\" in handler:
+            raise BundleError(f"invalid function handler in {config_path}")
+        function_root = config_path.parent.resolve()
+        handler_path = (function_root / handler).resolve()
+        if not _is_within(handler_path, function_root):
+            raise BundleError(f"function handler escapes its function directory: {config_path}")
+        if not handler_path.is_file():
+            raise BundleError(f"function handler does not exist: {handler_path}")
+
+    reference_count = 0
+    resolved_root = root.resolve()
+    for trace_path in sorted(output.rglob("*.nft.json")):
+        trace = _load_json(trace_path, limits)
+        if not isinstance(trace, dict) or not isinstance(trace.get("files"), list):
+            raise BundleError(f"invalid NFT trace: {trace_path}")
+        for reference in trace["files"]:
+            reference_count += 1
+            if reference_count > limits.max_trace_references:
+                raise BundleError("too many NFT trace references")
+            if not isinstance(reference, str) or not reference or "\\" in reference:
+                raise BundleError(f"invalid NFT trace path in {trace_path}")
+            resolved = (trace_path.parent / reference).resolve()
+            if not _is_within(resolved, resolved_root):
+                raise BundleError(f"NFT trace escapes the deployment root: {trace_path}")
+            if not resolved.is_file():
+                raise BundleError(f"NFT trace references a missing file: {resolved}")
+
+
+def _copy_member(source: object, destination_fd: int, expected_size: int) -> None:
+    remaining = expected_size
+    while remaining:
+        chunk = source.read(min(COPY_CHUNK_BYTES, remaining))
+        if not chunk:
+            raise BundleError("archive member ended before its declared size")
+        _write_all(destination_fd, chunk)
+        remaining -= len(chunk)
+    if source.read(1):
+        raise BundleError("archive member exceeds its declared size")
+
+
+def extract_bundle(
+    archive: Path,
+    destination: Path,
+    limits: Optional[Limits] = None,
+) -> None:
+    """Stream-validate *archive* into a staging directory and atomically publish it."""
+
+    limits = limits or Limits()
+    archive = archive.resolve()
+    destination = destination.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        raise BundleError(f"destination already exists: {destination}")
+    try:
+        archive_size = archive.stat().st_size
+    except OSError as error:
+        raise BundleError(f"cannot stat archive {archive}: {error}") from error
+    if archive_size > limits.max_archive_bytes:
+        raise BundleError(
+            f"archive is too large: {archive_size} > {limits.max_archive_bytes} bytes"
+        )
+    try:
+        _preflight_tar(archive, limits)
+    except BundleError:
+        raise
+    except Exception as error:
+        raise BundleError(f"failed tar preflight: {error}") from error
+
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.", dir=str(destination.parent))
+    )
+    seen = set()
+    member_count = 0
+    total_bytes = 0
+    try:
+        try:
+            tar_handle = tarfile.open(archive, mode="r|gz")
+        except (OSError, tarfile.TarError) as error:
+            raise BundleError(f"cannot open archive {archive}: {error}") from error
+
+        with tar_handle:
+            for member in tar_handle:
+                member_count += 1
+                if member_count > limits.max_members:
+                    raise BundleError(f"archive has more than {limits.max_members} members")
+                name = _normalise_member_name(member.name, limits.max_path_bytes)
+                if name in seen:
+                    raise BundleError(f"duplicate archive member: {name}")
+                seen.add(name)
+
+                if not (member.isdir() or member.isreg()):
+                    raise BundleError(f"links and special files are forbidden: {name}")
+                size = member.size if member.isreg() else 0
+                if size < 0 or size > limits.max_file_bytes:
+                    raise BundleError(f"archive member is too large: {name} ({size} bytes)")
+                total_bytes += size
+                if total_bytes > limits.max_total_bytes:
+                    raise BundleError(
+                        f"archive expands beyond {limits.max_total_bytes} bytes"
+                    )
+
+                target = staging.joinpath(*name.split("/"))
+                if not _is_within(target.resolve(), staging.resolve()):
+                    raise BundleError(f"archive path escapes extraction root: {name}")
+                if member.isdir():
+                    if target.exists() and not target.is_dir():
+                        raise BundleError(f"archive directory conflicts with a file: {name}")
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+
+                target.parent.mkdir(parents=True, exist_ok=True)
+                extracted = tar_handle.extractfile(member)
+                if extracted is None:
+                    raise BundleError(f"cannot read archive member: {name}")
+                flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                mode = 0o755 if member.mode & stat.S_IXUSR else 0o644
+                try:
+                    fd = os.open(target, flags, mode)
+                except OSError as error:
+                    raise BundleError(f"cannot create extracted file {name}: {error}") from error
+                try:
+                    _copy_member(extracted, fd, size)
+                finally:
+                    os.close(fd)
+
+        if member_count == 0:
+            raise BundleError("archive is empty")
+        _validate_vercel_paths(staging, limits)
+        os.replace(staging, destination)
+    except Exception as error:
+        shutil.rmtree(staging, ignore_errors=True)
+        if isinstance(error, BundleError):
+            raise
+        raise BundleError(f"failed to extract bundle: {error}") from error
+
+
+def _parse_args(arguments: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("destination", type=Path)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Optional[Iterable[str]] = None) -> int:
+    args = _parse_args(arguments)
+    try:
+        extract_bundle(args.archive, args.destination)
+    except BundleError as error:
+        print(f"docs preview bundle rejected: {error}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/docs_preview_bundle.py
+++ b/.github/scripts/docs_preview_bundle.py
@@ -37,12 +37,23 @@ class Limits:
     max_metadata_member_bytes: int = 1024 * 1024
     max_metadata_total_bytes: int = 32 * 1024 * 1024
     max_json_bytes: int = 5 * 1024 * 1024
-    max_file_path_references: int = 400_000
+    max_file_path_references: int = 20_000_000
+    max_file_path_references_per_config: int = 10_000
 
 
 ALLOWED_ROOTS = (".vercel/output",)
 COPY_CHUNK_BYTES = 1024 * 1024
 TAR_BLOCK_BYTES = 512
+
+
+class _FilePathCache:
+    """Cache repeated paths across the thousands of generated function configs."""
+
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+        self.bundle_paths: dict[str, str] = {}
+        self.source_paths: dict[str, str] = {}
+        self.resolved_sources: dict[str, Path] = {}
 
 
 def _write_all(fd: int, data: bytes) -> None:
@@ -303,37 +314,57 @@ def _load_json(path: Path, limits: Limits) -> object:
 def _file_path_map(
     config_path: Path,
     config: dict,
-    root: Path,
     limits: Limits,
+    cache: _FilePathCache,
 ) -> dict[str, Path]:
     raw_map = config.get("filePathMap")
     if raw_map is None:
         return {}
     if not isinstance(raw_map, dict):
         raise BundleError(f"filePathMap is not an object: {config_path}")
-    if len(raw_map) > limits.max_file_path_references:
+    if len(raw_map) > limits.max_file_path_references_per_config:
         raise BundleError(f"filePathMap has too many entries: {config_path}")
 
-    resolved_root = root.resolve()
     entries: dict[str, Path] = {}
     for raw_bundle_path, raw_source_path in raw_map.items():
-        bundle_path = _normalise_relative_path(
-            raw_bundle_path,
-            f"filePathMap bundle path in {config_path}",
-            limits.max_path_bytes,
+        bundle_path = (
+            cache.bundle_paths.get(raw_bundle_path)
+            if isinstance(raw_bundle_path, str)
+            else None
         )
-        source_path = _normalise_relative_path(
-            raw_source_path,
-            f"filePathMap source path in {config_path}",
-            limits.max_path_bytes,
-        )
-        resolved_source = (resolved_root / source_path).resolve()
-        if not _is_within(resolved_source, resolved_root):
-            raise BundleError(f"filePathMap escapes the deployment root: {config_path}")
-        if not resolved_source.is_file():
-            raise BundleError(
-                f"filePathMap references a missing regular file: {resolved_source}"
+        if bundle_path is None:
+            bundle_path = _normalise_relative_path(
+                raw_bundle_path,
+                f"filePathMap bundle path in {config_path}",
+                limits.max_path_bytes,
             )
+            cache.bundle_paths[raw_bundle_path] = bundle_path
+
+        source_path = (
+            cache.source_paths.get(raw_source_path)
+            if isinstance(raw_source_path, str)
+            else None
+        )
+        if source_path is None:
+            source_path = _normalise_relative_path(
+                raw_source_path,
+                f"filePathMap source path in {config_path}",
+                limits.max_path_bytes,
+            )
+            cache.source_paths[raw_source_path] = source_path
+
+        resolved_source = cache.resolved_sources.get(source_path)
+        if resolved_source is None:
+            resolved_source = (cache.root / source_path).resolve()
+            if not _is_within(resolved_source, cache.root):
+                raise BundleError(
+                    f"filePathMap escapes the deployment root: {config_path}"
+                )
+            if not resolved_source.is_file():
+                raise BundleError(
+                    f"filePathMap references a missing regular file: {resolved_source}"
+                )
+            cache.resolved_sources[source_path] = resolved_source
         entries[bundle_path] = resolved_source
     return entries
 
@@ -348,11 +379,12 @@ def _validate_vercel_paths(root: Path, limits: Limits) -> None:
         raise BundleError("bundle has no Vercel function configuration")
 
     reference_count = 0
+    cache = _FilePathCache(root)
     for config_path in configs:
         config = _load_json(config_path, limits)
         if not isinstance(config, dict):
             raise BundleError(f"function configuration is not an object: {config_path}")
-        file_path_map = _file_path_map(config_path, config, root, limits)
+        file_path_map = _file_path_map(config_path, config, limits, cache)
         reference_count += len(file_path_map)
         if reference_count > limits.max_file_path_references:
             raise BundleError("too many Vercel filePathMap references")
@@ -390,11 +422,12 @@ def seal_bundle(
     if not configs:
         raise BundleError("build has no Vercel function configuration")
     reference_count = 0
+    cache = _FilePathCache(source_root)
     for config_path in configs:
         config = _load_json(config_path, limits)
         if not isinstance(config, dict):
             raise BundleError(f"function configuration is not an object: {config_path}")
-        entries = _file_path_map(config_path, config, source_root, limits)
+        entries = _file_path_map(config_path, config, limits, cache)
         reference_count += len(entries)
         if reference_count > limits.max_file_path_references:
             raise BundleError("too many Vercel filePathMap references")

--- a/.github/scripts/docs_preview_bundle.py
+++ b/.github/scripts/docs_preview_bundle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import hashlib
 import json
 import os
 import re
@@ -36,10 +37,10 @@ class Limits:
     max_metadata_member_bytes: int = 1024 * 1024
     max_metadata_total_bytes: int = 32 * 1024 * 1024
     max_json_bytes: int = 5 * 1024 * 1024
-    max_trace_references: int = 400_000
+    max_file_path_references: int = 400_000
 
 
-ALLOWED_ROOTS = (".vercel/output", "website/node_modules")
+ALLOWED_ROOTS = (".vercel/output",)
 COPY_CHUNK_BYTES = 1024 * 1024
 TAR_BLOCK_BYTES = 512
 
@@ -75,6 +76,19 @@ def _normalise_member_name(raw_name: str, max_path_bytes: int) -> str:
     if not any(name == root or name.startswith(root + "/") for root in ALLOWED_ROOTS):
         raise BundleError(f"unexpected archive path: {raw_name!r}")
     return name
+
+
+def _normalise_relative_path(raw_name: object, label: str, max_path_bytes: int) -> str:
+    if not isinstance(raw_name, str) or not raw_name:
+        raise BundleError(f"{label} must be a non-empty string")
+    if "\x00" in raw_name or "\\" in raw_name or raw_name.startswith("/"):
+        raise BundleError(f"unsafe {label}: {raw_name!r}")
+    if len(raw_name.encode("utf-8", errors="surrogateescape")) > max_path_bytes:
+        raise BundleError(f"{label} is too long: {raw_name!r}")
+    parts = raw_name.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise BundleError(f"unsafe {label}: {raw_name!r}")
+    return "/".join(parts)
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -153,7 +167,10 @@ def _parse_pax(payload: bytes, limits: Limits) -> None:
                 raise BundleError("invalid PAX path encoding") from error
             _normalise_member_name(path, limits.max_path_bytes)
         elif key in {"mtime", "atime", "ctime"}:
-            if len(value) > 64 or re.fullmatch(rb"-?[0-9]+(?:\.[0-9]+)?", value) is None:
+            if (
+                len(value) > 64
+                or re.fullmatch(rb"-?[0-9]+(?:\.[0-9]+)?", value) is None
+            ):
                 raise BundleError(f"invalid PAX timestamp: {key}")
         else:
             raise BundleError(f"unsupported PAX key: {key}")
@@ -224,7 +241,9 @@ def _preflight_tar(archive: Path, limits: Limits) -> None:
             else:
                 if type_flag in (b"\0", b"0"):
                     if size > limits.max_file_bytes:
-                        raise BundleError(f"tar member exceeds {limits.max_file_bytes} bytes")
+                        raise BundleError(
+                            f"tar member exceeds {limits.max_file_bytes} bytes"
+                        )
                     content_bytes += size
                     if content_bytes > limits.max_total_bytes:
                         raise BundleError(
@@ -266,62 +285,153 @@ def _preflight_tar(archive: Path, limits: Limits) -> None:
                 raise BundleError("tar archive has excessive trailing padding")
 
 
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant {value}")
+
+
 def _load_json(path: Path, limits: Limits) -> object:
     size = path.stat().st_size
     if size > limits.max_json_bytes:
         raise BundleError(f"JSON metadata is too large: {path} ({size} bytes)")
     try:
         with path.open("r", encoding="utf-8") as handle:
-            return json.load(handle)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            return json.load(handle, parse_constant=_reject_json_constant)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
         raise BundleError(f"invalid JSON metadata in {path}: {error}") from error
+
+
+def _file_path_map(
+    config_path: Path,
+    config: dict,
+    root: Path,
+    limits: Limits,
+) -> dict[str, Path]:
+    raw_map = config.get("filePathMap")
+    if raw_map is None:
+        return {}
+    if not isinstance(raw_map, dict):
+        raise BundleError(f"filePathMap is not an object: {config_path}")
+    if len(raw_map) > limits.max_file_path_references:
+        raise BundleError(f"filePathMap has too many entries: {config_path}")
+
+    resolved_root = root.resolve()
+    entries: dict[str, Path] = {}
+    for raw_bundle_path, raw_source_path in raw_map.items():
+        bundle_path = _normalise_relative_path(
+            raw_bundle_path,
+            f"filePathMap bundle path in {config_path}",
+            limits.max_path_bytes,
+        )
+        source_path = _normalise_relative_path(
+            raw_source_path,
+            f"filePathMap source path in {config_path}",
+            limits.max_path_bytes,
+        )
+        resolved_source = (resolved_root / source_path).resolve()
+        if not _is_within(resolved_source, resolved_root):
+            raise BundleError(f"filePathMap escapes the deployment root: {config_path}")
+        if not resolved_source.is_file():
+            raise BundleError(
+                f"filePathMap references a missing regular file: {resolved_source}"
+            )
+        entries[bundle_path] = resolved_source
+    return entries
 
 
 def _validate_vercel_paths(root: Path, limits: Limits) -> None:
     output = root / ".vercel" / "output"
-    node_modules = root / "website" / "node_modules"
     if not output.is_dir():
         raise BundleError("bundle is missing .vercel/output")
-    if not node_modules.is_dir():
-        raise BundleError("bundle is missing website/node_modules")
 
     configs = sorted(output.rglob(".vc-config.json"))
     if not configs:
         raise BundleError("bundle has no Vercel function configuration")
 
+    reference_count = 0
     for config_path in configs:
         config = _load_json(config_path, limits)
         if not isinstance(config, dict):
             raise BundleError(f"function configuration is not an object: {config_path}")
+        file_path_map = _file_path_map(config_path, config, root, limits)
+        reference_count += len(file_path_map)
+        if reference_count > limits.max_file_path_references:
+            raise BundleError("too many Vercel filePathMap references")
+
         handler = config.get("handler")
         if handler is None:
             continue
-        if not isinstance(handler, str) or not handler or "\\" in handler:
-            raise BundleError(f"invalid function handler in {config_path}")
-        function_root = config_path.parent.resolve()
-        handler_path = (function_root / handler).resolve()
-        if not _is_within(handler_path, function_root):
-            raise BundleError(f"function handler escapes its function directory: {config_path}")
-        if not handler_path.is_file():
-            raise BundleError(f"function handler does not exist: {handler_path}")
+        handler = _normalise_relative_path(
+            handler,
+            f"function handler in {config_path}",
+            limits.max_path_bytes,
+        )
+        physical_handler = config_path.parent / handler
+        if handler not in file_path_map and not physical_handler.is_file():
+            raise BundleError(f"function handler does not exist: {config_path}")
 
+
+def seal_bundle(
+    source_root: Path,
+    archive: Path,
+    limits: Optional[Limits] = None,
+) -> None:
+    """Materialize Vercel file references inside Build Output and seal only it."""
+
+    limits = limits or Limits()
+    source_root = source_root.resolve()
+    archive = archive.resolve()
+    output = source_root / ".vercel" / "output"
+    if not output.is_dir():
+        raise BundleError("build is missing .vercel/output")
+    internal = output / ".docs-preview-files"
+    internal.mkdir(parents=True, exist_ok=True)
+
+    configs = sorted(output.rglob(".vc-config.json"))
+    if not configs:
+        raise BundleError("build has no Vercel function configuration")
     reference_count = 0
-    resolved_root = root.resolve()
-    for trace_path in sorted(output.rglob("*.nft.json")):
-        trace = _load_json(trace_path, limits)
-        if not isinstance(trace, dict) or not isinstance(trace.get("files"), list):
-            raise BundleError(f"invalid NFT trace: {trace_path}")
-        for reference in trace["files"]:
-            reference_count += 1
-            if reference_count > limits.max_trace_references:
-                raise BundleError("too many NFT trace references")
-            if not isinstance(reference, str) or not reference or "\\" in reference:
-                raise BundleError(f"invalid NFT trace path in {trace_path}")
-            resolved = (trace_path.parent / reference).resolve()
-            if not _is_within(resolved, resolved_root):
-                raise BundleError(f"NFT trace escapes the deployment root: {trace_path}")
-            if not resolved.is_file():
-                raise BundleError(f"NFT trace references a missing file: {resolved}")
+    for config_path in configs:
+        config = _load_json(config_path, limits)
+        if not isinstance(config, dict):
+            raise BundleError(f"function configuration is not an object: {config_path}")
+        entries = _file_path_map(config_path, config, source_root, limits)
+        reference_count += len(entries)
+        if reference_count > limits.max_file_path_references:
+            raise BundleError("too many Vercel filePathMap references")
+        if not entries:
+            continue
+
+        rewritten = {}
+        for bundle_path, source_path in entries.items():
+            source_relative = source_path.relative_to(source_root).as_posix()
+            if _is_within(source_path, output):
+                materialized_relative = source_relative
+            else:
+                digest = hashlib.sha256(source_relative.encode("utf-8")).hexdigest()
+                materialized = internal / digest
+                if not materialized.exists():
+                    shutil.copy2(source_path, materialized, follow_symlinks=True)
+                materialized_relative = materialized.relative_to(source_root).as_posix()
+            rewritten[bundle_path] = materialized_relative
+
+        config["filePathMap"] = rewritten
+        temporary = config_path.with_name(config_path.name + ".tmp")
+        temporary.write_text(
+            json.dumps(config, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(temporary, config_path)
+
+    _validate_vercel_paths(source_root, limits)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    if archive.exists():
+        raise BundleError(f"archive already exists: {archive}")
+    try:
+        with tarfile.open(archive, mode="w:gz", dereference=True) as bundle:
+            bundle.add(output, arcname=".vercel/output", recursive=True)
+    except (OSError, tarfile.TarError) as error:
+        archive.unlink(missing_ok=True)
+        raise BundleError(f"failed to seal bundle: {error}") from error
 
 
 def _copy_member(source: object, destination_fd: int, expected_size: int) -> None:
@@ -380,7 +490,9 @@ def extract_bundle(
             for member in tar_handle:
                 member_count += 1
                 if member_count > limits.max_members:
-                    raise BundleError(f"archive has more than {limits.max_members} members")
+                    raise BundleError(
+                        f"archive has more than {limits.max_members} members"
+                    )
                 name = _normalise_member_name(member.name, limits.max_path_bytes)
                 if name in seen:
                     raise BundleError(f"duplicate archive member: {name}")
@@ -390,7 +502,9 @@ def extract_bundle(
                     raise BundleError(f"links and special files are forbidden: {name}")
                 size = member.size if member.isreg() else 0
                 if size < 0 or size > limits.max_file_bytes:
-                    raise BundleError(f"archive member is too large: {name} ({size} bytes)")
+                    raise BundleError(
+                        f"archive member is too large: {name} ({size} bytes)"
+                    )
                 total_bytes += size
                 if total_bytes > limits.max_total_bytes:
                     raise BundleError(
@@ -402,7 +516,9 @@ def extract_bundle(
                     raise BundleError(f"archive path escapes extraction root: {name}")
                 if member.isdir():
                     if target.exists() and not target.is_dir():
-                        raise BundleError(f"archive directory conflicts with a file: {name}")
+                        raise BundleError(
+                            f"archive directory conflicts with a file: {name}"
+                        )
                     target.mkdir(parents=True, exist_ok=True)
                     continue
 
@@ -417,7 +533,9 @@ def extract_bundle(
                 try:
                     fd = os.open(target, flags, mode)
                 except OSError as error:
-                    raise BundleError(f"cannot create extracted file {name}: {error}") from error
+                    raise BundleError(
+                        f"cannot create extracted file {name}: {error}"
+                    ) from error
                 try:
                     _copy_member(extracted, fd, size)
                 finally:
@@ -436,15 +554,30 @@ def extract_bundle(
 
 def _parse_args(arguments: Optional[Iterable[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("archive", type=Path)
-    parser.add_argument("destination", type=Path)
+    commands = parser.add_subparsers(dest="command", required=True)
+    extract = commands.add_parser(
+        "extract", help="validate and extract a sealed bundle"
+    )
+    extract.add_argument("archive", type=Path)
+    extract.add_argument("destination", type=Path)
+    seal = commands.add_parser(
+        "seal",
+        help="materialize Vercel file references and create a self-contained bundle",
+    )
+    seal.add_argument("source_root", type=Path)
+    seal.add_argument("archive", type=Path)
     return parser.parse_args(arguments)
 
 
 def main(arguments: Optional[Iterable[str]] = None) -> int:
     args = _parse_args(arguments)
     try:
-        extract_bundle(args.archive, args.destination)
+        if args.command == "extract":
+            extract_bundle(args.archive, args.destination)
+        elif args.command == "seal":
+            seal_bundle(args.source_root, args.archive)
+        else:
+            raise AssertionError(args.command)
     except BundleError as error:
         print(f"docs preview bundle rejected: {error}", file=os.sys.stderr)
         return 1

--- a/.github/scripts/docs_preview_github.py
+++ b/.github/scripts/docs_preview_github.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""GitHub-side control plane for trusted docs-preview deployments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from docs_preview_artifact import ArtifactError, extract_artifact, read_intent
+
+
+API_BASE = "https://api.github.com"
+MAX_JSON_BYTES = 16 * 1024 * 1024
+MAX_ARTIFACT_BYTES = 2_200_000_000
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+DEPLOYMENT_ID_PATTERN = re.compile(r"^dpl_[A-Za-z0-9]+$")
+PREVIEW_URL_PATTERN = re.compile(
+    r"^https://pr-[0-9]+\.preview\.[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$"
+)
+
+
+class ApiError(RuntimeError):
+    """A GitHub API response violated the trusted workflow contract."""
+
+
+@dataclass(frozen=True)
+class PullState:
+    number: str
+    state: str
+    head_sha: str
+    head_repository: str
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Never forward GitHub credentials to artifact storage hosts."""
+
+    def redirect_request(self, request, fp, code, message, headers, new_url):
+        redirected = super().redirect_request(
+            request, fp, code, message, headers, new_url
+        )
+        if redirected is None:
+            return None
+        parsed = urllib.parse.urlsplit(new_url)
+        if parsed.scheme != "https":
+            raise ApiError("GitHub API attempted a non-HTTPS redirect")
+        if parsed.hostname != urllib.parse.urlsplit(request.full_url).hostname:
+            redirected.remove_header("Authorization")
+            redirected.remove_header("X-GitHub-Api-Version")
+        return redirected
+
+
+class GitHubClient:
+    def __init__(self, token: str, repository: str, timeout: int = 30):
+        if not token:
+            raise ValueError("GitHub token is required")
+        if not REPOSITORY_PATTERN.fullmatch(repository):
+            raise ValueError("repository must have owner/name form")
+        self._token = token
+        self.repository = repository
+        self.timeout = timeout
+        self._opener = urllib.request.build_opener(_SafeRedirectHandler())
+
+    def _url(self, path: str, query: Optional[dict[str, object]] = None) -> str:
+        if path.startswith("/") or ".." in path.split("/"):
+            raise ValueError("unsafe GitHub API path")
+        owner, name = self.repository.split("/", 1)
+        url = "{}/repos/{}/{}/{}".format(
+            API_BASE,
+            urllib.parse.quote(owner, safe=""),
+            urllib.parse.quote(name, safe=""),
+            path,
+        )
+        if query:
+            url += "?" + urllib.parse.urlencode(query)
+        return url
+
+    def _open(
+        self,
+        method: str,
+        path: str,
+        query: Optional[dict[str, object]] = None,
+        body: Optional[dict[str, object]] = None,
+    ):
+        encoded_body = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self._token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if body is not None:
+            encoded_body = json.dumps(body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            self._url(path, query),
+            data=encoded_body,
+            method=method,
+            headers=headers,
+        )
+        try:
+            return self._opener.open(request, timeout=self.timeout)
+        except urllib.error.HTTPError as error:
+            raise ApiError(
+                f"GitHub API {method} {path} returned HTTP {error.code}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise ApiError(
+                f"GitHub API {method} {path} failed: {error.reason}"
+            ) from error
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        query: Optional[dict[str, object]] = None,
+        body: Optional[dict[str, object]] = None,
+    ) -> object:
+        with self._open(method, path, query, body) as response:
+            raw = response.read(MAX_JSON_BYTES + 1)
+        if len(raw) > MAX_JSON_BYTES:
+            raise ApiError(f"GitHub API {path} response is too large")
+        try:
+            return json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ApiError(f"GitHub API {path} returned invalid JSON") from error
+
+    def download(self, path: str, destination: Path, maximum_bytes: int) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            raise ApiError(f"download destination already exists: {destination}")
+        copied = 0
+        try:
+            with self._open("GET", path) as response, destination.open("xb") as output:
+                while True:
+                    chunk = response.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    copied += len(chunk)
+                    if copied > maximum_bytes:
+                        raise ApiError(
+                            "GitHub artifact download exceeded its size limit"
+                        )
+                    output.write(chunk)
+        except Exception:
+            destination.unlink(missing_ok=True)
+            raise
+
+
+def _pull_from_response(number: str, response: object) -> PullState:
+    if not isinstance(response, dict):
+        raise ApiError("GitHub pull request response is not an object")
+    head = response.get("head")
+    repository = head.get("repo") if isinstance(head, dict) else None
+    state = response.get("state")
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    head_repository = (
+        repository.get("full_name") if isinstance(repository, dict) else None
+    )
+    if (
+        state not in {"open", "closed"}
+        or not isinstance(head_sha, str)
+        or not SHA_PATTERN.fullmatch(head_sha)
+        or not isinstance(head_repository, str)
+    ):
+        raise ApiError("GitHub pull request response has an invalid state or head")
+    return PullState(number, state, head_sha, head_repository)
+
+
+def pull_state(client: GitHubClient, number: str) -> PullState:
+    if not number.isdigit():
+        raise ValueError("pull request number must be digits")
+    return _pull_from_response(
+        number,
+        client.request_json("GET", f"pulls/{number}"),
+    )
+
+
+def workflow_pr_number(workflow_pulls_json: str) -> Optional[str]:
+    """Resolve an unambiguous PR directly from the workflow_run payload."""
+
+    try:
+        workflow_pulls = json.loads(workflow_pulls_json or "[]")
+    except json.JSONDecodeError as error:
+        raise ApiError("workflow_run pull request list is invalid JSON") from error
+    if not isinstance(workflow_pulls, list):
+        raise ApiError("workflow_run pull request list is not an array")
+    numbers = {
+        pull.get("number")
+        for pull in workflow_pulls
+        if isinstance(pull, dict)
+        and isinstance(pull.get("number"), int)
+        and pull["number"] > 0
+    }
+    if len(numbers) > 1:
+        raise ApiError("workflow_run is associated with multiple pull requests")
+    if numbers:
+        return str(numbers.pop())
+    return None
+
+
+def associated_pr_number(
+    associated_pulls: object,
+    head_sha: str,
+    repository: str,
+) -> str:
+    """Resolve the one same-repository PR associated with a commit."""
+
+    if not isinstance(associated_pulls, list):
+        raise ApiError("commit association response is not an array")
+    matches = []
+    for pull in associated_pulls:
+        if not isinstance(pull, dict):
+            continue
+        head = pull.get("head")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        number = pull.get("number")
+        if (
+            isinstance(head, dict)
+            and head.get("sha") == head_sha
+            and isinstance(head_repo, dict)
+            and head_repo.get("full_name") == repository
+            and isinstance(number, int)
+            and number > 0
+        ):
+            matches.append(number)
+    if len(set(matches)) != 1:
+        raise ApiError(
+            f"expected one same-repository pull request for {head_sha}, "
+            f"found {len(set(matches))}"
+        )
+    return str(matches[0])
+
+
+def reconcile_mode(
+    action: str,
+    pull: PullState,
+    expected_head_sha: str,
+    repository: str,
+) -> str:
+    if action not in {"deploy", "cleanup"}:
+        raise ValueError("invalid docs-preview action")
+    if pull.state == "closed":
+        return "cleanup"
+    if action == "cleanup":
+        return "noop"
+    if pull.head_sha == expected_head_sha and pull.head_repository == repository:
+        return "deploy"
+    return "noop"
+
+
+def _write_output(name: str, value: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_.:/-]+", value):
+        raise ApiError(f"unsafe GitHub Actions output value for {name}")
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise ApiError("GITHUB_OUTPUT is unavailable")
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"{name}={value}\n")
+
+
+def _summary(message: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as summary:
+            summary.write(message + "\n")
+
+
+def prepare(
+    client: GitHubClient,
+    workflow_pulls_json: str,
+    workflow_head_sha: str,
+    workflow_run_id: str,
+    docs_domain: str,
+    artifact_zip: Path,
+    artifact_directory: Path,
+) -> None:
+    if not SHA_PATTERN.fullmatch(workflow_head_sha):
+        raise ValueError("workflow head SHA is invalid")
+    if not workflow_run_id.isdigit():
+        raise ValueError("workflow run ID must be digits")
+
+    pr_number = workflow_pr_number(workflow_pulls_json)
+    if pr_number is None:
+        associated = client.request_json(
+            "GET",
+            f"commits/{workflow_head_sha}/pulls",
+        )
+        pr_number = associated_pr_number(
+            associated,
+            workflow_head_sha,
+            client.repository,
+        )
+    artifact_name = f"docs-preview-{pr_number}"
+    response = client.request_json(
+        "GET",
+        f"actions/runs/{workflow_run_id}/artifacts",
+        {"name": artifact_name, "per_page": 100},
+    )
+    if not isinstance(response, dict) or response.get("total_count") != 1:
+        count = response.get("total_count") if isinstance(response, dict) else "invalid"
+        raise ApiError(f"expected one {artifact_name} artifact, found {count}")
+    artifacts = response.get("artifacts")
+    artifact = (
+        artifacts[0] if isinstance(artifacts, list) and len(artifacts) == 1 else None
+    )
+    if not isinstance(artifact, dict):
+        raise ApiError("GitHub artifact response is invalid")
+    artifact_id = artifact.get("id")
+    artifact_size = artifact.get("size_in_bytes")
+    if (
+        not isinstance(artifact_id, int)
+        or artifact_id <= 0
+        or not isinstance(artifact_size, int)
+        or artifact_size < 0
+        or artifact_size > MAX_ARTIFACT_BYTES
+        or artifact.get("expired") is not False
+    ):
+        raise ApiError("GitHub artifact is expired or violates its size contract")
+
+    client.download(
+        f"actions/artifacts/{artifact_id}/zip",
+        artifact_zip,
+        MAX_ARTIFACT_BYTES,
+    )
+    extract_artifact(artifact_zip, artifact_directory)
+    intent = read_intent(artifact_directory, pr_number)
+    pull = pull_state(client, pr_number)
+    mode = reconcile_mode(intent.action, pull, workflow_head_sha, client.repository)
+    alias = f"pr-{pr_number}.preview.{docs_domain}"
+    _write_output("pr", pr_number)
+    _write_output("action", intent.action)
+    _write_output("mode", mode)
+    _write_output("alias", alias)
+    _write_output("url", f"https://{alias}")
+    _summary(
+        f"Resolved artifact action {intent.action} and PR state "
+        f"{pull.state} to {mode}."
+    )
+
+
+def recheck(
+    client: GitHubClient,
+    pr_number: str,
+    expected_head_sha: str,
+) -> None:
+    pull = pull_state(client, pr_number)
+    authorized = (
+        pull.state == "open"
+        and pull.head_sha == expected_head_sha
+        and pull.head_repository == client.repository
+    )
+    _write_output("authorized", str(authorized).lower())
+    if not authorized:
+        _summary(
+            "Deployment became stale while queued; a newer run will reconcile "
+            "the preview."
+        )
+
+
+def upsert_preview_comment(
+    client: GitHubClient,
+    pr_number: str,
+    deployment_id: str,
+    preview_url: str,
+) -> None:
+    if not pr_number.isdigit():
+        raise ValueError("pull request number must be digits")
+    if not DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id):
+        raise ValueError("invalid Vercel deployment ID")
+    if ".." in preview_url or not PREVIEW_URL_PATTERN.fullmatch(preview_url):
+        raise ValueError("invalid docs-preview URL")
+
+    marker = "<!-- docs-preview-url -->"
+    body = "\n".join(
+        [
+            marker,
+            f"<!-- docs-preview-deployment:{deployment_id} -->",
+            "### Docs preview",
+            "",
+            f"{preview_url}/docs",
+            "",
+            "Stable for this PR; it updates after each docs or website change.",
+        ]
+    )
+    existing_id = None
+    for page in range(1, 101):
+        response = client.request_json(
+            "GET",
+            f"issues/{pr_number}/comments",
+            {"per_page": 100, "page": page},
+        )
+        if not isinstance(response, list):
+            raise ApiError("GitHub issue comments response is not an array")
+        for comment in response:
+            if (
+                isinstance(comment, dict)
+                and isinstance(comment.get("body"), str)
+                and marker in comment["body"]
+                and isinstance(comment.get("id"), int)
+            ):
+                existing_id = comment["id"]
+                break
+        if existing_id is not None or len(response) < 100:
+            break
+    else:
+        raise ApiError("GitHub issue comment scan exceeded 10,000 comments")
+    if existing_id is None:
+        client.request_json(
+            "POST",
+            f"issues/{pr_number}/comments",
+            body={"body": body},
+        )
+    else:
+        client.request_json(
+            "PATCH",
+            f"issues/comments/{existing_id}",
+            body={"body": body},
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    prepare_command = commands.add_parser("prepare")
+    prepare_command.add_argument("--workflow-pulls-json", required=True)
+    prepare_command.add_argument("--workflow-head-sha", required=True)
+    prepare_command.add_argument("--workflow-run-id", required=True)
+    prepare_command.add_argument("--docs-domain", required=True)
+    prepare_command.add_argument("--artifact-zip", type=Path, required=True)
+    prepare_command.add_argument("--artifact-directory", type=Path, required=True)
+
+    recheck_command = commands.add_parser("recheck")
+    recheck_command.add_argument("--pr-number", required=True)
+    recheck_command.add_argument("--workflow-head-sha", required=True)
+
+    comment = commands.add_parser("comment")
+    comment.add_argument("--pr-number", required=True)
+    comment.add_argument("--deployment-id", required=True)
+    comment.add_argument("--preview-url", required=True)
+    return parser
+
+
+def main(arguments: Optional[Iterable[str]] = None) -> int:
+    args = _parser().parse_args(arguments)
+    token = os.environ.get("GH_TOKEN", "")
+    try:
+        client = GitHubClient(token, args.repository)
+        if args.command == "prepare":
+            prepare(
+                client,
+                args.workflow_pulls_json,
+                args.workflow_head_sha,
+                args.workflow_run_id,
+                args.docs_domain,
+                args.artifact_zip,
+                args.artifact_directory,
+            )
+        elif args.command == "recheck":
+            recheck(client, args.pr_number, args.workflow_head_sha)
+        elif args.command == "comment":
+            upsert_preview_comment(
+                client,
+                args.pr_number,
+                args.deployment_id,
+                args.preview_url,
+            )
+        else:
+            raise AssertionError(args.command)
+    except (ApiError, ArtifactError, OSError, ValueError) as error:
+        print(f"docs-preview GitHub control failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/docs_preview_vercel.py
+++ b/.github/scripts/docs_preview_vercel.py
@@ -6,19 +6,26 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Sequence
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
 
 
 API_BASE = "https://api.vercel.com"
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+DOMAIN_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")
+DEPLOYMENT_ID_PATTERN = re.compile(r"^dpl_[A-Za-z0-9]+$")
+DEPLOYMENT_URL_PATTERN = re.compile(r"^https://[A-Za-z0-9.-]+$")
 
 
 class ApiError(RuntimeError):
-    """A Vercel API request failed."""
+    """A Vercel API request failed or returned an unsafe shape."""
 
 
 @dataclass(frozen=True)
@@ -29,8 +36,8 @@ class UnsafeEnvironmentVariable:
 
 class VercelClient:
     def __init__(self, token: str, team_id: str, timeout: int = 30):
-        if not token or not team_id:
-            raise ValueError("Vercel token and team ID are required")
+        if not token or not IDENTIFIER_PATTERN.fullmatch(team_id):
+            raise ValueError("valid Vercel token and team ID are required")
         self._token = token
         self.team_id = team_id
         self.timeout = timeout
@@ -39,45 +46,60 @@ class VercelClient:
         self,
         method: str,
         path: str,
-        query: Optional[Dict[str, object]] = None,
+        query: Optional[dict[str, object]] = None,
+        body: Optional[dict[str, object]] = None,
+        allow_missing: bool = False,
     ) -> object:
         parameters = {"teamId": self.team_id}
         if query:
             parameters.update(query)
         url = API_BASE + path + "?" + urllib.parse.urlencode(parameters)
+        encoded_body = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+        }
+        if encoded_body is not None:
+            headers["Content-Type"] = "application/json"
         request = urllib.request.Request(
             url,
+            data=encoded_body,
             method=method,
-            headers={
-                "Authorization": f"Bearer {self._token}",
-                "Accept": "application/json",
-            },
+            headers=headers,
         )
         try:
             with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                body = response.read()
+                raw = response.read(16 * 1024 * 1024 + 1)
         except urllib.error.HTTPError as error:
+            if allow_missing and error.code == 404:
+                return None
             raise ApiError(
                 f"Vercel API {method} {path} returned HTTP {error.code}"
             ) from error
         except urllib.error.URLError as error:
-            raise ApiError(f"Vercel API {method} {path} failed: {error.reason}") from error
-        if not body:
+            raise ApiError(
+                f"Vercel API {method} {path} failed: {error.reason}"
+            ) from error
+        if len(raw) > 16 * 1024 * 1024:
+            raise ApiError(f"Vercel API {path} response is too large")
+        if not raw:
             return {}
         try:
-            return json.loads(body)
+            return json.loads(raw)
         except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise ApiError(f"Vercel API {method} {path} returned invalid JSON") from error
+            raise ApiError(
+                f"Vercel API {method} {path} returned invalid JSON"
+            ) from error
 
     def paginated(
         self,
         path: str,
         item_key: str,
-        query: Optional[Dict[str, object]] = None,
-    ) -> List[object]:
+        query: Optional[dict[str, object]] = None,
+    ) -> list[object]:
         parameters = dict(query or {})
         parameters.setdefault("limit", 100)
-        items: List[object] = []
+        items: list[object] = []
         seen_cursors = set()
         for _ in range(1_000):
             response = self.request("GET", path, parameters)
@@ -98,6 +120,71 @@ class VercelClient:
         raise ApiError(f"Vercel API {path} exceeded the pagination limit")
 
 
+def validate_configuration(
+    team_id: str,
+    project_id: str,
+    production_project_id: str,
+    docs_domain: str,
+) -> None:
+    if not all(
+        IDENTIFIER_PATTERN.fullmatch(value)
+        for value in (team_id, project_id, production_project_id)
+    ):
+        raise ValueError(
+            "set valid VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, and "
+            "VERCEL_DOCS_PREVIEW_PROJECT_ID repository variables"
+        )
+    if project_id == production_project_id:
+        raise ValueError(
+            "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated, "
+            "non-production project"
+        )
+    if (
+        len(docs_domain) > 253
+        or ".." in docs_domain
+        or not DOMAIN_PATTERN.fullmatch(docs_domain)
+    ):
+        raise ValueError("DOCS_DOMAIN must be a valid lowercase DNS name")
+
+
+def write_project_link(
+    directory: Path,
+    team_id: str,
+    project_id: str,
+    include_build_settings: bool,
+) -> None:
+    payload: dict[str, object] = {"projectId": project_id, "orgId": team_id}
+    if include_build_settings:
+        payload["settings"] = {
+            "framework": "nextjs",
+            "devCommand": None,
+            "installCommand": None,
+            "buildCommand": None,
+            "outputDirectory": None,
+            "rootDirectory": "website/apps/bittensor-website",
+            "directoryListing": False,
+            "nodeVersion": "24.x",
+        }
+    destination = directory.resolve() / ".vercel" / "project.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=".project.",
+        suffix=".json",
+        dir=destination.parent,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as temporary:
+            json.dump(payload, temporary, sort_keys=True, separators=(",", ":"))
+        os.replace(temporary_name, destination)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        Path(temporary_name).unlink(missing_ok=True)
+        raise
+
+
 def _targets_preview(target: object) -> bool:
     if isinstance(target, str):
         return target.lower() == "preview"
@@ -105,15 +192,14 @@ def _targets_preview(target: object) -> bool:
         return any(
             isinstance(value, str) and value.lower() == "preview" for value in target
         )
-    # Unknown target shapes cannot prove that the variable is absent from Preview.
     return True
 
 
 def unsafe_preview_variables(
     project_variables: Sequence[object],
     shared_variables: Sequence[object],
-) -> List[UnsafeEnvironmentVariable]:
-    unsafe: List[UnsafeEnvironmentVariable] = []
+) -> list[UnsafeEnvironmentVariable]:
+    unsafe: list[UnsafeEnvironmentVariable] = []
     for source, variables in (
         ("project", project_variables),
         ("team-shared", shared_variables),
@@ -135,29 +221,11 @@ def unsafe_preview_variables(
     return sorted(unsafe, key=lambda item: (item.source, item.key))
 
 
-def deployment_ids_for_pr(
-    deployments: Sequence[object],
-    pr_number: str,
-    keep_deployment_id: Optional[str] = None,
-) -> List[str]:
-    matches = []
-    for deployment in deployments:
-        if not isinstance(deployment, dict):
-            raise ApiError("Vercel deployments response contains an invalid entry")
-        metadata = deployment.get("meta")
-        deployment_id = deployment.get("uid") or deployment.get("id")
-        if (
-            isinstance(metadata, dict)
-            and str(metadata.get("docsPreviewPr", "")) == pr_number
-            and isinstance(deployment_id, str)
-            and deployment_id
-            and deployment_id != keep_deployment_id
-        ):
-            matches.append(deployment_id)
-    return sorted(set(matches))
-
-
-def audit_environment(client: VercelClient, project_id: str) -> None:
+def audit_project(
+    client: VercelClient,
+    project_id: str,
+    preview_domain: str,
+) -> None:
     project_path = "/v10/projects/{}/env".format(
         urllib.parse.quote(project_id, safe="")
     )
@@ -175,6 +243,115 @@ def audit_environment(client: VercelClient, project_id: str) -> None:
             f"variables ({descriptions}); refusing to deploy PR-controlled functions"
         )
 
+    domain = client.request(
+        "GET",
+        "/v9/projects/{}/domains/{}".format(
+            urllib.parse.quote(project_id, safe=""),
+            urllib.parse.quote(preview_domain, safe=""),
+        ),
+    )
+    if (
+        not isinstance(domain, dict)
+        or domain.get("name") != preview_domain
+        or domain.get("verified") is not True
+    ):
+        raise ApiError(
+            f"preview project must pre-provision and verify {preview_domain}"
+        )
+
+
+def deployment_id_for_url(
+    client: VercelClient,
+    project_id: str,
+    deployment_url: str,
+) -> str:
+    if not DEPLOYMENT_URL_PATTERN.fullmatch(deployment_url):
+        raise ValueError("Vercel CLI returned an invalid deployment URL")
+    host = deployment_url.removeprefix("https://")
+    response = client.request(
+        "GET",
+        f"/v13/deployments/{urllib.parse.quote(host, safe='')}",
+    )
+    deployment_id = response.get("id") if isinstance(response, dict) else None
+    response_project_id = (
+        response.get("projectId") if isinstance(response, dict) else None
+    )
+    if (
+        not isinstance(deployment_id, str)
+        or not DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id)
+        or response_project_id != project_id
+    ):
+        raise ApiError("Vercel deployment response has an invalid ID")
+    return deployment_id
+
+
+def set_alias(client: VercelClient, deployment_id: str, alias: str) -> None:
+    if not DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id):
+        raise ValueError("invalid Vercel deployment ID")
+    if not DOMAIN_PATTERN.fullmatch(alias):
+        raise ValueError("invalid docs-preview alias")
+    client.request(
+        "POST",
+        f"/v2/deployments/{urllib.parse.quote(deployment_id, safe='')}/aliases",
+        body={"alias": alias},
+    )
+
+
+def remove_alias(
+    client: VercelClient,
+    project_id: str,
+    alias: str,
+) -> bool:
+    if not DOMAIN_PATTERN.fullmatch(alias):
+        raise ValueError("invalid docs-preview alias")
+    response = client.request(
+        "GET",
+        f"/now/aliases/{urllib.parse.quote(alias, safe='')}",
+        allow_missing=True,
+    )
+    if response is None:
+        return False
+    alias_id = response.get("uid") if isinstance(response, dict) else None
+    alias_project_id = response.get("projectId") if isinstance(response, dict) else None
+    if not isinstance(alias_id, str) or not alias_id or alias_project_id != project_id:
+        raise ApiError("refusing to remove an alias outside the preview project")
+    client.request(
+        "DELETE",
+        f"/now/aliases/{urllib.parse.quote(alias_id, safe='')}",
+    )
+    return True
+
+
+def deployment_ids_for_pr(
+    deployments: Sequence[object],
+    pr_number: str,
+    keep_deployment_id: Optional[str] = None,
+) -> list[str]:
+    matches = []
+    for deployment in deployments:
+        if not isinstance(deployment, dict):
+            raise ApiError("Vercel deployments response contains an invalid entry")
+        metadata = deployment.get("meta")
+        deployment_id = deployment.get("uid") or deployment.get("id")
+        if (
+            isinstance(metadata, dict)
+            and str(metadata.get("docsPreviewPr", "")) == pr_number
+            and isinstance(deployment_id, str)
+            and deployment_id
+            and deployment_id != keep_deployment_id
+        ):
+            matches.append(deployment_id)
+    return sorted(set(matches))
+
+
+def delete_deployment(client: VercelClient, deployment_id: str) -> None:
+    if not DEPLOYMENT_ID_PATTERN.fullmatch(deployment_id):
+        raise ValueError("invalid Vercel deployment ID")
+    client.request(
+        "DELETE",
+        f"/v13/deployments/{urllib.parse.quote(deployment_id, safe='')}",
+    )
+
 
 def delete_pr_deployments(
     client: VercelClient,
@@ -188,41 +365,113 @@ def delete_pr_deployments(
         {"projectId": project_id},
     )
     deployment_ids = deployment_ids_for_pr(
-        deployments, pr_number, keep_deployment_id=keep_deployment_id
+        deployments,
+        pr_number,
+        keep_deployment_id=keep_deployment_id,
     )
     for deployment_id in deployment_ids:
-        client.request(
-            "DELETE",
-            "/v13/deployments/{}".format(
-                urllib.parse.quote(deployment_id, safe="")
-            ),
-        )
+        delete_deployment(client, deployment_id)
     return len(deployment_ids)
+
+
+def _write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise ApiError("GITHUB_OUTPUT is unavailable")
+    if not re.fullmatch(r"[A-Za-z0-9_.:/-]+", value):
+        raise ApiError(f"unsafe GitHub Actions output value for {name}")
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"{name}={value}\n")
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--project-id", required=True)
     parser.add_argument("--team-id", required=True)
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser("audit-environment")
-    cleanup = subparsers.add_parser("delete-pr-deployments")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    validate = commands.add_parser("validate-config")
+    validate.add_argument("--production-project-id", required=True)
+    validate.add_argument("--docs-domain", required=True)
+
+    link = commands.add_parser("link-project")
+    link.add_argument("--directory", type=Path, required=True)
+    link.add_argument("--include-build-settings", action="store_true")
+
+    audit = commands.add_parser("audit-project")
+    audit.add_argument("--preview-domain", required=True)
+
+    deployment = commands.add_parser("deployment-id")
+    deployment.add_argument("--deployment-url", required=True)
+
+    alias = commands.add_parser("set-alias")
+    alias.add_argument("--deployment-id", required=True)
+    alias.add_argument("--alias", required=True)
+
+    remove = commands.add_parser("remove-alias")
+    remove.add_argument("--alias", required=True)
+
+    cleanup = commands.add_parser("delete-pr-deployments")
     cleanup.add_argument("--pr-number", required=True)
     cleanup.add_argument("--keep-deployment-id")
+
+    delete = commands.add_parser("delete-deployment")
+    delete.add_argument("--deployment-id", required=True)
     return parser
 
 
 def main(arguments: Optional[Iterable[str]] = None) -> int:
     args = _parser().parse_args(arguments)
-    token = os.environ.get("VERCEL_TOKEN", "")
-    if not token:
-        print("VERCEL_TOKEN is required", file=sys.stderr)
-        return 1
+    token_commands = {
+        "audit-project",
+        "deployment-id",
+        "set-alias",
+        "remove-alias",
+        "delete-pr-deployments",
+        "delete-deployment",
+    }
     try:
+        if args.command == "validate-config":
+            validate_configuration(
+                args.team_id,
+                args.project_id,
+                args.production_project_id,
+                args.docs_domain,
+            )
+            return 0
+        if args.command == "link-project":
+            write_project_link(
+                args.directory,
+                args.team_id,
+                args.project_id,
+                args.include_build_settings,
+            )
+            return 0
+
+        token = os.environ.get("VERCEL_TOKEN", "")
+        if args.command in token_commands and not token:
+            raise ValueError("VERCEL_TOKEN is required")
         client = VercelClient(token, args.team_id)
-        if args.command == "audit-environment":
-            audit_environment(client, args.project_id)
-            print("Vercel docs-preview project has no non-system Preview variables")
+        if args.command == "audit-project":
+            audit_project(client, args.project_id, args.preview_domain)
+            print("Vercel preview project and domain satisfy the trusted boundary")
+        elif args.command == "deployment-id":
+            deployment_id = deployment_id_for_url(
+                client,
+                args.project_id,
+                args.deployment_url,
+            )
+            _write_output("deployment_id", deployment_id)
+            _write_output("deployment_url", args.deployment_url)
+        elif args.command == "set-alias":
+            set_alias(client, args.deployment_id, args.alias)
+        elif args.command == "remove-alias":
+            removed = remove_alias(client, args.project_id, args.alias)
+            print(
+                "Removed preview alias"
+                if removed
+                else "Preview alias was already absent"
+            )
         elif args.command == "delete-pr-deployments":
             count = delete_pr_deployments(
                 client,
@@ -231,10 +480,12 @@ def main(arguments: Optional[Iterable[str]] = None) -> int:
                 keep_deployment_id=args.keep_deployment_id,
             )
             print(f"Deleted {count} obsolete docs-preview deployment(s)")
+        elif args.command == "delete-deployment":
+            delete_deployment(client, args.deployment_id)
         else:
             raise AssertionError(args.command)
-    except (ApiError, ValueError) as error:
-        print(f"docs-preview Vercel guard failed: {error}", file=sys.stderr)
+    except (ApiError, OSError, ValueError) as error:
+        print(f"docs-preview Vercel control failed: {error}", file=sys.stderr)
         return 1
     return 0
 

--- a/.github/scripts/docs_preview_vercel.py
+++ b/.github/scripts/docs_preview_vercel.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Fail-closed Vercel controls for trusted docs-preview deployments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+
+API_BASE = "https://api.vercel.com"
+
+
+class ApiError(RuntimeError):
+    """A Vercel API request failed."""
+
+
+@dataclass(frozen=True)
+class UnsafeEnvironmentVariable:
+    source: str
+    key: str
+
+
+class VercelClient:
+    def __init__(self, token: str, team_id: str, timeout: int = 30):
+        if not token or not team_id:
+            raise ValueError("Vercel token and team ID are required")
+        self._token = token
+        self.team_id = team_id
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        query: Optional[Dict[str, object]] = None,
+    ) -> object:
+        parameters = {"teamId": self.team_id}
+        if query:
+            parameters.update(query)
+        url = API_BASE + path + "?" + urllib.parse.urlencode(parameters)
+        request = urllib.request.Request(
+            url,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            raise ApiError(
+                f"Vercel API {method} {path} returned HTTP {error.code}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise ApiError(f"Vercel API {method} {path} failed: {error.reason}") from error
+        if not body:
+            return {}
+        try:
+            return json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ApiError(f"Vercel API {method} {path} returned invalid JSON") from error
+
+    def paginated(
+        self,
+        path: str,
+        item_key: str,
+        query: Optional[Dict[str, object]] = None,
+    ) -> List[object]:
+        parameters = dict(query or {})
+        parameters.setdefault("limit", 100)
+        items: List[object] = []
+        seen_cursors = set()
+        for _ in range(1_000):
+            response = self.request("GET", path, parameters)
+            if not isinstance(response, dict) or not isinstance(
+                response.get(item_key), list
+            ):
+                raise ApiError(f"Vercel API {path} returned an unexpected response")
+            items.extend(response[item_key])
+            pagination = response.get("pagination") or {}
+            cursor = pagination.get("next") if isinstance(pagination, dict) else None
+            if cursor is None:
+                return items
+            cursor = str(cursor)
+            if cursor in seen_cursors:
+                raise ApiError(f"Vercel API {path} repeated a pagination cursor")
+            seen_cursors.add(cursor)
+            parameters["until"] = cursor
+        raise ApiError(f"Vercel API {path} exceeded the pagination limit")
+
+
+def _targets_preview(target: object) -> bool:
+    if isinstance(target, str):
+        return target.lower() == "preview"
+    if isinstance(target, list):
+        return any(
+            isinstance(value, str) and value.lower() == "preview" for value in target
+        )
+    # Unknown target shapes cannot prove that the variable is absent from Preview.
+    return True
+
+
+def unsafe_preview_variables(
+    project_variables: Sequence[object],
+    shared_variables: Sequence[object],
+) -> List[UnsafeEnvironmentVariable]:
+    unsafe: List[UnsafeEnvironmentVariable] = []
+    for source, variables in (
+        ("project", project_variables),
+        ("team-shared", shared_variables),
+    ):
+        for variable in variables:
+            if not isinstance(variable, dict):
+                unsafe.append(UnsafeEnvironmentVariable(source, "<invalid-response>"))
+                continue
+            if variable.get("system") is True:
+                continue
+            if _targets_preview(variable.get("target")):
+                key = variable.get("key")
+                unsafe.append(
+                    UnsafeEnvironmentVariable(
+                        source,
+                        key if isinstance(key, str) and key else "<unnamed>",
+                    )
+                )
+    return sorted(unsafe, key=lambda item: (item.source, item.key))
+
+
+def deployment_ids_for_pr(
+    deployments: Sequence[object],
+    pr_number: str,
+    keep_deployment_id: Optional[str] = None,
+) -> List[str]:
+    matches = []
+    for deployment in deployments:
+        if not isinstance(deployment, dict):
+            raise ApiError("Vercel deployments response contains an invalid entry")
+        metadata = deployment.get("meta")
+        deployment_id = deployment.get("uid") or deployment.get("id")
+        if (
+            isinstance(metadata, dict)
+            and str(metadata.get("docsPreviewPr", "")) == pr_number
+            and isinstance(deployment_id, str)
+            and deployment_id
+            and deployment_id != keep_deployment_id
+        ):
+            matches.append(deployment_id)
+    return sorted(set(matches))
+
+
+def audit_environment(client: VercelClient, project_id: str) -> None:
+    project_path = "/v10/projects/{}/env".format(
+        urllib.parse.quote(project_id, safe="")
+    )
+    project_variables = client.paginated(project_path, "envs", {"decrypt": "false"})
+    shared_variables = client.paginated(
+        "/v1/env",
+        "data",
+        {"projectId": project_id},
+    )
+    unsafe = unsafe_preview_variables(project_variables, shared_variables)
+    if unsafe:
+        descriptions = ", ".join(f"{item.source}:{item.key}" for item in unsafe)
+        raise ApiError(
+            "docs-preview project exposes non-system Preview environment "
+            f"variables ({descriptions}); refusing to deploy PR-controlled functions"
+        )
+
+
+def delete_pr_deployments(
+    client: VercelClient,
+    project_id: str,
+    pr_number: str,
+    keep_deployment_id: Optional[str] = None,
+) -> int:
+    deployments = client.paginated(
+        "/v7/deployments",
+        "deployments",
+        {"projectId": project_id},
+    )
+    deployment_ids = deployment_ids_for_pr(
+        deployments, pr_number, keep_deployment_id=keep_deployment_id
+    )
+    for deployment_id in deployment_ids:
+        client.request(
+            "DELETE",
+            "/v13/deployments/{}".format(
+                urllib.parse.quote(deployment_id, safe="")
+            ),
+        )
+    return len(deployment_ids)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-id", required=True)
+    parser.add_argument("--team-id", required=True)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("audit-environment")
+    cleanup = subparsers.add_parser("delete-pr-deployments")
+    cleanup.add_argument("--pr-number", required=True)
+    cleanup.add_argument("--keep-deployment-id")
+    return parser
+
+
+def main(arguments: Optional[Iterable[str]] = None) -> int:
+    args = _parser().parse_args(arguments)
+    token = os.environ.get("VERCEL_TOKEN", "")
+    if not token:
+        print("VERCEL_TOKEN is required", file=sys.stderr)
+        return 1
+    try:
+        client = VercelClient(token, args.team_id)
+        if args.command == "audit-environment":
+            audit_environment(client, args.project_id)
+            print("Vercel docs-preview project has no non-system Preview variables")
+        elif args.command == "delete-pr-deployments":
+            count = delete_pr_deployments(
+                client,
+                args.project_id,
+                args.pr_number,
+                keep_deployment_id=args.keep_deployment_id,
+            )
+            print(f"Deleted {count} obsolete docs-preview deployment(s)")
+        else:
+            raise AssertionError(args.command)
+    except (ApiError, ValueError) as error:
+        print(f"docs-preview Vercel guard failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_docs_preview_artifact.py
+++ b/.github/scripts/test_docs_preview_artifact.py
@@ -6,7 +6,13 @@ import warnings
 import zipfile
 from pathlib import Path
 
-from docs_preview_artifact import ArtifactError, Limits, extract_artifact
+from docs_preview_artifact import (
+    ArtifactError,
+    ArtifactIntent,
+    Limits,
+    extract_artifact,
+    read_intent,
+)
 
 
 class DocsPreviewArtifactTests(unittest.TestCase):
@@ -57,6 +63,13 @@ class DocsPreviewArtifactTests(unittest.TestCase):
                 self.assertEqual(
                     (self.destination / "docs-preview-action.txt").read_bytes(),
                     entries[0][1],
+                )
+                self.assertEqual(
+                    read_intent(self.destination, "42"),
+                    ArtifactIntent(
+                        action=entries[0][1].decode().strip(),
+                        pr_number="42",
+                    ),
                 )
 
     def test_rejects_paths_duplicates_and_extra_entries(self):
@@ -117,6 +130,30 @@ class DocsPreviewArtifactTests(unittest.TestCase):
                 with self.assertRaises(ArtifactError):
                     extract_artifact(self.archive, destination, limits=limits)
                 self.assertFalse(destination.exists())
+
+    def test_intent_rejects_mismatch_multiline_and_action_shape(self):
+        cases = [
+            ("deploy\n", "41\n", "42"),
+            ("deploy\ncleanup\n", "42\n", "42"),
+            ("unknown\n", "42\n", "42"),
+            ("deploy\n", "not-a-number\n", "42"),
+        ]
+        for index, (action, pr_number, expected_pr) in enumerate(cases):
+            with self.subTest(index=index):
+                directory = self.root / f"intent-{index}"
+                directory.mkdir()
+                (directory / "docs-preview-action.txt").write_text(
+                    action,
+                    encoding="ascii",
+                )
+                (directory / "docs-preview-pr-number.txt").write_text(
+                    pr_number,
+                    encoding="ascii",
+                )
+                if action.startswith("deploy"):
+                    (directory / "docs-preview-sealed.tgz").write_bytes(b"bundle")
+                with self.assertRaises(ArtifactError):
+                    read_intent(directory, expected_pr)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_docs_preview_artifact.py
+++ b/.github/scripts/test_docs_preview_artifact.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import tempfile
+import unittest
+import warnings
+import zipfile
+from pathlib import Path
+
+from docs_preview_artifact import ArtifactError, Limits, extract_artifact
+
+
+class DocsPreviewArtifactTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.archive = self.root / "artifact.zip"
+        self.destination = self.root / "artifact"
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write_zip(self, entries):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with zipfile.ZipFile(
+                self.archive, "w", compression=zipfile.ZIP_DEFLATED
+            ) as archive:
+                for name, content in entries:
+                    archive.writestr(name, content)
+
+    def assert_rejected(self, entries, limits=None):
+        self.write_zip(entries)
+        with self.assertRaises(ArtifactError):
+            extract_artifact(self.archive, self.destination, limits=limits)
+        self.assertFalse(self.destination.exists())
+        self.assertEqual(list(self.root.glob(".artifact.*")), [])
+
+    def test_extracts_deploy_and_cleanup_artifacts(self):
+        for index, entries in enumerate(
+            [
+                [
+                    ("docs-preview-action.txt", b"deploy\n"),
+                    ("docs-preview-pr-number.txt", b"42\n"),
+                    ("docs-preview-sealed.tgz", b"bundle"),
+                ],
+                [
+                    ("docs-preview-action.txt", b"cleanup\n"),
+                    ("docs-preview-pr-number.txt", b"42\n"),
+                ],
+            ]
+        ):
+            with self.subTest(index=index):
+                self.archive = self.root / f"artifact-{index}.zip"
+                self.destination = self.root / f"artifact-{index}"
+                self.write_zip(entries)
+                extract_artifact(self.archive, self.destination)
+                self.assertEqual(
+                    (self.destination / "docs-preview-action.txt").read_bytes(),
+                    entries[0][1],
+                )
+
+    def test_rejects_paths_duplicates_and_extra_entries(self):
+        cases = [
+            [
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-pr-number.txt", b"42\n"),
+                ("../docs-preview-sealed.tgz", b"bundle"),
+            ],
+            [
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-pr-number.txt", b"42\n"),
+            ],
+            [
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-pr-number.txt", b"42\n"),
+                ("docs-preview-sealed.tgz", b"bundle"),
+                ("extra", b"x"),
+            ],
+        ]
+        for index, entries in enumerate(cases):
+            with self.subTest(index=index):
+                self.archive = self.root / f"unsafe-{index}.zip"
+                self.destination = self.root / f"unsafe-{index}"
+                self.assert_rejected(entries)
+
+    def test_rejects_symlink_entry(self):
+        with zipfile.ZipFile(self.archive, "w") as archive:
+            archive.writestr("docs-preview-action.txt", b"deploy\n")
+            archive.writestr("docs-preview-pr-number.txt", b"42\n")
+            info = zipfile.ZipInfo("docs-preview-sealed.tgz")
+            info.create_system = 3
+            info.external_attr = 0o120777 << 16
+            archive.writestr(info, b"/etc/passwd")
+        with self.assertRaises(ArtifactError):
+            extract_artifact(self.archive, self.destination)
+        self.assertFalse(self.destination.exists())
+
+    def test_enforces_file_total_zip_and_central_directory_limits(self):
+        self.write_zip(
+            [
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-pr-number.txt", b"42\n"),
+                ("docs-preview-sealed.tgz", b"bundle"),
+            ]
+        )
+        size = self.archive.stat().st_size
+        cases = [
+            Limits(max_zip_bytes=size - 1),
+            Limits(max_bundle_bytes=5),
+            Limits(max_total_bytes=10),
+            Limits(max_central_directory_bytes=10),
+        ]
+        for index, limits in enumerate(cases):
+            with self.subTest(index=index):
+                destination = self.root / f"limit-{index}"
+                with self.assertRaises(ArtifactError):
+                    extract_artifact(self.archive, destination, limits=limits)
+                self.assertFalse(destination.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_docs_preview_bundle.py
+++ b/.github/scripts/test_docs_preview_bundle.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from docs_preview_bundle import BundleError, Limits, extract_bundle
+from docs_preview_bundle import BundleError, Limits, extract_bundle, seal_bundle
 
 
 def file_entry(name, content=b"x", mode=0o644):
@@ -20,29 +20,22 @@ def directory_entry(name):
 
 
 def valid_entries(prefix=""):
-    function = f"{prefix}.vercel/output/functions/app.func"
+    output = f"{prefix}.vercel/output"
+    function = f"{output}/functions/app.func"
+    materialized = f"{output}/.docs-preview-files/library"
+    config = {
+        "runtime": "nodejs20.x",
+        "handler": "index.js",
+        "filePathMap": {
+            "index.js": ".vercel/output/.docs-preview-files/library",
+        },
+    }
     return [
-        directory_entry(f"{prefix}.vercel/output"),
+        directory_entry(output),
         directory_entry(function),
-        file_entry(
-            f"{function}/.vc-config.json",
-            json.dumps({"runtime": "nodejs20.x", "handler": "index.js"}).encode(),
-        ),
-        file_entry(f"{function}/index.js", b"module.exports = {}"),
-        file_entry(
-            f"{function}/index.nft.json",
-            json.dumps(
-                {
-                    "version": 1,
-                    "files": [
-                        "index.js",
-                        "../../../../website/node_modules/pkg/index.js",
-                    ],
-                }
-            ).encode(),
-        ),
-        directory_entry(f"{prefix}website/node_modules/pkg"),
-        file_entry(f"{prefix}website/node_modules/pkg/index.js", b"module.exports = 1"),
+        directory_entry(f"{output}/.docs-preview-files"),
+        file_entry(f"{function}/.vc-config.json", json.dumps(config).encode()),
+        file_entry(materialized, b"module.exports = {}"),
     ]
 
 
@@ -98,23 +91,34 @@ class DocsPreviewBundleTests(unittest.TestCase):
         write_archive(self.archive, entries)
         with self.assertRaises(BundleError):
             extract_bundle(self.archive, self.destination, limits=limits)
-        self.assertFalse(self.destination.exists(), "failed extraction must not be published")
+        self.assertFalse(
+            self.destination.exists(), "failed extraction must not be published"
+        )
         self.assertEqual(
             list(self.root.glob(".deploy.*")),
             [],
             "failed extraction must remove its staging directory",
         )
 
-    def test_extracts_valid_bundle(self):
+    @staticmethod
+    def replace_config(entries, config):
+        index = next(
+            i for i, entry in enumerate(entries) if entry[1].endswith(".vc-config.json")
+        )
+        entries[index] = file_entry(
+            entries[index][1],
+            json.dumps(config).encode(),
+        )
+
+    def test_extracts_valid_self_contained_bundle(self):
         self.extract(valid_entries())
         self.assertTrue(
             (
-                self.destination
-                / ".vercel/output/functions/app.func/.vc-config.json"
+                self.destination / ".vercel/output/functions/app.func/.vc-config.json"
             ).is_file()
         )
         self.assertTrue(
-            (self.destination / "website/node_modules/pkg/index.js").is_file()
+            (self.destination / ".vercel/output/.docs-preview-files/library").is_file()
         )
 
     def test_accepts_explicit_dot_slash_prefix(self):
@@ -122,18 +126,17 @@ class DocsPreviewBundleTests(unittest.TestCase):
         self.assertTrue((self.destination / ".vercel/output").is_dir())
 
     def test_accepts_bounded_long_name_metadata(self):
-        long_path = "website/node_modules/" + "/".join(["nested"] * 20) + "/index.js"
-        entries = valid_entries() + [file_entry(long_path)]
-        self.extract(entries)
+        long_path = ".vercel/output/" + "/".join(["nested"] * 20) + "/index.js"
+        self.extract(valid_entries() + [file_entry(long_path)])
         self.assertTrue((self.destination / long_path).is_file())
 
     def test_rejects_traversal_absolute_backslash_and_empty_components(self):
         unsafe_names = [
-            "../../website/node_modules/escape",
-            "/website/node_modules/escape",
-            "website\\node_modules\\escape",
-            "website//node_modules/escape",
-            "website/./node_modules/escape",
+            "../../.vercel/output/escape",
+            "/.vercel/output/escape",
+            ".vercel\\output\\escape",
+            ".vercel/output//escape",
+            ".vercel/output/./escape",
         ]
         for index, name in enumerate(unsafe_names):
             with self.subTest(name=name):
@@ -150,14 +153,14 @@ class DocsPreviewBundleTests(unittest.TestCase):
     def test_rejects_links_and_special_files(self):
         for index, entry in enumerate(
             [
-                ("symlink", "website/node_modules/link", b"/etc/passwd", 0o777),
+                ("symlink", ".vercel/output/link", b"/etc/passwd", 0o777),
                 (
                     "hardlink",
-                    "website/node_modules/link",
-                    b"website/node_modules/pkg/index.js",
+                    ".vercel/output/link",
+                    b".vercel/output/.docs-preview-files/library",
                     0o644,
                 ),
-                ("fifo", "website/node_modules/pipe", b"", 0o644),
+                ("fifo", ".vercel/output/pipe", b"", 0o644),
             ]
         ):
             with self.subTest(kind=entry[0]):
@@ -171,37 +174,24 @@ class DocsPreviewBundleTests(unittest.TestCase):
     def test_rejects_duplicate_member(self):
         self.assert_rejected(
             valid_entries()
-            + [file_entry("website/node_modules/pkg/index.js", b"replacement")]
-        )
-
-    def test_rejects_pax_size_override_before_tarfile_parses_it(self):
-        self.assert_rejected(
-            valid_entries()
             + [
-                (
-                    "pax-size",
-                    "website/node_modules/pkg/override.js",
-                    b"x",
-                    0o644,
+                file_entry(
+                    ".vercel/output/.docs-preview-files/library",
+                    b"replacement",
                 )
             ]
         )
 
-    def test_rejects_unsupported_pax_parser_inputs(self):
-        self.assert_rejected(
-            valid_entries()
-            + [
-                (
-                    "pax-unknown",
-                    "website/node_modules/pkg/override.js",
-                    b"x",
-                    0o644,
+    def test_rejects_pax_overrides_before_tarfile_parses_them(self):
+        for kind in ("pax-size", "pax-unknown"):
+            with self.subTest(kind=kind):
+                self.assert_rejected(
+                    valid_entries()
+                    + [(kind, ".vercel/output/override.js", b"x", 0o644)]
                 )
-            ]
-        )
 
     def test_enforces_tar_metadata_member_limit(self):
-        long_path = "website/node_modules/" + "/".join(["nested"] * 20) + "/index.js"
+        long_path = ".vercel/output/" + "/".join(["nested"] * 20) + "/index.js"
         self.assert_rejected(
             valid_entries() + [file_entry(long_path)],
             limits=Limits(max_metadata_member_bytes=8),
@@ -224,36 +214,60 @@ class DocsPreviewBundleTests(unittest.TestCase):
                     extract_bundle(self.archive, destination, limits=limits)
                 self.assertFalse(destination.exists())
 
-    def test_rejects_nft_path_escape_and_missing_reference(self):
+    def test_rejects_file_path_map_escape_and_missing_reference(self):
         for index, reference in enumerate(
-            ["../../../../../outside", "../../../../website/node_modules/missing.js"]
+            ["../../proc/self/cmdline", ".vercel/output/missing.js"]
         ):
             entries = valid_entries()
-            trace_index = next(
-                i for i, entry in enumerate(entries) if entry[1].endswith(".nft.json")
+            self.replace_config(
+                entries,
+                {
+                    "runtime": "nodejs20.x",
+                    "handler": "index.js",
+                    "filePathMap": {"index.js": reference},
+                },
             )
-            entries[trace_index] = file_entry(
-                entries[trace_index][1],
-                json.dumps({"version": 1, "files": [reference]}).encode(),
+            archive = self.root / f"reference-{index}.tgz"
+            destination = self.root / f"reference-{index}"
+            write_archive(archive, entries)
+            with self.assertRaises(BundleError):
+                extract_bundle(archive, destination)
+            self.assertFalse(destination.exists())
+
+    def test_rejects_unsafe_file_path_map_bundle_paths(self):
+        for index, bundle_path in enumerate(
+            ["../index.js", "/index.js", "dir\\index.js", "dir//index.js"]
+        ):
+            entries = valid_entries()
+            self.replace_config(
+                entries,
+                {
+                    "runtime": "nodejs20.x",
+                    "handler": "index.js",
+                    "filePathMap": {
+                        bundle_path: ".vercel/output/.docs-preview-files/library"
+                    },
+                },
             )
-            archive = self.root / f"trace-{index}.tgz"
-            destination = self.root / f"trace-{index}"
+            archive = self.root / f"bundle-path-{index}.tgz"
+            destination = self.root / f"bundle-path-{index}"
             write_archive(archive, entries)
             with self.assertRaises(BundleError):
                 extract_bundle(archive, destination)
             self.assertFalse(destination.exists())
 
     def test_rejects_handler_escape_and_missing_handler(self):
-        for index, handler in enumerate(
-            ["../../../../website/node_modules/pkg/index.js", "missing.js"]
-        ):
+        for index, handler in enumerate(["../index.js", "missing.js"]):
             entries = valid_entries()
-            config_index = next(
-                i for i, entry in enumerate(entries) if entry[1].endswith(".vc-config.json")
-            )
-            entries[config_index] = file_entry(
-                entries[config_index][1],
-                json.dumps({"runtime": "nodejs20.x", "handler": handler}).encode(),
+            self.replace_config(
+                entries,
+                {
+                    "runtime": "nodejs20.x",
+                    "handler": handler,
+                    "filePathMap": {
+                        "index.js": ".vercel/output/.docs-preview-files/library"
+                    },
+                },
             )
             archive = self.root / f"handler-{index}.tgz"
             destination = self.root / f"handler-{index}"
@@ -264,12 +278,20 @@ class DocsPreviewBundleTests(unittest.TestCase):
 
     def test_rejects_nul_in_handler_and_cleans_staging(self):
         entries = valid_entries()
-        config_index = next(
+        self.replace_config(
+            entries,
+            {"runtime": "nodejs20.x", "handler": "index.js\u0000"},
+        )
+        self.assert_rejected(entries)
+
+    def test_rejects_non_standard_json_constants(self):
+        entries = valid_entries()
+        index = next(
             i for i, entry in enumerate(entries) if entry[1].endswith(".vc-config.json")
         )
-        entries[config_index] = file_entry(
-            entries[config_index][1],
-            json.dumps({"runtime": "nodejs20.x", "handler": "index.js\u0000"}).encode(),
+        entries[index] = file_entry(
+            entries[index][1],
+            b'{"runtime":"nodejs20.x","handler":NaN}',
         )
         self.assert_rejected(entries)
 
@@ -279,20 +301,57 @@ class DocsPreviewBundleTests(unittest.TestCase):
             extract_bundle(self.archive, self.destination)
         self.assertFalse(self.destination.exists())
 
-    def test_rejects_excessive_trace_references(self):
-        entries = valid_entries()
-        trace_index = next(
-            i for i, entry in enumerate(entries) if entry[1].endswith(".nft.json")
+    def test_rejects_excessive_file_path_map_references(self):
+        self.assert_rejected(
+            valid_entries(),
+            limits=Limits(max_file_path_references=0),
         )
-        entries[trace_index] = file_entry(
-            entries[trace_index][1],
-            json.dumps({"version": 1, "files": ["index.js", "index.js"]}).encode(),
+
+    def test_seal_materializes_external_references_and_rewrites_config(self):
+        source = self.root / "source"
+        function = source / ".vercel/output/functions/app.func"
+        dependency = source / "website/node_modules/pkg/index.js"
+        function.mkdir(parents=True)
+        dependency.parent.mkdir(parents=True)
+        dependency.write_text("module.exports = 1", encoding="utf-8")
+        config = {
+            "runtime": "nodejs20.x",
+            "handler": "index.js",
+            "filePathMap": {"index.js": "website/node_modules/pkg/index.js"},
+        }
+        config_path = function / ".vc-config.json"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+
+        seal_bundle(source, self.archive)
+        rewritten = json.loads(config_path.read_text(encoding="utf-8"))
+        materialized = rewritten["filePathMap"]["index.js"]
+        self.assertTrue(materialized.startswith(".vercel/output/.docs-preview-files/"))
+
+        extract_bundle(self.archive, self.destination)
+        self.assertTrue((self.destination / materialized).is_file())
+        self.assertFalse((self.destination / "website").exists())
+
+    def test_seal_rejects_reference_that_resolves_outside_source_root(self):
+        source = self.root / "source"
+        function = source / ".vercel/output/functions/app.func"
+        function.mkdir(parents=True)
+        (function / ".vc-config.json").write_text(
+            json.dumps(
+                {
+                    "runtime": "nodejs20.x",
+                    "handler": "index.js",
+                    "filePathMap": {"index.js": "../outside.js"},
+                }
+            ),
+            encoding="utf-8",
         )
-        self.assert_rejected(entries, limits=Limits(max_trace_references=1))
+        with self.assertRaises(BundleError):
+            seal_bundle(source, self.archive)
+        self.assertFalse(self.archive.exists())
 
     def test_preserves_only_executable_or_non_executable_modes(self):
         entries = valid_entries()
-        script = "website/node_modules/pkg/tool"
+        script = ".vercel/output/tool"
         entries.append(file_entry(script, b"#!/bin/sh\n", mode=0o4777))
         self.extract(entries)
         extracted_mode = os.stat(self.destination / script).st_mode & 0o7777

--- a/.github/scripts/test_docs_preview_bundle.py
+++ b/.github/scripts/test_docs_preview_bundle.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from docs_preview_bundle import BundleError, Limits, extract_bundle
+
+
+def file_entry(name, content=b"x", mode=0o644):
+    return ("file", name, content, mode)
+
+
+def directory_entry(name):
+    return ("directory", name, b"", 0o755)
+
+
+def valid_entries(prefix=""):
+    function = f"{prefix}.vercel/output/functions/app.func"
+    return [
+        directory_entry(f"{prefix}.vercel/output"),
+        directory_entry(function),
+        file_entry(
+            f"{function}/.vc-config.json",
+            json.dumps({"runtime": "nodejs20.x", "handler": "index.js"}).encode(),
+        ),
+        file_entry(f"{function}/index.js", b"module.exports = {}"),
+        file_entry(
+            f"{function}/index.nft.json",
+            json.dumps(
+                {
+                    "version": 1,
+                    "files": [
+                        "index.js",
+                        "../../../../website/node_modules/pkg/index.js",
+                    ],
+                }
+            ).encode(),
+        ),
+        directory_entry(f"{prefix}website/node_modules/pkg"),
+        file_entry(f"{prefix}website/node_modules/pkg/index.js", b"module.exports = 1"),
+    ]
+
+
+def write_archive(path, entries):
+    with tarfile.open(path, "w:gz") as archive:
+        for kind, name, content, mode in entries:
+            info = tarfile.TarInfo(name)
+            info.mode = mode
+            if kind == "file":
+                info.size = len(content)
+                archive.addfile(info, io.BytesIO(content))
+            elif kind == "directory":
+                info.type = tarfile.DIRTYPE
+                archive.addfile(info)
+            elif kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = content.decode()
+                archive.addfile(info)
+            elif kind == "hardlink":
+                info.type = tarfile.LNKTYPE
+                info.linkname = content.decode()
+                archive.addfile(info)
+            elif kind == "fifo":
+                info.type = tarfile.FIFOTYPE
+                archive.addfile(info)
+            elif kind == "pax-size":
+                info.size = len(content)
+                info.pax_headers = {"size": "999999999"}
+                archive.addfile(info, io.BytesIO(content))
+            elif kind == "pax-unknown":
+                info.size = len(content)
+                info.pax_headers = {"uid": "999"}
+                archive.addfile(info, io.BytesIO(content))
+            else:
+                raise AssertionError(kind)
+
+
+class DocsPreviewBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.archive = self.root / "bundle.tgz"
+        self.destination = self.root / "deploy"
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def extract(self, entries, limits=None):
+        write_archive(self.archive, entries)
+        extract_bundle(self.archive, self.destination, limits=limits)
+
+    def assert_rejected(self, entries, limits=None):
+        write_archive(self.archive, entries)
+        with self.assertRaises(BundleError):
+            extract_bundle(self.archive, self.destination, limits=limits)
+        self.assertFalse(self.destination.exists(), "failed extraction must not be published")
+        self.assertEqual(
+            list(self.root.glob(".deploy.*")),
+            [],
+            "failed extraction must remove its staging directory",
+        )
+
+    def test_extracts_valid_bundle(self):
+        self.extract(valid_entries())
+        self.assertTrue(
+            (
+                self.destination
+                / ".vercel/output/functions/app.func/.vc-config.json"
+            ).is_file()
+        )
+        self.assertTrue(
+            (self.destination / "website/node_modules/pkg/index.js").is_file()
+        )
+
+    def test_accepts_explicit_dot_slash_prefix(self):
+        self.extract(valid_entries(prefix="./"))
+        self.assertTrue((self.destination / ".vercel/output").is_dir())
+
+    def test_accepts_bounded_long_name_metadata(self):
+        long_path = "website/node_modules/" + "/".join(["nested"] * 20) + "/index.js"
+        entries = valid_entries() + [file_entry(long_path)]
+        self.extract(entries)
+        self.assertTrue((self.destination / long_path).is_file())
+
+    def test_rejects_traversal_absolute_backslash_and_empty_components(self):
+        unsafe_names = [
+            "../../website/node_modules/escape",
+            "/website/node_modules/escape",
+            "website\\node_modules\\escape",
+            "website//node_modules/escape",
+            "website/./node_modules/escape",
+        ]
+        for index, name in enumerate(unsafe_names):
+            with self.subTest(name=name):
+                archive = self.root / f"unsafe-{index}.tgz"
+                destination = self.root / f"unsafe-{index}"
+                write_archive(archive, valid_entries() + [file_entry(name)])
+                with self.assertRaises(BundleError):
+                    extract_bundle(archive, destination)
+                self.assertFalse(destination.exists())
+
+    def test_rejects_unexpected_top_level_path(self):
+        self.assert_rejected(valid_entries() + [file_entry("package.json")])
+
+    def test_rejects_links_and_special_files(self):
+        for index, entry in enumerate(
+            [
+                ("symlink", "website/node_modules/link", b"/etc/passwd", 0o777),
+                (
+                    "hardlink",
+                    "website/node_modules/link",
+                    b"website/node_modules/pkg/index.js",
+                    0o644,
+                ),
+                ("fifo", "website/node_modules/pipe", b"", 0o644),
+            ]
+        ):
+            with self.subTest(kind=entry[0]):
+                archive = self.root / f"special-{index}.tgz"
+                destination = self.root / f"special-{index}"
+                write_archive(archive, valid_entries() + [entry])
+                with self.assertRaises(BundleError):
+                    extract_bundle(archive, destination)
+                self.assertFalse(destination.exists())
+
+    def test_rejects_duplicate_member(self):
+        self.assert_rejected(
+            valid_entries()
+            + [file_entry("website/node_modules/pkg/index.js", b"replacement")]
+        )
+
+    def test_rejects_pax_size_override_before_tarfile_parses_it(self):
+        self.assert_rejected(
+            valid_entries()
+            + [
+                (
+                    "pax-size",
+                    "website/node_modules/pkg/override.js",
+                    b"x",
+                    0o644,
+                )
+            ]
+        )
+
+    def test_rejects_unsupported_pax_parser_inputs(self):
+        self.assert_rejected(
+            valid_entries()
+            + [
+                (
+                    "pax-unknown",
+                    "website/node_modules/pkg/override.js",
+                    b"x",
+                    0o644,
+                )
+            ]
+        )
+
+    def test_enforces_tar_metadata_member_limit(self):
+        long_path = "website/node_modules/" + "/".join(["nested"] * 20) + "/index.js"
+        self.assert_rejected(
+            valid_entries() + [file_entry(long_path)],
+            limits=Limits(max_metadata_member_bytes=8),
+        )
+
+    def test_enforces_member_file_total_and_compressed_limits(self):
+        base = valid_entries()
+        write_archive(self.archive, base)
+        archive_size = self.archive.stat().st_size
+        cases = [
+            Limits(max_members=len(base) - 1),
+            Limits(max_file_bytes=4),
+            Limits(max_total_bytes=8),
+            Limits(max_archive_bytes=archive_size - 1),
+        ]
+        for index, limits in enumerate(cases):
+            with self.subTest(limit=index):
+                destination = self.root / f"limit-{index}"
+                with self.assertRaises(BundleError):
+                    extract_bundle(self.archive, destination, limits=limits)
+                self.assertFalse(destination.exists())
+
+    def test_rejects_nft_path_escape_and_missing_reference(self):
+        for index, reference in enumerate(
+            ["../../../../../outside", "../../../../website/node_modules/missing.js"]
+        ):
+            entries = valid_entries()
+            trace_index = next(
+                i for i, entry in enumerate(entries) if entry[1].endswith(".nft.json")
+            )
+            entries[trace_index] = file_entry(
+                entries[trace_index][1],
+                json.dumps({"version": 1, "files": [reference]}).encode(),
+            )
+            archive = self.root / f"trace-{index}.tgz"
+            destination = self.root / f"trace-{index}"
+            write_archive(archive, entries)
+            with self.assertRaises(BundleError):
+                extract_bundle(archive, destination)
+            self.assertFalse(destination.exists())
+
+    def test_rejects_handler_escape_and_missing_handler(self):
+        for index, handler in enumerate(
+            ["../../../../website/node_modules/pkg/index.js", "missing.js"]
+        ):
+            entries = valid_entries()
+            config_index = next(
+                i for i, entry in enumerate(entries) if entry[1].endswith(".vc-config.json")
+            )
+            entries[config_index] = file_entry(
+                entries[config_index][1],
+                json.dumps({"runtime": "nodejs20.x", "handler": handler}).encode(),
+            )
+            archive = self.root / f"handler-{index}.tgz"
+            destination = self.root / f"handler-{index}"
+            write_archive(archive, entries)
+            with self.assertRaises(BundleError):
+                extract_bundle(archive, destination)
+            self.assertFalse(destination.exists())
+
+    def test_rejects_nul_in_handler_and_cleans_staging(self):
+        entries = valid_entries()
+        config_index = next(
+            i for i, entry in enumerate(entries) if entry[1].endswith(".vc-config.json")
+        )
+        entries[config_index] = file_entry(
+            entries[config_index][1],
+            json.dumps({"runtime": "nodejs20.x", "handler": "index.js\u0000"}).encode(),
+        )
+        self.assert_rejected(entries)
+
+    def test_malformed_gzip_is_reported_as_bundle_error(self):
+        self.archive.write_bytes(b"not gzip")
+        with self.assertRaises(BundleError):
+            extract_bundle(self.archive, self.destination)
+        self.assertFalse(self.destination.exists())
+
+    def test_rejects_excessive_trace_references(self):
+        entries = valid_entries()
+        trace_index = next(
+            i for i, entry in enumerate(entries) if entry[1].endswith(".nft.json")
+        )
+        entries[trace_index] = file_entry(
+            entries[trace_index][1],
+            json.dumps({"version": 1, "files": ["index.js", "index.js"]}).encode(),
+        )
+        self.assert_rejected(entries, limits=Limits(max_trace_references=1))
+
+    def test_preserves_only_executable_or_non_executable_modes(self):
+        entries = valid_entries()
+        script = "website/node_modules/pkg/tool"
+        entries.append(file_entry(script, b"#!/bin/sh\n", mode=0o4777))
+        self.extract(entries)
+        extracted_mode = os.stat(self.destination / script).st_mode & 0o7777
+        self.assertEqual(extracted_mode, 0o755)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_docs_preview_bundle.py
+++ b/.github/scripts/test_docs_preview_bundle.py
@@ -307,6 +307,12 @@ class DocsPreviewBundleTests(unittest.TestCase):
             limits=Limits(max_file_path_references=0),
         )
 
+    def test_rejects_excessive_file_path_map_entries_per_config(self):
+        self.assert_rejected(
+            valid_entries(),
+            limits=Limits(max_file_path_references_per_config=0),
+        )
+
     def test_seal_materializes_external_references_and_rewrites_config(self):
         source = self.root / "source"
         function = source / ".vercel/output/functions/app.func"

--- a/.github/scripts/test_docs_preview_github.py
+++ b/.github/scripts/test_docs_preview_github.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from docs_preview_github import (
+    ApiError,
+    PullState,
+    associated_pr_number,
+    prepare,
+    reconcile_mode,
+    upsert_preview_comment,
+    workflow_pr_number,
+)
+
+
+SHA = "a" * 40
+REPOSITORY = "RaoFoundation/subtensor"
+
+
+class FakeGitHubClient:
+    def __init__(self, responses, artifact_entries=None):
+        self.repository = REPOSITORY
+        self.responses = iter(responses)
+        self.artifact_entries = artifact_entries or []
+        self.calls = []
+
+    def request_json(self, method, path, query=None, body=None):
+        self.calls.append((method, path, query, body))
+        return next(self.responses)
+
+    def download(self, path, destination, maximum_bytes):
+        self.calls.append(("DOWNLOAD", path, maximum_bytes, None))
+        with zipfile.ZipFile(destination, "w", zipfile.ZIP_DEFLATED) as archive:
+            for name, content in self.artifact_entries:
+                archive.writestr(name, content)
+
+
+class DocsPreviewGitHubTests(unittest.TestCase):
+    def test_resolves_pr_from_workflow_payload_without_commit_lookup(self):
+        self.assertEqual(workflow_pr_number('[{"number": 42}]'), "42")
+        self.assertIsNone(workflow_pr_number("[]"))
+        with self.assertRaises(ApiError):
+            workflow_pr_number('[{"number": 42}, {"number": 43}]')
+        with self.assertRaises(ApiError):
+            workflow_pr_number("{}")
+
+    def test_commit_fallback_requires_one_matching_same_repository_pr(self):
+        pulls = [
+            {
+                "number": 42,
+                "head": {"sha": SHA, "repo": {"full_name": REPOSITORY}},
+            },
+            {
+                "number": 43,
+                "head": {"sha": SHA, "repo": {"full_name": "fork/repository"}},
+            },
+        ]
+        self.assertEqual(
+            associated_pr_number(pulls, SHA, REPOSITORY),
+            "42",
+        )
+        with self.assertRaises(ApiError):
+            associated_pr_number([], SHA, REPOSITORY)
+
+    def test_reconciliation_fails_closed_for_stale_or_foreign_heads(self):
+        matching = PullState("42", "open", SHA, REPOSITORY)
+        stale = PullState("42", "open", "b" * 40, REPOSITORY)
+        foreign = PullState("42", "open", SHA, "fork/repository")
+        closed = PullState("42", "closed", SHA, REPOSITORY)
+        self.assertEqual(reconcile_mode("deploy", matching, SHA, REPOSITORY), "deploy")
+        self.assertEqual(reconcile_mode("deploy", stale, SHA, REPOSITORY), "noop")
+        self.assertEqual(reconcile_mode("deploy", foreign, SHA, REPOSITORY), "noop")
+        self.assertEqual(reconcile_mode("deploy", closed, SHA, REPOSITORY), "cleanup")
+        self.assertEqual(reconcile_mode("cleanup", matching, SHA, REPOSITORY), "noop")
+
+    def test_prepare_validates_artifact_and_emits_bounded_outputs(self):
+        responses = [
+            {
+                "total_count": 1,
+                "artifacts": [{"id": 7, "size_in_bytes": 100, "expired": False}],
+            },
+            {
+                "state": "open",
+                "head": {"sha": SHA, "repo": {"full_name": REPOSITORY}},
+            },
+        ]
+        client = FakeGitHubClient(
+            responses,
+            [
+                ("docs-preview-action.txt", b"deploy\n"),
+                ("docs-preview-pr-number.txt", b"42\n"),
+                ("docs-preview-sealed.tgz", b"bundle"),
+            ],
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            summary = root / "summary"
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_OUTPUT": str(output),
+                    "GITHUB_STEP_SUMMARY": str(summary),
+                },
+            ):
+                prepare(
+                    client,
+                    '[{"number": 42}]',
+                    SHA,
+                    "99",
+                    "bittensor.com",
+                    root / "artifact.zip",
+                    root / "artifact",
+                )
+            outputs = output.read_text(encoding="utf-8")
+        self.assertIn("pr=42\n", outputs)
+        self.assertIn("action=deploy\n", outputs)
+        self.assertIn("mode=deploy\n", outputs)
+        self.assertIn("alias=pr-42.preview.bittensor.com\n", outputs)
+        self.assertFalse(any(call[1].startswith("commits/") for call in client.calls))
+
+    def test_upsert_comment_updates_existing_marker_across_pages(self):
+        client = FakeGitHubClient(
+            [
+                [{"id": index, "body": "other"} for index in range(100)],
+                [{"id": 501, "body": "<!-- docs-preview-url -->"}],
+                {},
+            ]
+        )
+        upsert_preview_comment(
+            client,
+            "42",
+            "dpl_abc123",
+            "https://pr-42.preview.bittensor.com",
+        )
+        self.assertEqual(client.calls[-1][0:2], ("PATCH", "issues/comments/501"))
+        body = client.calls[-1][3]["body"]
+        self.assertIn("dpl_abc123", body)
+        self.assertIn("https://pr-42.preview.bittensor.com/docs", body)
+
+    def test_upsert_comment_rejects_unbounded_values(self):
+        client = FakeGitHubClient([])
+        invalid = [
+            ("not-a-number", "dpl_abc123", "https://pr-42.preview.bittensor.com"),
+            ("42", "bad-id", "https://pr-42.preview.bittensor.com"),
+            ("42", "dpl_abc123", "https://example.com\ninjected"),
+        ]
+        for values in invalid:
+            with self.subTest(values=values), self.assertRaises(ValueError):
+                upsert_preview_comment(client, *values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_docs_preview_vercel.py
+++ b/.github/scripts/test_docs_preview_vercel.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import Mock
+
+from docs_preview_vercel import (
+    ApiError,
+    UnsafeEnvironmentVariable,
+    VercelClient,
+    audit_environment,
+    deployment_ids_for_pr,
+    unsafe_preview_variables,
+)
+
+
+class FakeClient(VercelClient):
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = []
+        super().__init__("token", "team")
+
+    def request(self, method, path, query=None):
+        self.calls.append((method, path, dict(query or {})))
+        return next(self.responses)
+
+
+class DocsPreviewVercelTests(unittest.TestCase):
+    def test_flags_project_and_shared_preview_variables_without_values(self):
+        unsafe = unsafe_preview_variables(
+            [
+                {
+                    "key": "PROJECT_SECRET",
+                    "value": "must-not-appear",
+                    "target": ["preview"],
+                },
+                {"key": "PRODUCTION_ONLY", "target": ["production"]},
+                {"key": "VERCEL_ENV", "target": ["preview"], "system": True},
+            ],
+            [
+                {"key": "SHARED_SECRET", "target": "preview"},
+                {"key": "SHARED_PROD", "target": "production"},
+            ],
+        )
+        self.assertEqual(
+            unsafe,
+            [
+                UnsafeEnvironmentVariable("project", "PROJECT_SECRET"),
+                UnsafeEnvironmentVariable("team-shared", "SHARED_SECRET"),
+            ],
+        )
+        self.assertNotIn("must-not-appear", repr(unsafe))
+
+    def test_unknown_environment_shapes_fail_closed(self):
+        unsafe = unsafe_preview_variables([{"key": "UNKNOWN"}], [None])
+        self.assertEqual(
+            unsafe,
+            [
+                UnsafeEnvironmentVariable("project", "UNKNOWN"),
+                UnsafeEnvironmentVariable("team-shared", "<invalid-response>"),
+            ],
+        )
+
+    def test_environment_audit_covers_project_and_linked_shared_variables(self):
+        client = Mock()
+        client.paginated.side_effect = [[], []]
+        audit_environment(client, "prj_preview")
+        self.assertEqual(
+            client.paginated.call_args_list[0].args,
+            ("/v10/projects/prj_preview/env", "envs", {"decrypt": "false"}),
+        )
+        self.assertEqual(
+            client.paginated.call_args_list[1].args,
+            ("/v1/env", "data", {"projectId": "prj_preview"}),
+        )
+
+        client.paginated.side_effect = [
+            [{"key": "SECRET_VALUE", "value": "do-not-log", "target": ["preview"]}],
+            [],
+        ]
+        with self.assertRaises(ApiError) as context:
+            audit_environment(client, "prj_preview")
+        self.assertIn("SECRET_VALUE", str(context.exception))
+        self.assertNotIn("do-not-log", str(context.exception))
+
+    def test_pagination_collects_every_page_and_rejects_cursor_loops(self):
+        client = FakeClient(
+            [
+                {
+                    "data": [{"id": "one"}],
+                    "pagination": {"next": 123},
+                },
+                {
+                    "data": [{"id": "two"}],
+                    "pagination": {"next": None},
+                },
+            ]
+        )
+        self.assertEqual(
+            client.paginated("/v1/env", "data", {"projectId": "project"}),
+            [{"id": "one"}, {"id": "two"}],
+        )
+        self.assertEqual(client.calls[1][2]["until"], "123")
+
+        loop = FakeClient(
+            [
+                {"data": [], "pagination": {"next": 123}},
+                {"data": [], "pagination": {"next": 123}},
+            ]
+        )
+        with self.assertRaises(ApiError):
+            loop.paginated("/v1/env", "data")
+
+    def test_selects_only_matching_obsolete_deployments(self):
+        deployments = [
+            {"uid": "keep", "meta": {"docsPreviewPr": "42"}},
+            {"uid": "old", "meta": {"docsPreviewPr": 42}},
+            {"uid": "other", "meta": {"docsPreviewPr": "43"}},
+            {"uid": "unmarked", "meta": {}},
+        ]
+        self.assertEqual(
+            deployment_ids_for_pr(deployments, "42", keep_deployment_id="keep"),
+            ["old"],
+        )
+
+    def test_invalid_deployment_response_fails_closed(self):
+        with self.assertRaises(ApiError):
+            deployment_ids_for_pr([None], "42")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_docs_preview_vercel.py
+++ b/.github/scripts/test_docs_preview_vercel.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 
+import json
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import Mock
 
 from docs_preview_vercel import (
     ApiError,
     UnsafeEnvironmentVariable,
     VercelClient,
-    audit_environment,
+    audit_project,
+    deployment_id_for_url,
     deployment_ids_for_pr,
+    remove_alias,
+    set_alias,
     unsafe_preview_variables,
+    validate_configuration,
+    write_project_link,
 )
 
 
@@ -19,8 +27,15 @@ class FakeClient(VercelClient):
         self.calls = []
         super().__init__("token", "team")
 
-    def request(self, method, path, query=None):
-        self.calls.append((method, path, dict(query or {})))
+    def request(
+        self,
+        method,
+        path,
+        query=None,
+        body=None,
+        allow_missing=False,
+    ):
+        self.calls.append((method, path, dict(query or {}), body, allow_missing))
         return next(self.responses)
 
 
@@ -60,10 +75,14 @@ class DocsPreviewVercelTests(unittest.TestCase):
             ],
         )
 
-    def test_environment_audit_covers_project_and_linked_shared_variables(self):
+    def test_project_audit_covers_environment_and_verified_wildcard(self):
         client = Mock()
         client.paginated.side_effect = [[], []]
-        audit_environment(client, "prj_preview")
+        client.request.return_value = {
+            "name": "*.preview.bittensor.com",
+            "verified": True,
+        }
+        audit_project(client, "prj_preview", "*.preview.bittensor.com")
         self.assertEqual(
             client.paginated.call_args_list[0].args,
             ("/v10/projects/prj_preview/env", "envs", {"decrypt": "false"}),
@@ -72,15 +91,78 @@ class DocsPreviewVercelTests(unittest.TestCase):
             client.paginated.call_args_list[1].args,
             ("/v1/env", "data", {"projectId": "prj_preview"}),
         )
+        self.assertEqual(
+            client.request.call_args.args,
+            (
+                "GET",
+                "/v9/projects/prj_preview/domains/%2A.preview.bittensor.com",
+            ),
+        )
 
+    def test_project_audit_rejects_secrets_without_logging_values(self):
+        client = Mock()
         client.paginated.side_effect = [
             [{"key": "SECRET_VALUE", "value": "do-not-log", "target": ["preview"]}],
             [],
         ]
         with self.assertRaises(ApiError) as context:
-            audit_environment(client, "prj_preview")
+            audit_project(client, "prj_preview", "*.preview.bittensor.com")
         self.assertIn("SECRET_VALUE", str(context.exception))
         self.assertNotIn("do-not-log", str(context.exception))
+        client.request.assert_not_called()
+
+    def test_project_audit_rejects_missing_or_unverified_wildcard(self):
+        for response in (
+            None,
+            {"name": "*.preview.bittensor.com", "verified": False},
+            {"name": "other.example", "verified": True},
+        ):
+            with self.subTest(response=response):
+                client = Mock()
+                client.paginated.side_effect = [[], []]
+                client.request.return_value = response
+                with self.assertRaises(ApiError):
+                    audit_project(
+                        client,
+                        "prj_preview",
+                        "*.preview.bittensor.com",
+                    )
+
+    def test_configuration_requires_distinct_valid_projects(self):
+        validate_configuration(
+            "team_123",
+            "prj_preview",
+            "prj_production",
+            "bittensor.com",
+        )
+        with self.assertRaises(ValueError):
+            validate_configuration(
+                "team_123",
+                "prj_same",
+                "prj_same",
+                "bittensor.com",
+            )
+        with self.assertRaises(ValueError):
+            validate_configuration(
+                "team_123",
+                "prj_preview",
+                "prj_production",
+                "../bittensor.com",
+            )
+
+    def test_project_link_contains_only_expected_identifiers_and_settings(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            write_project_link(root, "team_123", "prj_preview", True)
+            payload = json.loads(
+                (root / ".vercel/project.json").read_text(encoding="utf-8")
+            )
+        self.assertEqual(payload["orgId"], "team_123")
+        self.assertEqual(payload["projectId"], "prj_preview")
+        self.assertEqual(
+            payload["settings"]["rootDirectory"],
+            "website/apps/bittensor-website",
+        )
 
     def test_pagination_collects_every_page_and_rejects_cursor_loops(self):
         client = FakeClient(
@@ -109,6 +191,58 @@ class DocsPreviewVercelTests(unittest.TestCase):
         )
         with self.assertRaises(ApiError):
             loop.paginated("/v1/env", "data")
+
+    def test_deployment_lookup_and_alias_switch_use_bounded_identifiers(self):
+        client = FakeClient([{"id": "dpl_abc123", "projectId": "prj_preview"}, {}])
+        deployment_id = deployment_id_for_url(
+            client,
+            "prj_preview",
+            "https://preview-abc.vercel.app",
+        )
+        self.assertEqual(deployment_id, "dpl_abc123")
+        set_alias(client, deployment_id, "pr-42.preview.bittensor.com")
+        self.assertEqual(
+            client.calls[1],
+            (
+                "POST",
+                "/v2/deployments/dpl_abc123/aliases",
+                {},
+                {"alias": "pr-42.preview.bittensor.com"},
+                False,
+            ),
+        )
+        wrong_project = FakeClient(
+            [{"id": "dpl_abc123", "projectId": "prj_production"}]
+        )
+        with self.assertRaises(ApiError):
+            deployment_id_for_url(
+                wrong_project,
+                "prj_preview",
+                "https://preview-abc.vercel.app",
+            )
+
+    def test_alias_removal_is_confined_to_preview_project(self):
+        client = FakeClient(
+            [
+                {"uid": "alias_123", "projectId": "prj_preview"},
+                {},
+            ]
+        )
+        self.assertTrue(
+            remove_alias(client, "prj_preview", "pr-42.preview.bittensor.com")
+        )
+        self.assertEqual(client.calls[1][0:2], ("DELETE", "/now/aliases/alias_123"))
+
+        wrong_project = FakeClient(
+            [{"uid": "alias_123", "projectId": "prj_production"}]
+        )
+        with self.assertRaises(ApiError):
+            remove_alias(
+                wrong_project,
+                "prj_preview",
+                "pr-42.preview.bittensor.com",
+            )
+        self.assertEqual(len(wrong_project.calls), 1)
 
     def test_selects_only_matching_obsolete_deployments(self):
         deployments = [

--- a/.github/scripts/test_docs_preview_workflows.py
+++ b/.github/scripts/test_docs_preview_workflows.py
@@ -11,6 +11,8 @@ DEPLOY_WORKFLOW = REPOSITORY / ".github/workflows/deploy-docs-preview.yml"
 REQUEST_WORKFLOW = REPOSITORY / ".github/workflows/request-docs-preview.yml"
 BUNDLE_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_bundle.py"
 ARTIFACT_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_artifact.py"
+GITHUB_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_github.py"
+VERCEL_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_vercel.py"
 CLI_PACKAGE = REPOSITORY / ".github/docs-preview-vercel/package.json"
 CLI_LOCK = REPOSITORY / ".github/docs-preview-vercel/package-lock.json"
 ACTION_SHA = re.compile(r"^\s*uses:\s+[^#\s]+@[0-9a-f]{40}(?:\s+#.*)?$")
@@ -22,11 +24,16 @@ class DocsPreviewWorkflowPolicyTests(unittest.TestCase):
         cls.deploy = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
         cls.request = REQUEST_WORKFLOW.read_text(encoding="utf-8")
         cls.bundle = BUNDLE_SCRIPT.read_text(encoding="utf-8")
+        cls.artifact = ARTIFACT_SCRIPT.read_text(encoding="utf-8")
+        cls.github = GITHUB_SCRIPT.read_text(encoding="utf-8")
+        cls.vercel = VERCEL_SCRIPT.read_text(encoding="utf-8")
 
     def test_every_external_action_is_pinned_to_a_commit(self):
         for workflow in (self.deploy, self.request):
             uses_lines = [
-                line for line in workflow.splitlines() if line.lstrip().startswith("uses:")
+                line
+                for line in workflow.splitlines()
+                if line.lstrip().startswith("uses:")
             ]
             self.assertTrue(uses_lines)
             for line in uses_lines:
@@ -38,6 +45,7 @@ class DocsPreviewWorkflowPolicyTests(unittest.TestCase):
         self.assertGreaterEqual(self.request.count("runs-on: ubuntu-24.04"), 2)
         self.assertIn("persist-credentials: false", self.request)
         self.assertIn("cancel-in-progress: true", self.request)
+        self.assertIn("retention-days: 1", self.request)
 
     def test_trusted_workflow_never_checks_out_pr_head(self):
         self.assertNotIn("pull_request.head.sha", self.deploy)
@@ -46,25 +54,27 @@ class DocsPreviewWorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("self-hosted", self.deploy)
         self.assertIn("runs-on: ubuntu-24.04", self.deploy)
 
-    def test_trusted_workflow_only_uses_expected_secrets(self):
+    def test_trusted_workflow_only_uses_vercel_deploy_token(self):
         secret_names = set(re.findall(r"secrets\.([A-Z0-9_]+)", self.deploy))
-        self.assertEqual(
-            secret_names,
-            {"GODADDY_API_KEY", "GODADDY_API_SECRET", "VERCEL_TOKEN"},
+        self.assertEqual(secret_names, {"VERCEL_TOKEN"})
+        self.assertNotIn("GODADDY", self.deploy)
+        self.assertNotIn("api.godaddy.com", self.deploy)
+        self.assertNotRegex(
+            self.deploy,
+            r"(?m)^\s{4}env:\s*\n(?:\s{6}.+\n)*\s{6}\w+:\s*\$\{\{\s*secrets\.",
         )
-        self.assertNotRegex(self.deploy, r"(?m)^\s{4}env:\s*\n(?:\s{6}.+\n)*\s{6}\w+:\s*\$\{\{\s*secrets\.")
 
     def test_dedicated_preview_project_is_enforced_in_both_halves(self):
         for workflow in (self.deploy, self.request):
             self.assertIn("VERCEL_DOCS_PREVIEW_PROJECT_ID", workflow)
             self.assertIn("VERCEL_DOCS_PROJECT_ID", workflow)
-            self.assertIn(
-                "must identify a dedicated, non-production project", workflow
-            )
-        self.assertNotIn(
-            "secrets.VERCEL_DOCS_PROJECT_ID",
-            self.deploy,
+            self.assertIn("validate-config", workflow)
+        self.assertIn(
+            "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated",
+            self.vercel,
         )
+        self.assertIn('"non-production project"', self.vercel)
+        self.assertNotIn("secrets.VERCEL_DOCS_PROJECT_ID", self.deploy)
         self.assertIn("vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''", self.deploy)
         self.assertGreaterEqual(
             self.request.count("vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''"),
@@ -72,50 +82,64 @@ class DocsPreviewWorkflowPolicyTests(unittest.TestCase):
         )
 
     def test_deploy_queue_and_stale_run_controls_are_present(self):
-        self.assertIn("queue: max", self.deploy)
-        self.assertIn("Reconcile artifact intent with current PR state", self.deploy)
+        self.assertIn("cancel-in-progress: false", self.deploy)
+        self.assertIn("group: docs-preview-", self.deploy)
+        self.assertIn(
+            "Resolve, download, and authorize the producing artifact", self.deploy
+        )
         self.assertIn("Re-check PR head immediately before deployment", self.deploy)
         self.assertIn("steps.recheck.outputs.authorized == 'true'", self.deploy)
-        self.assertIn(
-            "if: always() && steps.authorize.outputs.mode == 'cleanup'",
-            self.deploy,
-        )
+        self.assertIn("steps.meta.outputs.mode == 'cleanup'", self.deploy)
+        self.assertIn("head_repository.full_name == github.repository", self.deploy)
 
     def test_invalid_artifact_actions_and_shapes_fail_closed(self):
-        self.assertIn("invalid docs-preview action", self.deploy)
-        self.assertIn("artifact contains an unexpected file set", self.deploy)
-        self.assertIn("expected one ${artifact_name} artifact", self.deploy)
-        self.assertIn("artifact PR ${artifact_pr} does not match", self.deploy)
+        self.assertIn("invalid docs-preview action", self.artifact)
+        self.assertIn("artifact contains an unexpected file set", self.artifact)
+        self.assertIn("expected one {artifact_name} artifact", self.github)
+        self.assertIn("does not match workflow PR", self.artifact)
 
-    def test_secure_extractor_is_used_without_inline_tar_extraction(self):
-        artifact = ARTIFACT_SCRIPT.read_text(encoding="utf-8")
-        self.assertIn("docs_preview_artifact.py", self.deploy)
+    def test_secure_extractors_are_used_without_inline_archive_parsing(self):
+        self.assertIn("docs_preview_github.py", self.deploy)
         self.assertIn("docs_preview_bundle.py", self.deploy)
         self.assertNotIn("gh run download", self.deploy)
         self.assertNotIn("tarfile", self.deploy)
-        self.assertNotIn("extractall", artifact)
+        self.assertNotIn("extractall", self.artifact)
         self.assertNotIn("extractall", self.bundle)
         self.assertNotIn("getmembers", self.bundle)
         self.assertNotIn('lstrip("./")', self.bundle)
         self.assertIn('mode="r|gz"', self.bundle)
 
+    def test_bundle_is_self_contained_and_validates_every_vercel_file_map(self):
+        self.assertIn("seal_bundle", self.bundle)
+        self.assertIn('ALLOWED_ROOTS = (".vercel/output",)', self.bundle)
+        self.assertIn("filePathMap", self.bundle)
+        self.assertIn("filePathMap escapes the deployment root", self.bundle)
+        self.assertIn(".docs-preview-files", self.bundle)
+        self.assertNotIn("website/node_modules", self.deploy)
+        self.assertIn("docs_preview_bundle.py \\", self.request)
+        self.assertIn("seal \\", self.request)
+
     def test_preview_environment_and_deployment_lifecycle_are_guarded(self):
-        self.assertIn("audit-environment", self.deploy)
-        self.assertIn('client.paginated(project_path, "envs", {"decrypt": "false"})', (
-            REPOSITORY / ".github/scripts/docs_preview_vercel.py"
-        ).read_text(encoding="utf-8"))
-        self.assertIn('"projectId": project_id', (
-            REPOSITORY / ".github/scripts/docs_preview_vercel.py"
-        ).read_text(encoding="utf-8"))
-        self.assertIn("--meta \"docsPreviewPr=${PR_NUMBER}\"", self.deploy)
+        self.assertIn("audit-project", self.deploy)
+        self.assertIn('--preview-domain "*.preview.${DOCS_DOMAIN}"', self.deploy)
+        self.assertIn(
+            'client.paginated(project_path, "envs", {"decrypt": "false"})', self.vercel
+        )
+        self.assertIn('"projectId": project_id', self.vercel)
+        self.assertIn('--meta "docsPreviewPr=${PR_NUMBER}"', self.deploy)
         self.assertGreaterEqual(self.deploy.count("delete-pr-deployments"), 2)
-        self.assertIn("Roll back a failed new deployment", self.deploy)
+        self.assertIn("Roll back an unpromoted failed deployment", self.deploy)
         self.assertIn("id: alias", self.deploy)
         self.assertIn("steps.alias.outcome == 'skipped'", self.deploy)
-        rollback = self.deploy.split(
-            "- name: Roll back a failed new deployment", maxsplit=1
-        )[1].split("- name: Report a stale or superseded run", maxsplit=1)[0]
-        self.assertNotIn("/domains/", rollback)
+        self.assertNotIn("add-domain", self.deploy)
+        self.assertNotIn("remove-domain", self.deploy)
+
+    def test_trusted_workflow_delegates_control_plane_logic_to_tested_modules(self):
+        self.assertLessEqual(len(self.deploy.splitlines()), 320)
+        for forbidden in ("curl ", "jq ", "gh api", "node -e", "api.vercel.com"):
+            self.assertNotIn(forbidden, self.deploy)
+        self.assertGreaterEqual(self.deploy.count("docs_preview_github.py"), 3)
+        self.assertGreaterEqual(self.deploy.count("docs_preview_vercel.py"), 8)
 
     def test_cli_graph_is_locked_and_installed_without_scripts(self):
         package = json.loads(CLI_PACKAGE.read_text(encoding="utf-8"))

--- a/.github/scripts/test_docs_preview_workflows.py
+++ b/.github/scripts/test_docs_preview_workflows.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW = REPOSITORY / ".github/workflows/deploy-docs-preview.yml"
+REQUEST_WORKFLOW = REPOSITORY / ".github/workflows/request-docs-preview.yml"
+BUNDLE_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_bundle.py"
+ARTIFACT_SCRIPT = REPOSITORY / ".github/scripts/docs_preview_artifact.py"
+CLI_PACKAGE = REPOSITORY / ".github/docs-preview-vercel/package.json"
+CLI_LOCK = REPOSITORY / ".github/docs-preview-vercel/package-lock.json"
+ACTION_SHA = re.compile(r"^\s*uses:\s+[^#\s]+@[0-9a-f]{40}(?:\s+#.*)?$")
+
+
+class DocsPreviewWorkflowPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.deploy = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+        cls.request = REQUEST_WORKFLOW.read_text(encoding="utf-8")
+        cls.bundle = BUNDLE_SCRIPT.read_text(encoding="utf-8")
+
+    def test_every_external_action_is_pinned_to_a_commit(self):
+        for workflow in (self.deploy, self.request):
+            uses_lines = [
+                line for line in workflow.splitlines() if line.lstrip().startswith("uses:")
+            ]
+            self.assertTrue(uses_lines)
+            for line in uses_lines:
+                self.assertRegex(line, ACTION_SHA)
+
+    def test_untrusted_workflow_is_secret_free_and_ephemeral(self):
+        self.assertNotIn("secrets.", self.request)
+        self.assertNotIn("self-hosted", self.request)
+        self.assertGreaterEqual(self.request.count("runs-on: ubuntu-24.04"), 2)
+        self.assertIn("persist-credentials: false", self.request)
+        self.assertIn("cancel-in-progress: true", self.request)
+
+    def test_trusted_workflow_never_checks_out_pr_head(self):
+        self.assertNotIn("pull_request.head.sha", self.deploy)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", self.deploy)
+        self.assertIn("persist-credentials: false", self.deploy)
+        self.assertNotIn("self-hosted", self.deploy)
+        self.assertIn("runs-on: ubuntu-24.04", self.deploy)
+
+    def test_trusted_workflow_only_uses_expected_secrets(self):
+        secret_names = set(re.findall(r"secrets\.([A-Z0-9_]+)", self.deploy))
+        self.assertEqual(
+            secret_names,
+            {"GODADDY_API_KEY", "GODADDY_API_SECRET", "VERCEL_TOKEN"},
+        )
+        self.assertNotRegex(self.deploy, r"(?m)^\s{4}env:\s*\n(?:\s{6}.+\n)*\s{6}\w+:\s*\$\{\{\s*secrets\.")
+
+    def test_dedicated_preview_project_is_enforced_in_both_halves(self):
+        for workflow in (self.deploy, self.request):
+            self.assertIn("VERCEL_DOCS_PREVIEW_PROJECT_ID", workflow)
+            self.assertIn("VERCEL_DOCS_PROJECT_ID", workflow)
+            self.assertIn(
+                "must identify a dedicated, non-production project", workflow
+            )
+        self.assertNotIn(
+            "secrets.VERCEL_DOCS_PROJECT_ID",
+            self.deploy,
+        )
+        self.assertIn("vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''", self.deploy)
+        self.assertGreaterEqual(
+            self.request.count("vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''"),
+            2,
+        )
+
+    def test_deploy_queue_and_stale_run_controls_are_present(self):
+        self.assertIn("queue: max", self.deploy)
+        self.assertIn("Reconcile artifact intent with current PR state", self.deploy)
+        self.assertIn("Re-check PR head immediately before deployment", self.deploy)
+        self.assertIn("steps.recheck.outputs.authorized == 'true'", self.deploy)
+        self.assertIn(
+            "if: always() && steps.authorize.outputs.mode == 'cleanup'",
+            self.deploy,
+        )
+
+    def test_invalid_artifact_actions_and_shapes_fail_closed(self):
+        self.assertIn("invalid docs-preview action", self.deploy)
+        self.assertIn("artifact contains an unexpected file set", self.deploy)
+        self.assertIn("expected one ${artifact_name} artifact", self.deploy)
+        self.assertIn("artifact PR ${artifact_pr} does not match", self.deploy)
+
+    def test_secure_extractor_is_used_without_inline_tar_extraction(self):
+        artifact = ARTIFACT_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("docs_preview_artifact.py", self.deploy)
+        self.assertIn("docs_preview_bundle.py", self.deploy)
+        self.assertNotIn("gh run download", self.deploy)
+        self.assertNotIn("tarfile", self.deploy)
+        self.assertNotIn("extractall", artifact)
+        self.assertNotIn("extractall", self.bundle)
+        self.assertNotIn("getmembers", self.bundle)
+        self.assertNotIn('lstrip("./")', self.bundle)
+        self.assertIn('mode="r|gz"', self.bundle)
+
+    def test_preview_environment_and_deployment_lifecycle_are_guarded(self):
+        self.assertIn("audit-environment", self.deploy)
+        self.assertIn('client.paginated(project_path, "envs", {"decrypt": "false"})', (
+            REPOSITORY / ".github/scripts/docs_preview_vercel.py"
+        ).read_text(encoding="utf-8"))
+        self.assertIn('"projectId": project_id', (
+            REPOSITORY / ".github/scripts/docs_preview_vercel.py"
+        ).read_text(encoding="utf-8"))
+        self.assertIn("--meta \"docsPreviewPr=${PR_NUMBER}\"", self.deploy)
+        self.assertGreaterEqual(self.deploy.count("delete-pr-deployments"), 2)
+        self.assertIn("Roll back a failed new deployment", self.deploy)
+        self.assertIn("id: alias", self.deploy)
+        self.assertIn("steps.alias.outcome == 'skipped'", self.deploy)
+        rollback = self.deploy.split(
+            "- name: Roll back a failed new deployment", maxsplit=1
+        )[1].split("- name: Report a stale or superseded run", maxsplit=1)[0]
+        self.assertNotIn("/domains/", rollback)
+
+    def test_cli_graph_is_locked_and_installed_without_scripts(self):
+        package = json.loads(CLI_PACKAGE.read_text(encoding="utf-8"))
+        lock = json.loads(CLI_LOCK.read_text(encoding="utf-8"))
+        self.assertEqual(package["dependencies"], {"vercel": "56.4.1"})
+        self.assertEqual(lock["packages"][""]["dependencies"], package["dependencies"])
+        self.assertEqual(
+            lock["packages"]["node_modules/vercel"]["version"],
+            "56.4.1",
+        )
+        self.assertIn("tar", package["overrides"])
+        for workflow in (self.deploy, self.request):
+            self.assertIn("npm ci --ignore-scripts", workflow)
+            self.assertIn("npm audit --audit-level=high", workflow)
+            self.assertNotIn("npm install ", workflow)
+            self.assertNotIn("npx ", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/check-docs-preview-security.yml
+++ b/.github/workflows/check-docs-preview-security.yml
@@ -1,0 +1,64 @@
+name: Check Docs Preview Security
+
+on:
+  pull_request:
+    paths:
+      - ".github/docs-preview-vercel/**"
+      - ".github/scripts/docs_preview_*.py"
+      - ".github/scripts/test_docs_preview_*.py"
+      - ".github/workflows/check-docs-preview-security.yml"
+      - ".github/workflows/deploy-docs-preview.yml"
+      - ".github/workflows/request-docs-preview.yml"
+  push:
+    branches:
+      - main
+      - "release-v*"
+    paths:
+      - ".github/docs-preview-vercel/**"
+      - ".github/scripts/docs_preview_*.py"
+      - ".github/scripts/test_docs_preview_*.py"
+      - ".github/workflows/check-docs-preview-security.yml"
+      - ".github/workflows/deploy-docs-preview.yml"
+      - ".github/workflows/request-docs-preview.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  security-policy:
+    name: Docs preview trust-boundary tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out policy under test
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Parse workflow YAML
+        run: |
+          ruby -e '
+            require "yaml"
+            ARGV.each { |path| Psych.parse_file(path) }
+          ' \
+            .github/workflows/check-docs-preview-security.yml \
+            .github/workflows/deploy-docs-preview.yml \
+            .github/workflows/request-docs-preview.yml
+
+      - name: Run artifact and policy tests
+        run: |
+          python3 -m unittest discover \
+            --start-directory .github/scripts \
+            --pattern 'test_docs_preview_*.py'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: .github/docs-preview-vercel/package-lock.json
+
+      - name: Verify locked CLI graph
+        run: |
+          npm ci --ignore-scripts --prefix .github/docs-preview-vercel
+          npm audit --audit-level=high --omit=dev --prefix .github/docs-preview-vercel
+          .github/docs-preview-vercel/node_modules/.bin/vercel --version

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -1,11 +1,9 @@
 name: Deploy Docs Preview
 
-# Trusted half of docs previews. Always taken from the default branch
-# (`workflow_run`), so a PR cannot rewrite these steps to exfiltrate secrets.
-#
-# Never checks out PR HEAD and never runs PR-controlled scripts. Consumes only
-# the sealed artifact from `Request Docs Preview`, then deploys / aliases /
-# comments (or cleans up) with Vercel + GoDaddy credentials.
+# Trusted half of docs previews. GitHub loads workflow_run workflows from the
+# default branch. This job checks out only that branch, never PR HEAD, and
+# validates the PR-produced artifact before any deployment credential is
+# introduced. It stays disabled until VERCEL_DOCS_PREVIEW_PROJECT_ID is set.
 
 on:
   workflow_run:
@@ -17,28 +15,66 @@ permissions:
   contents: read
   pull-requests: write
 
+# Domain, deployment, and cleanup changes are globally serialized. Retain every
+# pending run; each run re-checks PR state and head SHA before changing Vercel.
+concurrency:
+  group: docs-preview-domain-dns
+  cancel-in-progress: false
+  queue: max
+
 jobs:
   deploy:
     name: Deploy or clean up docs preview
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
-    runs-on: [self-hosted, fireactions-turbo-8]
-    concurrency:
-      group: docs-preview-domain-dns
-      cancel-in-progress: false
-    # No secrets at job scope — each step opts into only what it needs so
-    # `npm install` / artifact extract never see Vercel/GoDaddy/GH credentials.
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''
+    runs-on: ubuntu-24.04
     env:
       DOCS_DOMAIN: ${{ vars.DOCS_DOMAIN || 'bittensor.com' }}
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PREVIEW_PROJECT_ID: ${{ vars.VERCEL_DOCS_PREVIEW_PROJECT_ID }}
+      VERCEL_PRODUCTION_PROJECT_ID: ${{ vars.VERCEL_DOCS_PROJECT_ID }}
     steps:
-      - name: Resolve PR number and download artifact
+      - name: Check out trusted controls from the default branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          path: trusted-source
+          sparse-checkout: |
+            .github/docs-preview-vercel
+            .github/scripts
+
+      - name: Require a dedicated preview project
+        run: |
+          set -euo pipefail
+          id_pattern='^[A-Za-z0-9_-]+$'
+          if ! [[ "${VERCEL_ORG_ID}" =~ ${id_pattern} ]] ||
+             ! [[ "${VERCEL_PREVIEW_PROJECT_ID}" =~ ${id_pattern} ]] ||
+             ! [[ "${VERCEL_PRODUCTION_PROJECT_ID}" =~ ${id_pattern} ]] ||
+             [ "${#VERCEL_ORG_ID}" -gt 128 ] ||
+             [ "${#VERCEL_PREVIEW_PROJECT_ID}" -gt 128 ] ||
+             [ "${#VERCEL_PRODUCTION_PROJECT_ID}" -gt 128 ]; then
+            echo "Set valid VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, and VERCEL_DOCS_PREVIEW_PROJECT_ID repository variables." >&2
+            exit 1
+          fi
+          if [ "${VERCEL_PREVIEW_PROJECT_ID}" = "${VERCEL_PRODUCTION_PROJECT_ID}" ]; then
+            echo "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated, non-production project." >&2
+            exit 1
+          fi
+          domain_pattern='^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$'
+          if ! [[ "${DOCS_DOMAIN}" =~ ${domain_pattern} ]] ||
+             [[ "${DOCS_DOMAIN}" == *..* ]] ||
+             [ "${#DOCS_DOMAIN}" -gt 253 ]; then
+            echo "DOCS_DOMAIN must be a valid lowercase DNS name." >&2
+            exit 1
+          fi
+
+      - name: Resolve and validate the producing artifact
         id: meta
         env:
-          # Pass event fields via env (never interpolate into the script body)
-          # so a crafted PR branch/title cannot break out of a shell quote.
-          # GH_TOKEN here is only for `gh run download` of our own artifact.
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -46,285 +82,475 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Prefer the pull_requests list; fall back to the commit→PR API when
-          # workflow_run omits it (race on just-opened PRs).
+          case "${WORKFLOW_HEAD_SHA}" in
+            *[!0-9a-f]*|'') echo "invalid workflow head SHA" >&2; exit 1 ;;
+          esac
+          case "${WORKFLOW_RUN_ID}" in
+            *[!0-9]*|'') echo "invalid workflow run ID" >&2; exit 1 ;;
+          esac
+
           pr=$(node -e '
-            const ev = JSON.parse(process.env.WORKFLOW_PULL_REQUESTS || "[]");
-            if (Array.isArray(ev) && ev[0] && ev[0].number) {
-              process.stdout.write(String(ev[0].number));
+            const pulls = JSON.parse(process.env.WORKFLOW_PULL_REQUESTS || "[]");
+            const numbers = [...new Set(
+              pulls.map((pull) => pull && pull.number).filter(Number.isSafeInteger)
+            )];
+            if (numbers.length > 1) {
+              process.stderr.write("workflow_run is associated with multiple PRs\n");
+              process.exit(1);
             }
+            if (numbers.length === 1) process.stdout.write(String(numbers[0]));
           ')
           if [ -z "${pr}" ]; then
-            pr=$(gh api \
-              "repos/${REPO}/commits/${WORKFLOW_HEAD_SHA}/pulls" \
-              --jq '.[0].number // empty')
+            associated=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${REPO}/commits/${WORKFLOW_HEAD_SHA}/pulls")
+            count=$(jq \
+              --arg sha "${WORKFLOW_HEAD_SHA}" \
+              --arg repo "${REPO}" \
+              '[.[] | select(.head.sha == $sha and .head.repo.full_name == $repo)] | length' \
+              <<<"${associated}")
+            if [ "${count}" != "1" ]; then
+              echo "expected exactly one same-repository PR for ${WORKFLOW_HEAD_SHA}, found ${count}" >&2
+              exit 1
+            fi
+            pr=$(jq -r \
+              --arg sha "${WORKFLOW_HEAD_SHA}" \
+              --arg repo "${REPO}" \
+              '.[] | select(.head.sha == $sha and .head.repo.full_name == $repo) | .number' \
+              <<<"${associated}")
           fi
-          if [ -z "${pr}" ]; then
-            echo "Could not resolve PR number for workflow_run ${WORKFLOW_RUN_ID}" >&2
+          case "${pr}" in
+            *[!0-9]*|'') echo "invalid PR number" >&2; exit 1 ;;
+          esac
+
+          artifact_name="docs-preview-${pr}"
+          artifact_response=$(gh api \
+            "repos/${REPO}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?name=${artifact_name}&per_page=100")
+          artifact_count=$(jq -r '.total_count' <<<"${artifact_response}")
+          if [ "${artifact_count}" != "1" ]; then
+            echo "expected one ${artifact_name} artifact, found ${artifact_count}" >&2
             exit 1
           fi
-          # PR numbers are digits only — reject anything else before using in paths.
-          case "${pr}" in
-            ''|*[!0-9]*) echo "invalid PR number: ${pr}" >&2; exit 1 ;;
+          artifact_size=$(jq -r '.artifacts[0].size_in_bytes' <<<"${artifact_response}")
+          artifact_id=$(jq -r '.artifacts[0].id' <<<"${artifact_response}")
+          artifact_expired=$(jq -r '.artifacts[0].expired' <<<"${artifact_response}")
+          case "${artifact_size}" in
+            *[!0-9]*|'') echo "invalid artifact size" >&2; exit 1 ;;
           esac
-          echo "pr=$pr" >> "$GITHUB_OUTPUT"
-          echo "alias=pr-${pr}.preview.${DOCS_DOMAIN}" >> "$GITHUB_OUTPUT"
-          echo "url=https://pr-${pr}.preview.${DOCS_DOMAIN}" >> "$GITHUB_OUTPUT"
+          case "${artifact_id}" in
+            *[!0-9]*|'') echo "invalid artifact ID" >&2; exit 1 ;;
+          esac
+          if [ "${artifact_expired}" != "false" ] || [ "${artifact_size}" -gt 2200000000 ]; then
+            echo "artifact is expired or exceeds the 2.2 GB download limit" >&2
+            exit 1
+          fi
 
-          # download-artifact@v4 needs the producing run id for workflow_run.
-          mkdir -p artifact
-          gh run download "${WORKFLOW_RUN_ID}" \
-            --repo "${REPO}" \
-            --name "docs-preview-${pr}" \
-            --dir artifact
-          action=$(tr -d '[:space:]' < artifact/docs-preview-action.txt)
-          echo "action=$action" >> "$GITHUB_OUTPUT"
+          artifact_zip="${RUNNER_TEMP}/docs-preview-artifact.zip"
+          curl --fail --location --silent --show-error \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
+            --output "${artifact_zip}"
+          python3 trusted-source/.github/scripts/docs_preview_artifact.py \
+            "${artifact_zip}" \
+            "${GITHUB_WORKSPACE}/artifact"
+          if [ "$(wc -c < artifact/docs-preview-action.txt)" -gt 16 ] ||
+             [ "$(wc -c < artifact/docs-preview-pr-number.txt)" -gt 32 ]; then
+            echo "artifact control file is too large" >&2
+            exit 1
+          fi
 
-      - name: Set up Node.js
-        if: steps.meta.outputs.action == 'deploy'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
+          mapfile -t action_lines < artifact/docs-preview-action.txt
+          mapfile -t pr_lines < artifact/docs-preview-pr-number.txt
+          if [ "${#action_lines[@]}" -ne 1 ] || [ "${#pr_lines[@]}" -ne 1 ]; then
+            echo "artifact control files must each contain exactly one line" >&2
+            exit 1
+          fi
+          action="${action_lines[0]%$'\r'}"
+          artifact_pr="${pr_lines[0]%$'\r'}"
+          if [ "${artifact_pr}" != "${pr}" ]; then
+            echo "artifact PR ${artifact_pr} does not match workflow PR ${pr}" >&2
+            exit 1
+          fi
 
-      - name: Install vercel CLI (no secrets)
-        if: steps.meta.outputs.action == 'deploy'
-        id: vercel_cli
+          mapfile -t files < <(find artifact -mindepth 1 -type f -printf '%P\n' | LC_ALL=C sort)
+          case "${action}" in
+            deploy)
+              expected=(
+                "docs-preview-action.txt"
+                "docs-preview-pr-number.txt"
+                "docs-preview-sealed.tgz"
+              )
+              ;;
+            cleanup)
+              expected=("docs-preview-action.txt" "docs-preview-pr-number.txt")
+              ;;
+            *)
+              echo "invalid docs-preview action: ${action}" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${files[*]}" != "${expected[*]}" ]; then
+            echo "artifact contains an unexpected file set" >&2
+            printf 'actual: %s\n' "${files[*]}" >&2
+            exit 1
+          fi
+
+          echo "pr=${pr}" >> "${GITHUB_OUTPUT}"
+          echo "action=${action}" >> "${GITHUB_OUTPUT}"
+          echo "alias=pr-${pr}.preview.${DOCS_DOMAIN}" >> "${GITHUB_OUTPUT}"
+          echo "url=https://pr-${pr}.preview.${DOCS_DOMAIN}" >> "${GITHUB_OUTPUT}"
+
+      - name: Reconcile artifact intent with current PR state
+        id: authorize
+        env:
+          ACTION: ${{ steps.meta.outputs.action }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          # Clean prefix + ignore-scripts: no deploy credentials in this step's
-          # environment, and no package lifecycle scripts from the registry.
-          CLEAN_CLI="${RUNNER_TEMP}/vercel-cli"
-          mkdir -p "$CLEAN_CLI"
-          npm install --prefix "$CLEAN_CLI" --no-save --no-package-lock --ignore-scripts vercel@56.4.1
-          test -x "$CLEAN_CLI/node_modules/.bin/vercel"
-          echo "dir=$CLEAN_CLI" >> "$GITHUB_OUTPUT"
+          pull=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          state=$(jq -r '.state' <<<"${pull}")
+          current_sha=$(jq -r '.head.sha' <<<"${pull}")
+          current_repo=$(jq -r '.head.repo.full_name // ""' <<<"${pull}")
 
-      - name: Extract sealed archive (no secrets)
-        if: steps.meta.outputs.action == 'deploy'
+          mode=noop
+          case "${ACTION}:${state}" in
+            deploy:open)
+              if [ "${current_sha}" = "${WORKFLOW_HEAD_SHA}" ] &&
+                 [ "${current_repo}" = "${REPO}" ]; then
+                mode=deploy
+              fi
+              ;;
+            deploy:closed|cleanup:closed)
+              mode=cleanup
+              ;;
+            cleanup:open)
+              mode=noop
+              ;;
+            *)
+              echo "unexpected PR state ${state}" >&2
+              exit 1
+              ;;
+          esac
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved artifact action ${ACTION} and PR state ${state} to ${mode}." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Set up Node.js
+        if: steps.authorize.outputs.mode == 'deploy'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: trusted-source/.github/docs-preview-vercel/package-lock.json
+
+      - name: Install locked Vercel CLI (no secrets)
+        if: steps.authorize.outputs.mode == 'deploy'
+        id: vercel-cli
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --prefix trusted-source/.github/docs-preview-vercel
+          npm audit --audit-level=high --omit=dev --prefix trusted-source/.github/docs-preview-vercel
+          cli="${GITHUB_WORKSPACE}/trusted-source/.github/docs-preview-vercel/node_modules/.bin/vercel"
+          test -x "${cli}"
+          "${cli}" --version
+          echo "bin=${cli}" >> "${GITHUB_OUTPUT}"
+
+      - name: Stream-validate and extract untrusted bundle (no secrets)
+        if: steps.authorize.outputs.mode == 'deploy'
         id: extract
         run: |
           set -euo pipefail
-          DEPLOY_ROOT="${RUNNER_TEMP}/docs-preview-deploy"
-          rm -rf "$DEPLOY_ROOT"
-          mkdir -p "$DEPLOY_ROOT"
-          ARCHIVE="$(pwd)/artifact/docs-preview-sealed.tgz"
-          # Heredoc body must be unindented — leading spaces would SyntaxError.
-          # Quotas bound a hostile PR archive before it can fill the runner disk.
-          MAX_ARCHIVE_BYTES=$((2 * 1024 * 1024 * 1024))   # 2 GiB compressed
-          MAX_MEMBERS=400000
-          MAX_TOTAL_UNCOMPRESSED=$((4 * 1024 * 1024 * 1024))  # 4 GiB
-          MAX_FILE_BYTES=$((512 * 1024 * 1024))  # 512 MiB per member
-          archive_bytes=$(wc -c < "$ARCHIVE")
-          if [ "$archive_bytes" -gt "$MAX_ARCHIVE_BYTES" ]; then
-            echo "archive too large: ${archive_bytes} bytes" >&2
-            exit 1
-          fi
-          python3 - "$ARCHIVE" "$DEPLOY_ROOT" "$MAX_MEMBERS" "$MAX_TOTAL_UNCOMPRESSED" "$MAX_FILE_BYTES" <<'PY'
-import os, sys, tarfile
+          deploy_root="${RUNNER_TEMP}/docs-preview-deploy"
+          test ! -e "${deploy_root}"
+          python3 trusted-source/.github/scripts/docs_preview_bundle.py \
+            "${GITHUB_WORKSPACE}/artifact/docs-preview-sealed.tgz" \
+            "${deploy_root}"
+          echo "root=${deploy_root}" >> "${GITHUB_OUTPUT}"
 
-archive, dest = sys.argv[1], sys.argv[2]
-max_members = int(sys.argv[3])
-max_total = int(sys.argv[4])
-max_file = int(sys.argv[5])
-dest = os.path.realpath(dest)
-allowed_prefixes = (".vercel/", "website/node_modules/")
-
-with tarfile.open(archive, "r:gz") as tf:
-    members = tf.getmembers()
-    if len(members) > max_members:
-        raise SystemExit(f"too many members: {len(members)} > {max_members}")
-    total = 0
-    for member in members:
-        name = member.name.lstrip("./")
-        if name.startswith("/") or name.startswith("\\") or ".." in name.split("/"):
-            raise SystemExit(f"refusing unsafe path: {member.name!r}")
-        if not name.startswith(allowed_prefixes):
-            raise SystemExit(f"refusing unexpected path: {member.name!r}")
-        if member.issym() or member.islnk():
-            raise SystemExit(f"refusing link member: {member.name!r}")
-        if not (member.isfile() or member.isdir()):
-            raise SystemExit(f"refusing non-file member: {member.name!r}")
-        size = member.size or 0
-        if size > max_file:
-            raise SystemExit(f"member too large: {member.name!r} ({size} bytes)")
-        total += size
-        if total > max_total:
-            raise SystemExit(f"uncompressed total too large: {total} > {max_total}")
-        target = os.path.realpath(os.path.join(dest, name))
-        if target != dest and not target.startswith(dest + os.sep):
-            raise SystemExit(f"refusing path escape: {member.name!r}")
-    try:
-        tf.extractall(dest, filter="data")
-    except TypeError:
-        tf.extractall(dest)
-PY
-          test -f "$DEPLOY_ROOT/.vercel/output/functions/_global-error.func/.vc-config.json"
-          test -d "$DEPLOY_ROOT/website/node_modules"
-          echo "root=$DEPLOY_ROOT" >> "$GITHUB_OUTPUT"
-
-      - name: Deploy prebuilt
-        if: steps.meta.outputs.action == 'deploy'
-        id: deploy
+      - name: Reject Preview environment variables
+        if: steps.authorize.outputs.mode == 'deploy'
         env:
-          PR_NUMBER: ${{ steps.meta.outputs.pr }}
-          ALIAS: ${{ steps.meta.outputs.alias }}
-          CLEAN_CLI: ${{ steps.vercel_cli.outputs.dir }}
-          DEPLOY_ROOT: ${{ steps.extract.outputs.root }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
         run: |
           set -euo pipefail
-          VERCEL_BIN="$CLEAN_CLI/node_modules/.bin/vercel"
-          test -x "$VERCEL_BIN"
-          # Keep PATH free of the artifact tree.
-          export PATH="${CLEAN_CLI}/node_modules/.bin:/usr/local/bin:/usr/bin:/bin"
-          cd "$DEPLOY_ROOT"
-          mkdir -p website/apps/bittensor-website .vercel
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            audit-environment
+
+      - name: Re-check PR head immediately before deployment
+        if: steps.authorize.outputs.mode == 'deploy'
+        id: recheck
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          pull=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          state=$(jq -r '.state' <<<"${pull}")
+          current_sha=$(jq -r '.head.sha' <<<"${pull}")
+          current_repo=$(jq -r '.head.repo.full_name // ""' <<<"${pull}")
+          authorized=false
+          if [ "${state}" = "open" ] &&
+             [ "${current_sha}" = "${WORKFLOW_HEAD_SHA}" ] &&
+             [ "${current_repo}" = "${REPO}" ]; then
+            authorized=true
+          fi
+          echo "authorized=${authorized}" >> "${GITHUB_OUTPUT}"
+          if [ "${authorized}" != "true" ]; then
+            echo "Deployment became stale while queued; a newer run will reconcile the preview." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Deploy validated prebuilt output
+        if: steps.recheck.outputs.authorized == 'true'
+        id: deploy
+        env:
+          DEPLOY_ROOT: ${{ steps.extract.outputs.root }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          VERCEL_BIN: ${{ steps.vercel-cli.outputs.bin }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test -n "${VERCEL_TOKEN}"
+          test -x "${VERCEL_BIN}"
+          cd "${DEPLOY_ROOT}"
+          mkdir -p .vercel website/apps/bittensor-website
           node -e '
             const fs = require("fs");
             fs.writeFileSync(".vercel/project.json", JSON.stringify({
-              projectId: process.env.VERCEL_PROJECT_ID,
+              projectId: process.env.VERCEL_PREVIEW_PROJECT_ID,
               orgId: process.env.VERCEL_ORG_ID,
             }));
           '
 
-          url=$("$VERCEL_BIN" deploy --prebuilt --archive=tgz --token "$VERCEL_TOKEN")
-          echo "Deployed: $url"
-
-          dep_id=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v13/deployments/${url#https://}?teamId=$VERCEL_ORG_ID" \
-            | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>process.stdout.write(JSON.parse(s).id))')
-          echo "deployment_id=$dep_id" >> "$GITHUB_OUTPUT"
-
-      - name: Register domain, alias deployment
-        if: steps.meta.outputs.action == 'deploy'
-        env:
-          ALIAS: ${{ steps.meta.outputs.alias }}
-          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
-          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
-          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
-        run: |
-          set -euo pipefail
-
-          resp=$(curl -sS -X POST \
-            -H "Authorization: Bearer $VERCEL_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"name\":\"$ALIAS\"}" \
-            "https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
-            || true)
-          if ! echo "$resp" | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8")); if(!d.name) process.exit(1)'; then
-            resp=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}")
+          token="${VERCEL_TOKEN}"
+          unset VERCEL_TOKEN
+          url=$(env -i \
+            CI=true \
+            HOME="${HOME}" \
+            PATH="${PATH}" \
+            TMPDIR="${RUNNER_TEMP}" \
+            "${VERCEL_BIN}" deploy \
+              --prebuilt \
+              --archive=tgz \
+              --yes \
+              --token "${token}" \
+              --meta "docsPreviewPr=${PR_NUMBER}" \
+              --meta "docsPreviewSha=${WORKFLOW_HEAD_SHA}")
+          if ! [[ "${url}" =~ ^https://[A-Za-z0-9.-]+$ ]]; then
+            echo "Vercel CLI returned an invalid deployment URL" >&2
+            exit 1
           fi
 
-          verified=$(echo "$resp" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).verified === true ? "yes" : "no"')
-          if [ "$verified" != "yes" ]; then
-            # Use `node -e`, not `-pe`: `-p` also prints the expression
-            # result, and `stdout.write` returns true, which corrupted the
-            # TXT value to "...<token>true" and broke Vercel verification.
-            challenge=$(echo "$resp" | node -e '
-              const d = JSON.parse(require("fs").readFileSync(0, "utf8"));
-              const v = (d.verification || []).find((x) => x.type === "TXT");
-              if (!v) { process.stderr.write("no TXT challenge\n"); process.exit(1); }
-              process.stdout.write(v.value);
-            ')
+          details=$(curl -fsS \
+            -H "Authorization: Bearer ${token}" \
+            "https://api.vercel.com/v13/deployments/${url#https://}?teamId=${VERCEL_ORG_ID}")
+          deployment_id=$(node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            if (typeof data.id !== "string" || !/^dpl_[A-Za-z0-9]+$/.test(data.id)) {
+              process.exit(1);
+            }
+            process.stdout.write(data.id);
+          ' <<<"${details}")
+          echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
+          echo "deployment_url=${url}" >> "${GITHUB_OUTPUT}"
+          echo "Created deployment ${deployment_id}." >> "${GITHUB_STEP_SUMMARY}"
 
-            existing=$(curl -sf \
+      - name: Register and verify domain
+        if: steps.recheck.outputs.authorized == 'true'
+        env:
+          ALIAS: ${{ steps.meta.outputs.alias }}
+          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
+          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sS -X POST \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"${ALIAS}\"}" \
+            "https://api.vercel.com/v10/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
+            || true)
+          if ! node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            if (typeof data.name !== "string") process.exit(1);
+          ' <<<"${response}"; then
+            response=$(curl -fsS \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}")
+          fi
+
+          verified=$(node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            process.stdout.write(data.verified === true ? "yes" : "no");
+          ' <<<"${response}")
+          if [ "${verified}" != "yes" ]; then
+            challenge=$(node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const record = (data.verification || []).find((item) => item.type === "TXT");
+              if (!record || typeof record.value !== "string") process.exit(1);
+              process.stdout.write(record.value);
+            ' <<<"${response}")
+
+            existing=$(curl -fsS \
               -H "Authorization: sso-key ${GODADDY_API_KEY}:${GODADDY_API_SECRET}" \
               "https://api.godaddy.com/v1/domains/${DOCS_DOMAIN}/records/TXT/_vercel")
-            payload=$(EXISTING_JSON="$existing" CHALLENGE="$challenge" node -e '
-              const existing = JSON.parse(process.env.EXISTING_JSON);
-              const values = new Set(existing.map((r) => r.data));
+            payload=$(EXISTING_JSON="${existing}" CHALLENGE="${challenge}" node -e '
+              const records = JSON.parse(process.env.EXISTING_JSON);
+              const values = new Set(records.map((record) => record.data));
               values.add(process.env.CHALLENGE);
               process.stdout.write(JSON.stringify(
-                [...values].sort().map((data) => ({ data, ttl: 600 }))
+                [...values].sort().map((data) => ({data, ttl: 600}))
               ));
             ')
-            curl -sf -X PUT \
+            curl -fsS -X PUT \
               -H "Authorization: sso-key ${GODADDY_API_KEY}:${GODADDY_API_SECRET}" \
               -H "Content-Type: application/json" \
-              -d "$payload" \
-              "https://api.godaddy.com/v1/domains/${DOCS_DOMAIN}/records/TXT/_vercel" > /dev/null
+              -d "${payload}" \
+              "https://api.godaddy.com/v1/domains/${DOCS_DOMAIN}/records/TXT/_vercel" \
+              > /dev/null
 
             verified=no
-            for i in 1 2 3 4 5 6 7 8 9 10; do
-              verify=$(curl -sS -X POST \
-                -H "Authorization: Bearer $VERCEL_TOKEN" \
-                "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/domains/${ALIAS}/verify?teamId=${VERCEL_ORG_ID}" \
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
+              verification=$(curl -sS -X POST \
+                -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+                "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}/verify?teamId=${VERCEL_ORG_ID}" \
                 || true)
-              if echo "$verify" | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).verified === true ? "yes" : "no"' | grep -q yes; then
+              if node -e '
+                const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+                if (data.verified !== true) process.exit(1);
+              ' <<<"${verification}"; then
                 verified=yes
                 break
               fi
               sleep 15
             done
-            if [ "$verified" != "yes" ]; then
-              echo "Timed out verifying $ALIAS" >&2
-              echo "$verify" >&2
+            if [ "${verified}" != "yes" ]; then
+              echo "timed out verifying ${ALIAS}" >&2
               exit 1
             fi
           fi
 
-          curl -sf -X POST \
-            -H "Authorization: Bearer $VERCEL_TOKEN" \
+      # Keep the alias switch in its own step. Once this step starts, its
+      # remote result can be ambiguous after a network error, so rollback must
+      # preserve the new deployment instead of risking a broken stable alias.
+      - name: Switch stable alias
+        id: alias
+        if: steps.recheck.outputs.authorized == 'true'
+        env:
+          ALIAS: ${{ steps.meta.outputs.alias }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"alias\":\"$ALIAS\"}" \
-            "https://api.vercel.com/v2/deployments/${DEPLOYMENT_ID}/aliases?teamId=${VERCEL_ORG_ID}" > /dev/null
+            -d "{\"alias\":\"${ALIAS}\"}" \
+            "https://api.vercel.com/v2/deployments/${DEPLOYMENT_ID}/aliases?teamId=${VERCEL_ORG_ID}" \
+            > /dev/null
+          echo "Aliased to https://${ALIAS}." >> "${GITHUB_STEP_SUMMARY}"
 
-          echo "Aliased to https://${ALIAS}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Delete superseded deployments for this PR
+        if: always() && steps.alias.outcome == 'success'
+        env:
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            delete-pr-deployments \
+            --pr-number "${PR_NUMBER}" \
+            --keep-deployment-id "${DEPLOYMENT_ID}"
 
       - name: Comment preview URL on PR
-        if: steps.meta.outputs.action == 'deploy'
+        if: always() && steps.alias.outcome == 'success'
         env:
-          PR_NUMBER: ${{ steps.meta.outputs.pr }}
-          PREVIEW_URL: ${{ steps.meta.outputs.url }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
           GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.meta.outputs.url }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
         run: |
+          set -euo pipefail
           marker="<!-- docs-preview-url -->"
           body=$(printf '%s\n' \
             "${marker}" \
+            "<!-- docs-preview-deployment:${DEPLOYMENT_ID} -->" \
             "### Docs preview" \
             "" \
             "${PREVIEW_URL}/docs" \
             "" \
-            "Stable for this PR — updates on each push that touches \`docs/**\` or \`website/**\`.")
-
+            "Stable for this PR; it updates after each docs or website change.")
           existing=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
-            | head -n 1)
-
-          if [ -n "$existing" ]; then
-            gh api \
-              --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | select(.body | contains("<!-- docs-preview-url -->"))] | .[0].id // empty')
+          if [ -n "${existing}" ]; then
+            gh api --method PATCH \
               "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
-              -f body="$body" > /dev/null
+              -f body="${body}" > /dev/null
           else
-            gh api \
-              --method POST \
+            gh api --method POST \
               "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -f body="$body" > /dev/null
+              -f body="${body}" > /dev/null
           fi
 
-      - name: Remove PR docs preview domain
-        if: steps.meta.outputs.action == 'cleanup'
+      - name: Remove closed PR domain
+        if: steps.authorize.outputs.mode == 'cleanup'
         env:
           ALIAS: ${{ steps.meta.outputs.alias }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
         run: |
           set -euo pipefail
-          code=$(curl -sS -o /tmp/del.json -w "%{http_code}" -X DELETE \
-            -H "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}" \
+          code=$(curl -sS -o "${RUNNER_TEMP}/delete-domain.json" -w "%{http_code}" \
+            -X DELETE \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}" \
             || true)
-          if [ "$code" = "200" ] || [ "$code" = "204" ]; then
-            echo "Removed ${ALIAS} from Vercel project" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No project domain to remove for ${ALIAS} (HTTP ${code})" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          case "${code}" in
+            200|204|404) ;;
+            *) echo "failed to remove ${ALIAS} (HTTP ${code})" >&2; exit 1 ;;
+          esac
+          echo "Removed ${ALIAS} from the preview project." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Delete closed PR deployments
+        if: always() && steps.authorize.outputs.mode == 'cleanup'
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            delete-pr-deployments \
+            --pr-number "${PR_NUMBER}"
+
+      - name: Roll back a failed new deployment
+        if: >-
+          failure() &&
+          steps.deploy.outputs.deployment_id != '' &&
+          steps.alias.outcome == 'skipped'
+        env:
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -u
+          curl -sS -X DELETE \
+            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+            "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_ORG_ID}" \
+            > /dev/null || true
+          echo "Rolled back failed deployment ${DEPLOYMENT_ID}." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Report a stale or superseded run
+        if: steps.authorize.outputs.mode == 'noop'
+        run: echo "No external state was changed." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -2,8 +2,8 @@ name: Deploy Docs Preview
 
 # Trusted half of docs previews. GitHub loads workflow_run workflows from the
 # default branch. This job checks out only that branch, never PR HEAD, and
-# validates the PR-produced artifact before any deployment credential is
-# introduced. It stays disabled until VERCEL_DOCS_PREVIEW_PROJECT_ID is set.
+# validates the PR-produced artifact before any deployment credential appears.
+# The preview project and *.preview.DOCS_DOMAIN must be provisioned in advance.
 
 on:
   workflow_run:
@@ -15,12 +15,11 @@ permissions:
   contents: read
   pull-requests: write
 
-# Domain, deployment, and cleanup changes are globally serialized. Retain every
-# pending run; each run re-checks PR state and head SHA before changing Vercel.
+# Serialize each PR while allowing unrelated previews in parallel. GitHub may
+# replace an older pending run; every run reconciles the PR's current state.
 concurrency:
-  group: docs-preview-domain-dns
+  group: docs-preview-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
-  queue: max
 
 jobs:
   deploy:
@@ -47,200 +46,35 @@ jobs:
             .github/docs-preview-vercel
             .github/scripts
 
-      - name: Require a dedicated preview project
+      - name: Validate the dedicated preview configuration
         run: |
-          set -euo pipefail
-          id_pattern='^[A-Za-z0-9_-]+$'
-          if ! [[ "${VERCEL_ORG_ID}" =~ ${id_pattern} ]] ||
-             ! [[ "${VERCEL_PREVIEW_PROJECT_ID}" =~ ${id_pattern} ]] ||
-             ! [[ "${VERCEL_PRODUCTION_PROJECT_ID}" =~ ${id_pattern} ]] ||
-             [ "${#VERCEL_ORG_ID}" -gt 128 ] ||
-             [ "${#VERCEL_PREVIEW_PROJECT_ID}" -gt 128 ] ||
-             [ "${#VERCEL_PRODUCTION_PROJECT_ID}" -gt 128 ]; then
-            echo "Set valid VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, and VERCEL_DOCS_PREVIEW_PROJECT_ID repository variables." >&2
-            exit 1
-          fi
-          if [ "${VERCEL_PREVIEW_PROJECT_ID}" = "${VERCEL_PRODUCTION_PROJECT_ID}" ]; then
-            echo "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated, non-production project." >&2
-            exit 1
-          fi
-          domain_pattern='^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$'
-          if ! [[ "${DOCS_DOMAIN}" =~ ${domain_pattern} ]] ||
-             [[ "${DOCS_DOMAIN}" == *..* ]] ||
-             [ "${#DOCS_DOMAIN}" -gt 253 ]; then
-            echo "DOCS_DOMAIN must be a valid lowercase DNS name." >&2
-            exit 1
-          fi
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            validate-config \
+            --production-project-id "${VERCEL_PRODUCTION_PROJECT_ID}" \
+            --docs-domain "${DOCS_DOMAIN}"
 
-      - name: Resolve and validate the producing artifact
+      - name: Resolve, download, and authorize the producing artifact
         id: meta
         env:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-          case "${WORKFLOW_HEAD_SHA}" in
-            *[!0-9a-f]*|'') echo "invalid workflow head SHA" >&2; exit 1 ;;
-          esac
-          case "${WORKFLOW_RUN_ID}" in
-            *[!0-9]*|'') echo "invalid workflow run ID" >&2; exit 1 ;;
-          esac
-
-          pr=$(node -e '
-            const pulls = JSON.parse(process.env.WORKFLOW_PULL_REQUESTS || "[]");
-            const numbers = [...new Set(
-              pulls.map((pull) => pull && pull.number).filter(Number.isSafeInteger)
-            )];
-            if (numbers.length > 1) {
-              process.stderr.write("workflow_run is associated with multiple PRs\n");
-              process.exit(1);
-            }
-            if (numbers.length === 1) process.stdout.write(String(numbers[0]));
-          ')
-          if [ -z "${pr}" ]; then
-            associated=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              "repos/${REPO}/commits/${WORKFLOW_HEAD_SHA}/pulls")
-            count=$(jq \
-              --arg sha "${WORKFLOW_HEAD_SHA}" \
-              --arg repo "${REPO}" \
-              '[.[] | select(.head.sha == $sha and .head.repo.full_name == $repo)] | length' \
-              <<<"${associated}")
-            if [ "${count}" != "1" ]; then
-              echo "expected exactly one same-repository PR for ${WORKFLOW_HEAD_SHA}, found ${count}" >&2
-              exit 1
-            fi
-            pr=$(jq -r \
-              --arg sha "${WORKFLOW_HEAD_SHA}" \
-              --arg repo "${REPO}" \
-              '.[] | select(.head.sha == $sha and .head.repo.full_name == $repo) | .number' \
-              <<<"${associated}")
-          fi
-          case "${pr}" in
-            *[!0-9]*|'') echo "invalid PR number" >&2; exit 1 ;;
-          esac
-
-          artifact_name="docs-preview-${pr}"
-          artifact_response=$(gh api \
-            "repos/${REPO}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?name=${artifact_name}&per_page=100")
-          artifact_count=$(jq -r '.total_count' <<<"${artifact_response}")
-          if [ "${artifact_count}" != "1" ]; then
-            echo "expected one ${artifact_name} artifact, found ${artifact_count}" >&2
-            exit 1
-          fi
-          artifact_size=$(jq -r '.artifacts[0].size_in_bytes' <<<"${artifact_response}")
-          artifact_id=$(jq -r '.artifacts[0].id' <<<"${artifact_response}")
-          artifact_expired=$(jq -r '.artifacts[0].expired' <<<"${artifact_response}")
-          case "${artifact_size}" in
-            *[!0-9]*|'') echo "invalid artifact size" >&2; exit 1 ;;
-          esac
-          case "${artifact_id}" in
-            *[!0-9]*|'') echo "invalid artifact ID" >&2; exit 1 ;;
-          esac
-          if [ "${artifact_expired}" != "false" ] || [ "${artifact_size}" -gt 2200000000 ]; then
-            echo "artifact is expired or exceeds the 2.2 GB download limit" >&2
-            exit 1
-          fi
-
-          artifact_zip="${RUNNER_TEMP}/docs-preview-artifact.zip"
-          curl --fail --location --silent --show-error \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
-            --output "${artifact_zip}"
-          python3 trusted-source/.github/scripts/docs_preview_artifact.py \
-            "${artifact_zip}" \
-            "${GITHUB_WORKSPACE}/artifact"
-          if [ "$(wc -c < artifact/docs-preview-action.txt)" -gt 16 ] ||
-             [ "$(wc -c < artifact/docs-preview-pr-number.txt)" -gt 32 ]; then
-            echo "artifact control file is too large" >&2
-            exit 1
-          fi
-
-          mapfile -t action_lines < artifact/docs-preview-action.txt
-          mapfile -t pr_lines < artifact/docs-preview-pr-number.txt
-          if [ "${#action_lines[@]}" -ne 1 ] || [ "${#pr_lines[@]}" -ne 1 ]; then
-            echo "artifact control files must each contain exactly one line" >&2
-            exit 1
-          fi
-          action="${action_lines[0]%$'\r'}"
-          artifact_pr="${pr_lines[0]%$'\r'}"
-          if [ "${artifact_pr}" != "${pr}" ]; then
-            echo "artifact PR ${artifact_pr} does not match workflow PR ${pr}" >&2
-            exit 1
-          fi
-
-          mapfile -t files < <(find artifact -mindepth 1 -type f -printf '%P\n' | LC_ALL=C sort)
-          case "${action}" in
-            deploy)
-              expected=(
-                "docs-preview-action.txt"
-                "docs-preview-pr-number.txt"
-                "docs-preview-sealed.tgz"
-              )
-              ;;
-            cleanup)
-              expected=("docs-preview-action.txt" "docs-preview-pr-number.txt")
-              ;;
-            *)
-              echo "invalid docs-preview action: ${action}" >&2
-              exit 1
-              ;;
-          esac
-          if [ "${files[*]}" != "${expected[*]}" ]; then
-            echo "artifact contains an unexpected file set" >&2
-            printf 'actual: %s\n' "${files[*]}" >&2
-            exit 1
-          fi
-
-          echo "pr=${pr}" >> "${GITHUB_OUTPUT}"
-          echo "action=${action}" >> "${GITHUB_OUTPUT}"
-          echo "alias=pr-${pr}.preview.${DOCS_DOMAIN}" >> "${GITHUB_OUTPUT}"
-          echo "url=https://pr-${pr}.preview.${DOCS_DOMAIN}" >> "${GITHUB_OUTPUT}"
-
-      - name: Reconcile artifact intent with current PR state
-        id: authorize
-        env:
-          ACTION: ${{ steps.meta.outputs.action }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.meta.outputs.pr }}
-          REPO: ${{ github.repository }}
-          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          set -euo pipefail
-          pull=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
-          state=$(jq -r '.state' <<<"${pull}")
-          current_sha=$(jq -r '.head.sha' <<<"${pull}")
-          current_repo=$(jq -r '.head.repo.full_name // ""' <<<"${pull}")
-
-          mode=noop
-          case "${ACTION}:${state}" in
-            deploy:open)
-              if [ "${current_sha}" = "${WORKFLOW_HEAD_SHA}" ] &&
-                 [ "${current_repo}" = "${REPO}" ]; then
-                mode=deploy
-              fi
-              ;;
-            deploy:closed|cleanup:closed)
-              mode=cleanup
-              ;;
-            cleanup:open)
-              mode=noop
-              ;;
-            *)
-              echo "unexpected PR state ${state}" >&2
-              exit 1
-              ;;
-          esac
-          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
-          echo "Resolved artifact action ${ACTION} and PR state ${state} to ${mode}." >> "${GITHUB_STEP_SUMMARY}"
+          python3 trusted-source/.github/scripts/docs_preview_github.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            prepare \
+            --workflow-pulls-json "${WORKFLOW_PULL_REQUESTS}" \
+            --workflow-head-sha "${WORKFLOW_HEAD_SHA}" \
+            --workflow-run-id "${WORKFLOW_RUN_ID}" \
+            --docs-domain "${DOCS_DOMAIN}" \
+            --artifact-zip "${RUNNER_TEMP}/docs-preview-artifact.zip" \
+            --artifact-directory "${GITHUB_WORKSPACE}/artifact"
 
       - name: Set up Node.js
-        if: steps.authorize.outputs.mode == 'deploy'
+        if: steps.meta.outputs.mode == 'deploy'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
@@ -248,7 +82,7 @@ jobs:
           cache-dependency-path: trusted-source/.github/docs-preview-vercel/package-lock.json
 
       - name: Install locked Vercel CLI (no secrets)
-        if: steps.authorize.outputs.mode == 'deploy'
+        if: steps.meta.outputs.mode == 'deploy'
         id: vercel-cli
         run: |
           set -euo pipefail
@@ -259,53 +93,54 @@ jobs:
           "${cli}" --version
           echo "bin=${cli}" >> "${GITHUB_OUTPUT}"
 
-      - name: Stream-validate and extract untrusted bundle (no secrets)
-        if: steps.authorize.outputs.mode == 'deploy'
+      - name: Validate and extract the self-contained bundle (no secrets)
+        if: steps.meta.outputs.mode == 'deploy'
         id: extract
         run: |
           set -euo pipefail
           deploy_root="${RUNNER_TEMP}/docs-preview-deploy"
           test ! -e "${deploy_root}"
           python3 trusted-source/.github/scripts/docs_preview_bundle.py \
+            extract \
             "${GITHUB_WORKSPACE}/artifact/docs-preview-sealed.tgz" \
             "${deploy_root}"
           echo "root=${deploy_root}" >> "${GITHUB_OUTPUT}"
 
-      - name: Reject Preview environment variables
-        if: steps.authorize.outputs.mode == 'deploy'
+      - name: Audit preview project and pre-provisioned domain
+        if: steps.meta.outputs.mode == 'deploy'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -euo pipefail
           python3 trusted-source/.github/scripts/docs_preview_vercel.py \
             --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
             --team-id "${VERCEL_ORG_ID}" \
-            audit-environment
+            audit-project \
+            --preview-domain "*.preview.${DOCS_DOMAIN}"
 
       - name: Re-check PR head immediately before deployment
-        if: steps.authorize.outputs.mode == 'deploy'
+        if: steps.meta.outputs.mode == 'deploy'
         id: recheck
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
-          REPO: ${{ github.repository }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          set -euo pipefail
-          pull=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
-          state=$(jq -r '.state' <<<"${pull}")
-          current_sha=$(jq -r '.head.sha' <<<"${pull}")
-          current_repo=$(jq -r '.head.repo.full_name // ""' <<<"${pull}")
-          authorized=false
-          if [ "${state}" = "open" ] &&
-             [ "${current_sha}" = "${WORKFLOW_HEAD_SHA}" ] &&
-             [ "${current_repo}" = "${REPO}" ]; then
-            authorized=true
-          fi
-          echo "authorized=${authorized}" >> "${GITHUB_OUTPUT}"
-          if [ "${authorized}" != "true" ]; then
-            echo "Deployment became stale while queued; a newer run will reconcile the preview." >> "${GITHUB_STEP_SUMMARY}"
-          fi
+          python3 trusted-source/.github/scripts/docs_preview_github.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            recheck \
+            --pr-number "${PR_NUMBER}" \
+            --workflow-head-sha "${WORKFLOW_HEAD_SHA}"
+
+      - name: Link validated output to the preview project
+        if: steps.recheck.outputs.authorized == 'true'
+        env:
+          DEPLOY_ROOT: ${{ steps.extract.outputs.root }}
+        run: |
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            link-project \
+            --directory "${DEPLOY_ROOT}"
 
       - name: Deploy validated prebuilt output
         if: steps.recheck.outputs.authorized == 'true'
@@ -320,21 +155,14 @@ jobs:
           set -euo pipefail
           test -n "${VERCEL_TOKEN}"
           test -x "${VERCEL_BIN}"
-          cd "${DEPLOY_ROOT}"
-          mkdir -p .vercel website/apps/bittensor-website
-          node -e '
-            const fs = require("fs");
-            fs.writeFileSync(".vercel/project.json", JSON.stringify({
-              projectId: process.env.VERCEL_PREVIEW_PROJECT_ID,
-              orgId: process.env.VERCEL_ORG_ID,
-            }));
-          '
-
           token="${VERCEL_TOKEN}"
           unset VERCEL_TOKEN
+          cli_home="${RUNNER_TEMP}/vercel-cli-home"
+          mkdir -m 700 "${cli_home}"
+          cd "${DEPLOY_ROOT}"
           url=$(env -i \
             CI=true \
-            HOME="${HOME}" \
+            HOME="${cli_home}" \
             PATH="${PATH}" \
             TMPDIR="${RUNNER_TEMP}" \
             "${VERCEL_BIN}" deploy \
@@ -344,104 +172,17 @@ jobs:
               --token "${token}" \
               --meta "docsPreviewPr=${PR_NUMBER}" \
               --meta "docsPreviewSha=${WORKFLOW_HEAD_SHA}")
-          if ! [[ "${url}" =~ ^https://[A-Za-z0-9.-]+$ ]]; then
-            echo "Vercel CLI returned an invalid deployment URL" >&2
-            exit 1
-          fi
+          VERCEL_TOKEN="${token}" \
+            python3 "${GITHUB_WORKSPACE}/trusted-source/.github/scripts/docs_preview_vercel.py" \
+              --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+              --team-id "${VERCEL_ORG_ID}" \
+              deployment-id \
+              --deployment-url "${url}"
 
-          details=$(curl -fsS \
-            -H "Authorization: Bearer ${token}" \
-            "https://api.vercel.com/v13/deployments/${url#https://}?teamId=${VERCEL_ORG_ID}")
-          deployment_id=$(node -e '
-            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
-            if (typeof data.id !== "string" || !/^dpl_[A-Za-z0-9]+$/.test(data.id)) {
-              process.exit(1);
-            }
-            process.stdout.write(data.id);
-          ' <<<"${details}")
-          echo "deployment_id=${deployment_id}" >> "${GITHUB_OUTPUT}"
-          echo "deployment_url=${url}" >> "${GITHUB_OUTPUT}"
-          echo "Created deployment ${deployment_id}." >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Register and verify domain
-        if: steps.recheck.outputs.authorized == 'true'
-        env:
-          ALIAS: ${{ steps.meta.outputs.alias }}
-          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
-          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          set -euo pipefail
-          response=$(curl -sS -X POST \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "{\"name\":\"${ALIAS}\"}" \
-            "https://api.vercel.com/v10/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains?teamId=${VERCEL_ORG_ID}" \
-            || true)
-          if ! node -e '
-            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
-            if (typeof data.name !== "string") process.exit(1);
-          ' <<<"${response}"; then
-            response=$(curl -fsS \
-              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}")
-          fi
-
-          verified=$(node -e '
-            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
-            process.stdout.write(data.verified === true ? "yes" : "no");
-          ' <<<"${response}")
-          if [ "${verified}" != "yes" ]; then
-            challenge=$(node -e '
-              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
-              const record = (data.verification || []).find((item) => item.type === "TXT");
-              if (!record || typeof record.value !== "string") process.exit(1);
-              process.stdout.write(record.value);
-            ' <<<"${response}")
-
-            existing=$(curl -fsS \
-              -H "Authorization: sso-key ${GODADDY_API_KEY}:${GODADDY_API_SECRET}" \
-              "https://api.godaddy.com/v1/domains/${DOCS_DOMAIN}/records/TXT/_vercel")
-            payload=$(EXISTING_JSON="${existing}" CHALLENGE="${challenge}" node -e '
-              const records = JSON.parse(process.env.EXISTING_JSON);
-              const values = new Set(records.map((record) => record.data));
-              values.add(process.env.CHALLENGE);
-              process.stdout.write(JSON.stringify(
-                [...values].sort().map((data) => ({data, ttl: 600}))
-              ));
-            ')
-            curl -fsS -X PUT \
-              -H "Authorization: sso-key ${GODADDY_API_KEY}:${GODADDY_API_SECRET}" \
-              -H "Content-Type: application/json" \
-              -d "${payload}" \
-              "https://api.godaddy.com/v1/domains/${DOCS_DOMAIN}/records/TXT/_vercel" \
-              > /dev/null
-
-            verified=no
-            for _ in 1 2 3 4 5 6 7 8 9 10; do
-              verification=$(curl -sS -X POST \
-                -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-                "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}/verify?teamId=${VERCEL_ORG_ID}" \
-                || true)
-              if node -e '
-                const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
-                if (data.verified !== true) process.exit(1);
-              ' <<<"${verification}"; then
-                verified=yes
-                break
-              fi
-              sleep 15
-            done
-            if [ "${verified}" != "yes" ]; then
-              echo "timed out verifying ${ALIAS}" >&2
-              exit 1
-            fi
-          fi
-
-      # Keep the alias switch in its own step. Once this step starts, its
-      # remote result can be ambiguous after a network error, so rollback must
-      # preserve the new deployment instead of risking a broken stable alias.
-      - name: Switch stable alias
+      # Once alias switching starts, its remote result can be ambiguous after a
+      # network error. Preserve the new deployment rather than risk breaking
+      # the stable alias by rolling it back.
+      - name: Switch stable preview alias
         id: alias
         if: steps.recheck.outputs.authorized == 'true'
         env:
@@ -449,14 +190,12 @@ jobs:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -euo pipefail
-          curl -fsS -X POST \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "{\"alias\":\"${ALIAS}\"}" \
-            "https://api.vercel.com/v2/deployments/${DEPLOYMENT_ID}/aliases?teamId=${VERCEL_ORG_ID}" \
-            > /dev/null
-          echo "Aliased to https://${ALIAS}." >> "${GITHUB_STEP_SUMMARY}"
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            set-alias \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            --alias "${ALIAS}"
 
       - name: Delete superseded deployments for this PR
         if: always() && steps.alias.outcome == 'success'
@@ -465,7 +204,6 @@ jobs:
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -euo pipefail
           python3 trusted-source/.github/scripts/docs_preview_vercel.py \
             --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
             --team-id "${VERCEL_ORG_ID}" \
@@ -481,61 +219,38 @@ jobs:
           PREVIEW_URL: ${{ steps.meta.outputs.url }}
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
         run: |
-          set -euo pipefail
-          marker="<!-- docs-preview-url -->"
-          body=$(printf '%s\n' \
-            "${marker}" \
-            "<!-- docs-preview-deployment:${DEPLOYMENT_ID} -->" \
-            "### Docs preview" \
-            "" \
-            "${PREVIEW_URL}/docs" \
-            "" \
-            "Stable for this PR; it updates after each docs or website change.")
-          existing=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
-            --jq '[.[] | select(.body | contains("<!-- docs-preview-url -->"))] | .[0].id // empty')
-          if [ -n "${existing}" ]; then
-            gh api --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
-              -f body="${body}" > /dev/null
-          else
-            gh api --method POST \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              -f body="${body}" > /dev/null
-          fi
+          python3 trusted-source/.github/scripts/docs_preview_github.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            comment \
+            --pr-number "${PR_NUMBER}" \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            --preview-url "${PREVIEW_URL}"
 
-      - name: Remove closed PR domain
-        if: steps.authorize.outputs.mode == 'cleanup'
+      - name: Remove closed PR alias
+        if: steps.meta.outputs.mode == 'cleanup'
         env:
           ALIAS: ${{ steps.meta.outputs.alias }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -euo pipefail
-          code=$(curl -sS -o "${RUNNER_TEMP}/delete-domain.json" -w "%{http_code}" \
-            -X DELETE \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            "https://api.vercel.com/v9/projects/${VERCEL_PREVIEW_PROJECT_ID}/domains/${ALIAS}?teamId=${VERCEL_ORG_ID}" \
-            || true)
-          case "${code}" in
-            200|204|404) ;;
-            *) echo "failed to remove ${ALIAS} (HTTP ${code})" >&2; exit 1 ;;
-          esac
-          echo "Removed ${ALIAS} from the preview project." >> "${GITHUB_STEP_SUMMARY}"
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            remove-alias \
+            --alias "${ALIAS}"
 
       - name: Delete closed PR deployments
-        if: always() && steps.authorize.outputs.mode == 'cleanup'
+        if: always() && steps.meta.outputs.mode == 'cleanup'
         env:
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -euo pipefail
           python3 trusted-source/.github/scripts/docs_preview_vercel.py \
             --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
             --team-id "${VERCEL_ORG_ID}" \
             delete-pr-deployments \
             --pr-number "${PR_NUMBER}"
 
-      - name: Roll back a failed new deployment
+      - name: Roll back an unpromoted failed deployment
         if: >-
           failure() &&
           steps.deploy.outputs.deployment_id != '' &&
@@ -544,13 +259,13 @@ jobs:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment_id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          set -u
-          curl -sS -X DELETE \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            "https://api.vercel.com/v13/deployments/${DEPLOYMENT_ID}?teamId=${VERCEL_ORG_ID}" \
-            > /dev/null || true
-          echo "Rolled back failed deployment ${DEPLOYMENT_ID}." >> "${GITHUB_STEP_SUMMARY}"
+          python3 trusted-source/.github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PREVIEW_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            delete-deployment \
+            --deployment-id "${DEPLOYMENT_ID}" \
+            || true
 
       - name: Report a stale or superseded run
-        if: steps.authorize.outputs.mode == 'noop'
+        if: steps.meta.outputs.mode == 'noop'
         run: echo "No external state was changed." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/request-docs-preview.yml
+++ b/.github/workflows/request-docs-preview.yml
@@ -17,6 +17,7 @@ on:
       - "docs/**"
       - "website/**"
       - ".github/docs-preview-vercel/**"
+      - ".github/scripts/docs_preview_*.py"
       - ".github/workflows/request-docs-preview.yml"
 
 permissions:
@@ -37,6 +38,7 @@ jobs:
       vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''
     runs-on: ubuntu-24.04
     env:
+      DOCS_DOMAIN: ${{ vars.DOCS_DOMAIN || 'bittensor.com' }}
       VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_DOCS_PREVIEW_PROJECT_ID }}
       VERCEL_PRODUCTION_PROJECT_ID: ${{ vars.VERCEL_DOCS_PROJECT_ID }}
@@ -47,23 +49,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - name: Require a dedicated preview project
+      - name: Validate the dedicated preview configuration
         run: |
-          set -euo pipefail
-          id_pattern='^[A-Za-z0-9_-]+$'
-          if ! [[ "${VERCEL_ORG_ID}" =~ ${id_pattern} ]] ||
-             ! [[ "${VERCEL_PROJECT_ID}" =~ ${id_pattern} ]] ||
-             ! [[ "${VERCEL_PRODUCTION_PROJECT_ID}" =~ ${id_pattern} ]] ||
-             [ "${#VERCEL_ORG_ID}" -gt 128 ] ||
-             [ "${#VERCEL_PROJECT_ID}" -gt 128 ] ||
-             [ "${#VERCEL_PRODUCTION_PROJECT_ID}" -gt 128 ]; then
-            echo "Set valid VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, and VERCEL_DOCS_PREVIEW_PROJECT_ID repository variables." >&2
-            exit 1
-          fi
-          if [ "${VERCEL_PROJECT_ID}" = "${VERCEL_PRODUCTION_PROJECT_ID}" ]; then
-            echo "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated, non-production project." >&2
-            exit 1
-          fi
+          python3 .github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            validate-config \
+            --production-project-id "${VERCEL_PRODUCTION_PROJECT_ID}" \
+            --docs-domain "${DOCS_DOMAIN}"
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -85,27 +78,14 @@ jobs:
       - name: Assemble Vercel prebuilt output (no deploy token)
         run: |
           set -euo pipefail
-          mkdir -p .vercel
-          node -e '
-            const fs = require("fs");
-            fs.writeFileSync(".vercel/project.json", JSON.stringify({
-              projectId: process.env.VERCEL_PROJECT_ID,
-              orgId: process.env.VERCEL_ORG_ID,
-              settings: {
-                framework: "nextjs",
-                devCommand: null,
-                installCommand: null,
-                buildCommand: null,
-                outputDirectory: null,
-                rootDirectory: "website/apps/bittensor-website",
-                directoryListing: false,
-                nodeVersion: "24.x",
-              },
-            }, null, 2));
-          '
+          python3 .github/scripts/docs_preview_vercel.py \
+            --project-id "${VERCEL_PROJECT_ID}" \
+            --team-id "${VERCEL_ORG_ID}" \
+            link-project \
+            --directory "${GITHUB_WORKSPACE}" \
+            --include-build-settings
           .github/docs-preview-vercel/node_modules/.bin/vercel build
           test -d .vercel/output
-          test -d website/node_modules
 
       - name: Seal prebuilt output for trusted validation
         env:
@@ -115,9 +95,10 @@ jobs:
           case "${PR_NUMBER}" in
             ''|*[!0-9]*) echo "invalid PR number" >&2; exit 1 ;;
           esac
-          tar --create --gzip --file=docs-preview-sealed.tgz \
-            --hard-dereference --dereference \
-            .vercel/output website/node_modules
+          python3 .github/scripts/docs_preview_bundle.py \
+            seal \
+            "${GITHUB_WORKSPACE}" \
+            "${GITHUB_WORKSPACE}/docs-preview-sealed.tgz"
           printf '%s\n' "${PR_NUMBER}" > docs-preview-pr-number.txt
           printf '%s\n' "deploy" > docs-preview-action.txt
 

--- a/.github/workflows/request-docs-preview.yml
+++ b/.github/workflows/request-docs-preview.yml
@@ -1,18 +1,14 @@
 name: Request Docs Preview
 
-# Secret-free PR gate for docs previews.
+# Untrusted half of docs previews. This workflow runs pull-request code, so it
+# must remain secret-free. It only builds and uploads a bounded-lifetime
+# artifact for the default-branch workflow to validate.
 #
-# Trust boundary: this workflow runs untrusted PR HEAD and must never receive
-# VERCEL_TOKEN, GoDaddy credentials, or any other deploy secret. Same-repo PRs
-# can edit this file; keeping it credential-free closes that path.
-#
-# Build output is sealed and handed to the default-branch
-# `Deploy Docs Preview` workflow (`workflow_run`), which alone holds secrets
-# and never checks out or executes PR code.
-#
-# Requires repository variables (not secrets — these are public project IDs):
+# Repository variables used when previews are enabled (public identifiers, not
+# credentials). The jobs stay disabled until the dedicated preview ID exists:
 #   VERCEL_ORG_ID
 #   VERCEL_DOCS_PROJECT_ID
+#   VERCEL_DOCS_PREVIEW_PROJECT_ID
 
 on:
   pull_request:
@@ -20,10 +16,16 @@ on:
     paths:
       - "docs/**"
       - "website/**"
+      - ".github/docs-preview-vercel/**"
       - ".github/workflows/request-docs-preview.yml"
 
 permissions:
   contents: read
+
+# A close or newer commit cancels an in-flight build for the same PR.
+concurrency:
+  group: request-docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -31,50 +33,64 @@ jobs:
     if: >
       github.event.action != 'closed' &&
       !github.event.pull_request.head.repo.fork &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, fireactions-turbo-8]
-    concurrency:
-      group: request-docs-preview-build-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''
+    runs-on: ubuntu-24.04
     env:
-      # Public project identifiers only — never a deploy token.
       VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_DOCS_PROJECT_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_DOCS_PREVIEW_PROJECT_ID }}
+      VERCEL_PRODUCTION_PROJECT_ID: ${{ vars.VERCEL_DOCS_PROJECT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out untrusted PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
-      - name: Require public Vercel project vars
+      - name: Require a dedicated preview project
         run: |
           set -euo pipefail
-          if [ -z "${VERCEL_ORG_ID}" ] || [ -z "${VERCEL_PROJECT_ID}" ]; then
-            echo "Set repository variables VERCEL_ORG_ID and VERCEL_DOCS_PROJECT_ID" >&2
-            echo "(project/org IDs are not secrets; the deploy token stays on the trusted workflow)." >&2
+          id_pattern='^[A-Za-z0-9_-]+$'
+          if ! [[ "${VERCEL_ORG_ID}" =~ ${id_pattern} ]] ||
+             ! [[ "${VERCEL_PROJECT_ID}" =~ ${id_pattern} ]] ||
+             ! [[ "${VERCEL_PRODUCTION_PROJECT_ID}" =~ ${id_pattern} ]] ||
+             [ "${#VERCEL_ORG_ID}" -gt 128 ] ||
+             [ "${#VERCEL_PROJECT_ID}" -gt 128 ] ||
+             [ "${#VERCEL_PRODUCTION_PROJECT_ID}" -gt 128 ]; then
+            echo "Set valid VERCEL_ORG_ID, VERCEL_DOCS_PROJECT_ID, and VERCEL_DOCS_PREVIEW_PROJECT_ID repository variables." >&2
+            exit 1
+          fi
+          if [ "${VERCEL_PROJECT_ID}" = "${VERCEL_PRODUCTION_PROJECT_ID}" ]; then
+            echo "VERCEL_DOCS_PREVIEW_PROJECT_ID must identify a dedicated, non-production project." >&2
             exit 1
           fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
+          cache: npm
+          cache-dependency-path: .github/docs-preview-vercel/package-lock.json
 
-      - name: Enable corepack (yarn 4)
+      - name: Install locked Vercel CLI (no secrets)
+        run: |
+          set -euo pipefail
+          npm ci --ignore-scripts --prefix .github/docs-preview-vercel
+          npm audit --audit-level=high --omit=dev --prefix .github/docs-preview-vercel
+          test -x .github/docs-preview-vercel/node_modules/.bin/vercel
+
+      - name: Enable corepack (Yarn 4)
         run: corepack enable
 
       - name: Assemble Vercel prebuilt output (no deploy token)
         run: |
           set -euo pipefail
           mkdir -p .vercel
-          # Full project settings (framework / rootDirectory / node) — same
-          # payload `vercel pull` writes. IDs + settings are not secrets; the
-          # deploy token stays off this workflow.
           node -e '
             const fs = require("fs");
             fs.writeFileSync(".vercel/project.json", JSON.stringify({
               projectId: process.env.VERCEL_PROJECT_ID,
               orgId: process.env.VERCEL_ORG_ID,
-              projectName: "subtensor",
               settings: {
                 framework: "nextjs",
                 devCommand: null,
@@ -87,31 +103,33 @@ jobs:
               },
             }, null, 2));
           '
-          # Local assemble only — do not pass --token.
-          npx --yes vercel@56.4.1 build
-          test -f .vercel/output/functions/_global-error.func/.vc-config.json
+          .github/docs-preview-vercel/node_modules/.bin/vercel build
+          test -d .vercel/output
           test -d website/node_modules
 
-      - name: Seal prebuilt output for trusted deploy
+      - name: Seal prebuilt output for trusted validation
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          # Include website/node_modules: Next NFT traces resolve there during
-          # `vercel deploy --prebuilt`. Dereference links so the trusted
-          # extractor never has to honor PR-controlled symlinks/hardlinks.
+          case "${PR_NUMBER}" in
+            ''|*[!0-9]*) echo "invalid PR number" >&2; exit 1 ;;
+          esac
           tar --create --gzip --file=docs-preview-sealed.tgz \
             --hard-dereference --dereference \
             .vercel/output website/node_modules
-          printf '%s\n' "${{ github.event.pull_request.number }}" > docs-preview-pr-number.txt
+          printf '%s\n' "${PR_NUMBER}" > docs-preview-pr-number.txt
           printf '%s\n' "deploy" > docs-preview-action.txt
 
       - name: Upload sealed prebuilt output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-preview-${{ github.event.pull_request.number }}
           path: |
             docs-preview-sealed.tgz
             docs-preview-pr-number.txt
             docs-preview-action.txt
+          if-no-files-found: error
           retention-days: 1
 
   request-cleanup:
@@ -119,19 +137,27 @@ jobs:
     if: >
       github.event.action == 'closed' &&
       !github.event.pull_request.head.repo.fork &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, fireactions-turbo-8]
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      vars.VERCEL_DOCS_PREVIEW_PROJECT_ID != ''
+    runs-on: ubuntu-24.04
     steps:
-      - name: Upload cleanup marker
+      - name: Create cleanup marker
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          printf '%s\n' "${{ github.event.pull_request.number }}" > docs-preview-pr-number.txt
+          case "${PR_NUMBER}" in
+            ''|*[!0-9]*) echo "invalid PR number" >&2; exit 1 ;;
+          esac
+          printf '%s\n' "${PR_NUMBER}" > docs-preview-pr-number.txt
           printf '%s\n' "cleanup" > docs-preview-action.txt
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload cleanup marker
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-preview-${{ github.event.pull_request.number }}
           path: |
             docs-preview-pr-number.txt
             docs-preview-action.txt
+          if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Summary
- Keeps pull-request builds secret-free and runs both halves on ephemeral GitHub-hosted runners.
- Treats the PR artifact as hostile: bounds and validates the GitHub ZIP and tar stream, rejects links/special paths, and makes Vercel `filePathMap` references self-contained before the trusted deploy.
- Prevents `filePathMap` references such as `/proc/self/cmdline` from making the pinned Vercel CLI upload its token-bearing process arguments.
- Uses a dedicated preview project, rejects project-level and linked team-shared Preview variables, and verifies the project differs from production.
- Replaces per-PR DNS mutation with one pre-provisioned, verified `*.preview.DOCS_DOMAIN` wildcard.
- Moves GitHub and Vercel control-plane behavior into focused, tested Python modules; the trusted workflow contains only declarative orchestration.
- Pins the Vercel CLI dependency graph, disables lifecycle scripts, gives the deploy CLI a fresh home and minimal environment, and fails CI on high-severity advisories.
- Re-checks PR state and head SHA before deployment, serializes runs per source branch, confines aliases/deployments to the preview project, and removes closed-PR state.

## Preview enablement
The security boundary is fail-closed. The repository must have:
- `VERCEL_ORG_ID`
- `VERCEL_DOCS_PROJECT_ID`
- `VERCEL_DOCS_PREVIEW_PROJECT_ID` set to a dedicated non-production project
- `VERCEL_TOKEN` with access to that project
- `*.preview.DOCS_DOMAIN` attached to the preview project and verified once

The preview project must not expose project-level or linked team-shared environment variables to Preview. If the wildcard is absent or unverified, the trusted workflow stops before deployment. The code is safe to merge before wildcard provisioning, but previews remain unavailable.

No Vercel or DNS account changes are performed by this PR.

## Validation
- 56 Python artifact, archive, GitHub lifecycle, Vercel lifecycle, and workflow-policy tests
- Black formatting and Ruff lint
- Workflow YAML parsing and actionlint
- Locked Vercel CLI 56.4.1 clean install and startup
- `npm audit --audit-level=high --omit=dev` passes (three low-severity transitive advisories remain)
- Updated PR CI completed the real Vercel build, self-contained sealing, and artifact upload
- The safe validators accepted that exact 811 MB artifact and its 138,879 archive members locally without deployment credentials

## Base
Rebased onto `release-v439` at `09487e585`.
