### PR TITLE
Fix testnet GRANDPA warp sync checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1499,7 +1499,7 @@ checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "hash-db",
  "log",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3168,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3178,7 +3178,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3401,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4471,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "alloy-core",
 ]
@@ -4853,7 +4853,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
 ]
 
 [[package]]
@@ -5036,7 +5036,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5156,7 +5156,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5180,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5245,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5273,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5284,7 +5284,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5384,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5425,20 +5425,33 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "docify",
  "expander",
+ "frame-support-procedural-core",
  "frame-support-procedural-tools 13.0.1",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "frame-support-procedural-core"
+version = "34.0.0"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+dependencies = [
+ "cfg-expr",
+ "frame-support-procedural-tools 13.0.1",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 
@@ -5458,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.4.0",
@@ -5481,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5491,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5510,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5524,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5534,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8274,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "log",
@@ -8293,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8682,6 +8695,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
  "hex",
+ "hex-literal",
  "jsonrpsee",
  "log",
  "memmap2 0.9.8",
@@ -9263,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -9275,7 +9289,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-io",
  "sp-runtime",
 ]
@@ -9299,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9317,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9335,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9350,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9364,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9382,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9398,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9416,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9428,7 +9442,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9443,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9453,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9469,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9484,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9497,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9520,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9541,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9570,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9589,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9614,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9631,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9650,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9669,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9689,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9712,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9730,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9748,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9767,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9784,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9825,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9856,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9887,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9897,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9908,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9924,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9962,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9977,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9994,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10043,7 +10057,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10061,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10082,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10103,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10116,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10235,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10253,7 +10267,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10271,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10307,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10323,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10342,7 +10356,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10357,7 +10371,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10390,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10403,7 +10417,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10419,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10438,7 +10452,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10456,7 +10470,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10475,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10489,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10501,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10512,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10525,7 +10539,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10542,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10552,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10563,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10581,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10601,7 +10615,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10611,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10626,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10649,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10667,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10678,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10695,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10713,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10729,8 +10743,10 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
@@ -10739,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10757,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10767,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10785,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10800,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10846,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10860,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10870,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10882,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10898,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10911,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10925,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10937,7 +10953,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10954,7 +10970,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10967,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10988,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11034,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11046,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11063,7 +11079,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11085,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11108,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11127,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11144,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -11155,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11164,7 +11180,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11174,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11190,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11354,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11369,7 +11385,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11387,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11405,7 +11421,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11420,7 +11436,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11436,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11448,7 +11464,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11467,7 +11483,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11486,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11497,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11511,7 +11527,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11526,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11541,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11555,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11565,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -11591,7 +11607,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11608,7 +11624,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11630,7 +11646,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11650,7 +11666,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -12012,7 +12028,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12030,7 +12046,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12045,7 +12061,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fatality",
  "futures",
@@ -12068,7 +12084,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12101,7 +12117,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12125,7 +12141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12148,7 +12164,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12159,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fatality",
  "futures",
@@ -12181,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12195,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12208,7 +12224,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -12216,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12239,7 +12255,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12257,7 +12273,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12289,7 +12305,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -12313,7 +12329,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "futures",
@@ -12332,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12353,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12368,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -12390,7 +12406,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12404,7 +12420,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12420,7 +12436,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fatality",
  "futures",
@@ -12438,7 +12454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -12455,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fatality",
  "futures",
@@ -12469,7 +12485,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12486,7 +12502,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12514,7 +12530,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12527,7 +12543,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12542,7 +12558,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12553,7 +12569,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12568,7 +12584,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bs58",
  "futures",
@@ -12585,7 +12601,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12610,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12634,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12643,7 +12659,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12671,7 +12687,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fatality",
  "futures",
@@ -12702,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "clap",
@@ -12790,7 +12806,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -12810,7 +12826,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -12826,7 +12842,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -12855,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12888,7 +12904,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12938,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12950,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12998,7 +13014,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -13156,7 +13172,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13191,7 +13207,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13301,7 +13317,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13321,7 +13337,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13628,7 +13644,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "syn 2.0.106",
 ]
 
@@ -13810,7 +13826,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "syn 2.0.106",
 ]
 
@@ -14635,7 +14651,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14733,7 +14749,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15163,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "sp-core",
@@ -15174,7 +15190,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -15205,7 +15221,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "log",
@@ -15227,7 +15243,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15242,7 +15258,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -15258,7 +15274,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15269,7 +15285,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15280,7 +15296,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -15322,7 +15338,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fnv",
  "futures",
@@ -15348,7 +15364,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15376,7 +15392,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -15399,7 +15415,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -15428,7 +15444,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15453,7 +15469,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -15464,7 +15480,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15486,7 +15502,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15520,7 +15536,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15540,7 +15556,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15553,7 +15569,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -15587,7 +15603,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15597,7 +15613,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -15617,7 +15633,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15652,7 +15668,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -15675,7 +15691,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -15698,7 +15714,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -15711,7 +15727,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15722,7 +15738,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "anyhow",
  "log",
@@ -15738,7 +15754,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "console",
  "futures",
@@ -15754,7 +15770,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -15768,7 +15784,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15796,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15846,7 +15862,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15856,7 +15872,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -15875,7 +15891,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15896,7 +15912,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15916,7 +15932,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15951,7 +15967,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15970,7 +15986,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bs58",
  "bytes",
@@ -15991,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bytes",
  "fnv",
@@ -16025,7 +16041,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16034,7 +16050,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16066,7 +16082,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16086,7 +16102,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -16110,7 +16126,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -16143,13 +16159,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -16158,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "directories",
@@ -16222,7 +16238,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16233,7 +16249,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-db",
@@ -16252,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "clap",
  "fs4",
@@ -16265,7 +16281,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16284,7 +16300,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -16297,14 +16313,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "chrono",
  "futures",
@@ -16323,7 +16339,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "chrono",
  "console",
@@ -16351,7 +16367,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -16362,7 +16378,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -16379,7 +16395,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16393,7 +16409,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -16410,7 +16426,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -17166,7 +17182,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -17450,7 +17466,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -17545,7 +17561,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "hash-db",
@@ -17567,7 +17583,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17581,7 +17597,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17593,7 +17609,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17607,7 +17623,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17619,7 +17635,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17629,7 +17645,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -17648,7 +17664,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "futures",
@@ -17662,7 +17678,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17678,7 +17694,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17696,7 +17712,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17704,7 +17720,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -17716,7 +17732,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17733,7 +17749,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17744,7 +17760,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -17775,7 +17791,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -17792,7 +17808,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17826,7 +17842,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17839,17 +17855,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -17858,7 +17874,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17868,7 +17884,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17878,7 +17894,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17890,7 +17906,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17903,7 +17919,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bytes",
  "docify",
@@ -17915,7 +17931,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -17929,7 +17945,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17939,7 +17955,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -17950,7 +17966,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17959,7 +17975,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17969,7 +17985,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17980,7 +17996,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17997,7 +18013,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18010,7 +18026,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18020,7 +18036,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "backtrace",
  "regex",
@@ -18029,7 +18045,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18039,7 +18055,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -18068,7 +18084,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18087,7 +18103,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "Inflector",
  "expander",
@@ -18100,7 +18116,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18114,7 +18130,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18127,7 +18143,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "hash-db",
  "log",
@@ -18147,7 +18163,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18160,7 +18176,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18171,12 +18187,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18188,7 +18204,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18200,7 +18216,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -18211,7 +18227,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18220,7 +18236,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18234,7 +18250,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -18259,7 +18275,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18276,7 +18292,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -18288,7 +18304,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -18300,7 +18316,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -18474,7 +18490,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "clap",
  "docify",
@@ -18487,7 +18503,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -18505,7 +18521,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18518,7 +18534,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.4",
@@ -18539,7 +18555,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "environmental",
  "frame-support",
@@ -18563,7 +18579,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18617,7 +18633,7 @@ dependencies = [
 [[package]]
 name = "stc-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -18638,7 +18654,7 @@ dependencies = [
 [[package]]
 name = "stp-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18708,7 +18724,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -18733,7 +18749,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 
 [[package]]
 name = "substrate-fixed"
@@ -18749,7 +18765,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18769,7 +18785,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "http-body-util",
  "hyper 1.7.0",
@@ -18783,7 +18799,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -18810,7 +18826,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19919,7 +19935,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19930,7 +19946,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -20935,7 +20951,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21042,7 +21058,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -21692,7 +21708,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21703,7 +21719,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -21717,7 +21733,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1499,7 +1499,7 @@ checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "hash-db",
  "log",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -3001,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3168,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3178,7 +3178,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3367,7 +3367,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3401,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3426,7 +3426,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3491,7 +3491,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4471,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "alloy-core",
 ]
@@ -4853,7 +4853,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
 ]
 
 [[package]]
@@ -5036,7 +5036,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5156,7 +5156,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5180,7 +5180,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5245,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5273,7 +5273,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5284,7 +5284,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5354,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5384,7 +5384,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5425,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5439,14 +5439,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural-core"
 version = "34.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cfg-expr",
  "frame-support-procedural-tools 13.0.1",
@@ -5471,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.4.0",
@@ -5494,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5547,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "log",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9277,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -9289,7 +9289,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-io",
  "sp-runtime",
 ]
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9331,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9430,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9442,7 +9442,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9457,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9483,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9498,7 +9498,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9534,7 +9534,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9603,7 +9603,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9628,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9664,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9798,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9870,7 +9870,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9901,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9922,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9976,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10008,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10057,7 +10057,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10075,7 +10075,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10096,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10249,7 +10249,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10267,7 +10267,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10321,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10337,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10356,7 +10356,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10371,7 +10371,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10404,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10417,7 +10417,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10452,7 +10452,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10470,7 +10470,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10503,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10539,7 +10539,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10556,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10566,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10577,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10595,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10615,7 +10615,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10640,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10663,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10681,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10692,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10801,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10862,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10876,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10927,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10953,7 +10953,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10970,7 +10970,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11004,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11050,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11062,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11079,7 +11079,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11143,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11160,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11180,7 +11180,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11190,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11370,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11385,7 +11385,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11421,7 +11421,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11436,7 +11436,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11452,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11464,7 +11464,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11483,7 +11483,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11502,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11513,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11527,7 +11527,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11542,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11557,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11571,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11581,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -11607,7 +11607,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11624,7 +11624,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11646,7 +11646,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11666,7 +11666,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -12028,7 +12028,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12046,7 +12046,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12061,7 +12061,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fatality",
  "futures",
@@ -12084,7 +12084,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12117,7 +12117,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12141,7 +12141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12164,7 +12164,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12175,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fatality",
  "futures",
@@ -12197,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12224,7 +12224,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -12232,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12255,7 +12255,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12273,7 +12273,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12305,7 +12305,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -12329,7 +12329,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "futures",
@@ -12348,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12369,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12384,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -12406,7 +12406,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12420,7 +12420,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12436,7 +12436,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fatality",
  "futures",
@@ -12454,7 +12454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -12471,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fatality",
  "futures",
@@ -12485,7 +12485,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12502,7 +12502,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12530,7 +12530,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12543,7 +12543,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12558,7 +12558,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12569,7 +12569,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12584,7 +12584,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bs58",
  "futures",
@@ -12601,7 +12601,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12626,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12659,7 +12659,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12687,7 +12687,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fatality",
  "futures",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "clap",
@@ -12806,7 +12806,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -12826,7 +12826,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -12842,7 +12842,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12904,7 +12904,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12954,7 +12954,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -13014,7 +13014,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -13172,7 +13172,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13207,7 +13207,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13317,7 +13317,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13337,7 +13337,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13644,7 +13644,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "syn 2.0.106",
 ]
 
@@ -13826,7 +13826,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "syn 2.0.106",
 ]
 
@@ -14651,7 +14651,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14749,7 +14749,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15179,7 +15179,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "sp-core",
@@ -15190,7 +15190,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -15221,7 +15221,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "log",
@@ -15243,7 +15243,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15258,7 +15258,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -15274,7 +15274,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15285,7 +15285,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15296,7 +15296,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -15338,7 +15338,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fnv",
  "futures",
@@ -15364,7 +15364,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15392,7 +15392,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -15415,7 +15415,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -15444,7 +15444,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15469,7 +15469,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -15480,7 +15480,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15502,7 +15502,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15536,7 +15536,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15556,7 +15556,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15569,7 +15569,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -15603,7 +15603,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15613,7 +15613,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -15633,7 +15633,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15668,7 +15668,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -15691,7 +15691,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -15714,7 +15714,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -15727,7 +15727,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15738,7 +15738,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "anyhow",
  "log",
@@ -15754,7 +15754,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "console",
  "futures",
@@ -15770,7 +15770,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -15784,7 +15784,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15812,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15862,7 +15862,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15872,7 +15872,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -15891,7 +15891,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15912,7 +15912,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15932,7 +15932,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15967,7 +15967,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15986,7 +15986,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bs58",
  "bytes",
@@ -16007,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bytes",
  "fnv",
@@ -16041,7 +16041,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -16050,7 +16050,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -16082,7 +16082,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16102,7 +16102,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -16126,7 +16126,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -16159,13 +16159,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -16174,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "directories",
@@ -16238,7 +16238,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16249,7 +16249,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-db",
@@ -16268,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "clap",
  "fs4",
@@ -16281,7 +16281,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16300,7 +16300,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -16313,14 +16313,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "chrono",
  "futures",
@@ -16339,7 +16339,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "chrono",
  "console",
@@ -16367,7 +16367,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -16378,7 +16378,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -16395,7 +16395,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16409,7 +16409,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -16426,7 +16426,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -17182,7 +17182,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -17466,7 +17466,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -17561,7 +17561,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "hash-db",
@@ -17583,7 +17583,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17597,7 +17597,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17609,7 +17609,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17623,7 +17623,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17635,7 +17635,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17645,7 +17645,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -17664,7 +17664,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "futures",
@@ -17678,7 +17678,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17694,7 +17694,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17712,7 +17712,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17720,7 +17720,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -17732,7 +17732,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17749,7 +17749,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17760,7 +17760,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -17791,7 +17791,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -17808,7 +17808,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17842,7 +17842,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17855,17 +17855,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -17874,7 +17874,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17884,7 +17884,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17894,7 +17894,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17906,7 +17906,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17919,7 +17919,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bytes",
  "docify",
@@ -17931,7 +17931,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -17945,7 +17945,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17955,7 +17955,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -17966,7 +17966,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17975,7 +17975,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17985,7 +17985,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17996,7 +17996,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -18013,7 +18013,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18026,7 +18026,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -18036,7 +18036,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "backtrace",
  "regex",
@@ -18045,7 +18045,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -18055,7 +18055,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -18084,7 +18084,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -18103,7 +18103,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "Inflector",
  "expander",
@@ -18116,7 +18116,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18130,7 +18130,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18143,7 +18143,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "hash-db",
  "log",
@@ -18163,7 +18163,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18176,7 +18176,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18187,12 +18187,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18204,7 +18204,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18216,7 +18216,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -18227,7 +18227,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18236,7 +18236,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18250,7 +18250,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -18275,7 +18275,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18292,7 +18292,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -18304,7 +18304,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -18316,7 +18316,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -18490,7 +18490,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "clap",
  "docify",
@@ -18503,7 +18503,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -18521,7 +18521,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18534,7 +18534,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.4",
@@ -18555,7 +18555,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "environmental",
  "frame-support",
@@ -18579,7 +18579,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18633,7 +18633,7 @@ dependencies = [
 [[package]]
 name = "stc-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -18654,7 +18654,7 @@ dependencies = [
 [[package]]
 name = "stp-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18724,7 +18724,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -18749,7 +18749,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 
 [[package]]
 name = "substrate-fixed"
@@ -18765,7 +18765,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18785,7 +18785,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "http-body-util",
  "hyper 1.7.0",
@@ -18799,7 +18799,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -18826,7 +18826,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19935,7 +19935,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19946,7 +19946,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -20951,7 +20951,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -21058,7 +21058,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -21708,7 +21708,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21719,7 +21719,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -21733,7 +21733,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=3a843596a439a252723bc5b257b0e281ed3d9540#3a843596a439a252723bc5b257b0e281ed3d9540"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=a08c7b0f0b6429910a953cbbaec4b4138294fa38#a08c7b0f0b6429910a953cbbaec4b4138294fa38"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ subtensor-runtime-common = { default-features = false, path = "common" }
 subtensor-swap-interface = { default-features = false, path = "primitives/swap-interface" }
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
-stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
 ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
@@ -136,122 +136,122 @@ num_enum = { version = "0.7.4", default-features = false }
 environmental = { version = "1.1.4", default-features = false }
 tokio = { version = "1.38", default-features = false }
 
-frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 
 pallet-subtensor-proxy = { path = "pallets/proxy", default-features = false }
 pallet-subtensor-utility = { path = "pallets/utility", default-features = false }
-pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
 # NPoS
-frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed.git", tag = "v0.6.0", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
-polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
-runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 
 # Frontier
 # Vendored via `git subtree` from RaoFoundation/frontier
@@ -290,8 +290,8 @@ pallet-hotfix-sufficients = { path = "vendor/frontier/frame/hotfix-sufficients",
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
 w3f-bls = { path = "vendor/w3f-bls", default-features = false }
 ark-crypto-primitives = { version = "0.4.0", default-features = false }
 ark-scale = { version = "0.0.11", default-features = false }
@@ -342,104 +342,104 @@ zstd-safe = { git = "https://github.com/gztensor/zstd-safe", rev = "42cc34ef6abe
 # build. Redirect the frontier-side polkadot-sdk crates to the RaoFoundation
 # remote at the same rev so the whole graph resolves to a single copy.
 [patch."https://github.com/opentensor/polkadot-sdk"]
-binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
+binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ subtensor-runtime-common = { default-features = false, path = "common" }
 subtensor-swap-interface = { default-features = false, path = "primitives/swap-interface" }
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
-stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
 ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
@@ -136,122 +136,122 @@ num_enum = { version = "0.7.4", default-features = false }
 environmental = { version = "1.1.4", default-features = false }
 tokio = { version = "1.38", default-features = false }
 
-frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 
 pallet-subtensor-proxy = { path = "pallets/proxy", default-features = false }
 pallet-subtensor-utility = { path = "pallets/utility", default-features = false }
-pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
 # NPoS
-frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed.git", tag = "v0.6.0", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
-polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
-runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 
 # Frontier
 # Vendored via `git subtree` from RaoFoundation/frontier
@@ -290,8 +290,8 @@ pallet-hotfix-sufficients = { path = "vendor/frontier/frame/hotfix-sufficients",
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false }
 w3f-bls = { path = "vendor/w3f-bls", default-features = false }
 ark-crypto-primitives = { version = "0.4.0", default-features = false }
 ark-scale = { version = "0.0.11", default-features = false }
@@ -342,104 +342,104 @@ zstd-safe = { git = "https://github.com/gztensor/zstd-safe", rev = "42cc34ef6abe
 # build. Redirect the frontier-side polkadot-sdk crates to the RaoFoundation
 # remote at the same rev so the whole graph resolves to a single copy.
 [patch."https://github.com/opentensor/polkadot-sdk"]
-binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
-xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "3a843596a439a252723bc5b257b0e281ed3d9540" }
+binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }
+xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38" }

--- a/chainspecs/plain_spec_testfinney.json
+++ b/chainspecs/plain_spec_testfinney.json
@@ -6,7 +6,7 @@
     "/dns/bootnode.test.chain.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr"
   ],
   "telemetryEndpoints": null,
-  "protocolId": "bittensor",
+  "protocolId": "bittensor-testnet",
   "properties": {
     "ss58Format": 42,
     "tokenDecimals": 9,

--- a/chainspecs/raw_spec_testfinney.json
+++ b/chainspecs/raw_spec_testfinney.json
@@ -6,7 +6,7 @@
     "/dns/bootnode.test.chain.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr"
   ],
   "telemetryEndpoints": null,
-  "protocolId": "bittensor",
+  "protocolId": "bittensor-testnet",
   "properties": {
     "ss58Format": 42,
     "tokenDecimals": 9,

--- a/eco-tests/Cargo.toml
+++ b/eco-tests/Cargo.toml
@@ -23,22 +23,22 @@ useless_conversion = "allow"
 time = { version = "0.3.47", default-features = false }
 pallet-subtensor = { path = "../pallets/subtensor", default-features = false, features = ["std"] }
 pallet-alpha-assets = { path = "../pallets/alpha-assets", default-features = false, features = ["std"] }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive", "std"] }
 scale-info = { version = "2.11.2", default-features = false, features = ["derive", "std"] }
-pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
-pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
+pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
 pallet-drand = { path = "../pallets/drand", default-features = false, features = ["std"] }
 pallet-subtensor-swap = { path = "../pallets/swap", default-features = false, features = ["std"] }
 pallet-subtensor-swap-runtime-api = { path = "../pallets/swap/runtime-api", default-features = false, features = ["std"] }
 subtensor-custom-rpc-runtime-api = { path = "../pallets/subtensor/runtime-api", default-features = false, features = ["std"] }
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
 pallet-crowdloan = { path = "../pallets/crowdloan", default-features = false, features = ["std"] }
 pallet-subtensor-proxy = { path = "../pallets/proxy", default-features = false, features = ["std"] }
 pallet-subtensor-utility = { path = "../pallets/utility", default-features = false, features = ["std"] }
@@ -50,7 +50,7 @@ substrate-fixed = { git = "https://github.com/encointer/substrate-fixed.git", ta
 safe-math = { path = "../primitives/safe-math", default-features = false, features = ["std"] }
 log = { version = "0.4.21", default-features = false, features = ["std"] }
 approx = "0.5"
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false, features = ["std"] }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "a08c7b0f0b6429910a953cbbaec4b4138294fa38", default-features = false, features = ["std"] }
 tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,6 +26,7 @@ clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true, features = ["thread-pool"] }
 serde = { workspace = true, features = ["derive"] }
 hex.workspace = true
+hex-literal.workspace = true
 tokio = { workspace = true, features = ["time", "rt", "net"] }
 
 # Storage import

--- a/node/src/chain_spec/testnet.rs
+++ b/node/src/chain_spec/testnet.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 
+const TESTNET_PROTOCOL_ID: &str = "bittensor-testnet";
+
 pub fn finney_testnet_config() -> Result<ChainSpec, String> {
     let path: PathBuf = std::path::PathBuf::from("./snapshot.json");
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
@@ -55,7 +57,7 @@ pub fn finney_testnet_config() -> Result<ChainSpec, String> {
             .parse()
             .unwrap(),
     ])
-    .with_protocol_id("bittensor")
+    .with_protocol_id(TESTNET_PROTOCOL_ID)
     .with_id("bittensor")
     .with_chain_type(ChainType::Development)
     .with_genesis_config_patch(testnet_genesis(
@@ -131,4 +133,31 @@ fn testnet_genesis(
             "key": Some(root_key),
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_in_specs_use_testnet_protocol_id() {
+        for (name, spec) in [
+            (
+                "plain",
+                include_str!("../../../chainspecs/plain_spec_testfinney.json"),
+            ),
+            (
+                "raw",
+                include_str!("../../../chainspecs/raw_spec_testfinney.json"),
+            ),
+        ] {
+            let spec: serde_json::Value =
+                serde_json::from_str(spec).expect("checked-in chain spec should be valid");
+            assert_eq!(
+                spec.get("protocolId").and_then(serde_json::Value::as_str),
+                Some(TESTNET_PROTOCOL_ID),
+                "{name} testnet chain spec has an unexpected protocol ID"
+            );
+        }
+    }
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,5 +1,7 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
+mod grandpa_warp_sync;
+
 use crate::consensus::ConsensusMechanism;
 use futures::{FutureExt, StreamExt as _, channel::mpsc};
 use node_subtensor_runtime::{RuntimeApi, TransactionConverter, opaque::Block};
@@ -305,10 +307,9 @@ where
     let peer_store_handle = net_config.peer_store_handle();
     let metrics = NB::register_notification_metrics(maybe_registry);
 
-    let grandpa_protocol_name = sc_consensus_grandpa::protocol_standard_name(
-        &client.block_hash(0u32)?.expect("Genesis block exists; qed"),
-        &config.chain_spec,
-    );
+    let genesis_hash = client.block_hash(0u32)?.expect("Genesis block exists; qed");
+    let grandpa_protocol_name =
+        sc_consensus_grandpa::protocol_standard_name(&genesis_hash, &config.chain_spec);
 
     let (grandpa_protocol_config, grandpa_notification_service) =
         sc_consensus_grandpa::grandpa_peers_set_config::<_, NB>(
@@ -320,24 +321,15 @@ where
     let warp_sync_config = if sealing.is_some() {
         None
     } else {
-        let set_id = match config.chain_spec.chain_type() {
-            // Finney patch
-            ChainType::Live => 3,
-            // Testnet patch
-            ChainType::Development => 2,
-            // All others (e.g. localnet)
-            _ => 0,
-        };
-        log::warn!(
-            "Grandpa warp sync patch enabled. Chain type = {:?}. Set ID = {set_id}",
-            config.chain_spec.chain_type()
-        );
         net_config.add_notification_protocol(grandpa_protocol_config);
+        let warp_sync_config =
+            grandpa_warp_sync::config(genesis_hash, config.chain_spec.chain_type());
+        log::warn!("{}", warp_sync_config.log_message());
         let warp_sync: Arc<dyn WarpSyncProvider<Block>> =
             Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
                 backend.clone(),
                 grandpa_link.shared_authority_set().clone(),
-                sc_consensus_grandpa::warp_proof::HardForks::new_initial_set_id(set_id),
+                warp_sync_config.into_hard_forks(),
             ));
 
         Some(WarpSyncConfig::WithProvider(warp_sync))

--- a/node/src/service/grandpa_warp_sync.rs
+++ b/node/src/service/grandpa_warp_sync.rs
@@ -1,0 +1,160 @@
+use node_subtensor_runtime::opaque::Block;
+use sc_chain_spec::ChainType;
+use sc_consensus_grandpa::{AuthoritySetHardFork, warp_proof::HardForks};
+use sp_consensus_grandpa::{AuthorityId, AuthorityList};
+use sp_core::{ByteArray, H256};
+
+const TESTNET_GENESIS: H256 = H256(hex_literal::hex!(
+    "8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+));
+
+pub(super) enum Config {
+    TestnetCheckpoints(Vec<AuthoritySetHardFork<Block>>),
+    InitialSetId(u64),
+}
+
+pub(super) fn config(genesis_hash: H256, chain_type: ChainType) -> Config {
+    if genesis_hash == TESTNET_GENESIS {
+        Config::TestnetCheckpoints(testnet_checkpoints())
+    } else {
+        let set_id = match chain_type {
+            ChainType::Live => 3,
+            ChainType::Development => 2,
+            _ => 0,
+        };
+        Config::InitialSetId(set_id)
+    }
+}
+
+impl Config {
+    pub(super) fn log_message(&self) -> String {
+        match self {
+            Self::TestnetCheckpoints(_) => "Testnet GRANDPA warp sync checkpoints enabled.".into(),
+            Self::InitialSetId(set_id) => {
+                format!("GRANDPA warp sync initial set ID patch enabled. Set ID = {set_id}")
+            }
+        }
+    }
+
+    pub(super) fn into_hard_forks(self) -> HardForks<Block> {
+        match self {
+            Self::TestnetCheckpoints(checkpoints) => {
+                HardForks::new_hard_forked_authorities(checkpoints)
+            }
+            Self::InitialSetId(set_id) => HardForks::new_initial_set_id(set_id),
+        }
+    }
+}
+
+#[allow(clippy::expect_used)]
+fn testnet_authorities() -> AuthorityList {
+    [
+        hex_literal::hex!("dc832c3b7bdfc721e90e5ee9e532c06b62a0def3c79dab5324460d938db6600a"),
+        hex_literal::hex!("c8a00ef71912b3868b101cb70ebd029999d1c9b6a1390122a98f60d72b9a0fc4"),
+        hex_literal::hex!("ee70f7b52998c2b4f3d42e509e8360cda92b0cd4ca100cd4d32be5a1ac297909"),
+        hex_literal::hex!("b57a038c9139a060358f3b654df74a1cb6d15bcdb8438bcebd64ce67ec4301eb"),
+        hex_literal::hex!("755f75dfc66aaa3b1e761a8845249509b8bd2fdf0d94cb74e1e12e1e0f4d3519"),
+        hex_literal::hex!("d97a64267f177505b0565a18677c9f5d4284d7f2eb96d515556e7e52217f82e9"),
+    ]
+    .into_iter()
+    .map(|bytes| {
+        (
+            AuthorityId::from_slice(&bytes).expect("authority IDs are exactly 32 bytes"),
+            1,
+        )
+    })
+    .collect()
+}
+
+fn testnet_checkpoints() -> Vec<AuthoritySetHardFork<Block>> {
+    let authorities = testnet_authorities();
+
+    [
+        (
+            1,
+            4_589_686,
+            hex_literal::hex!("2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b"),
+        ),
+        (
+            3,
+            5_534_451,
+            hex_literal::hex!("4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4"),
+        ),
+    ]
+    .into_iter()
+    .map(|(set_id, number, hash)| AuthoritySetHardFork {
+        set_id,
+        block: (H256::from(hash), number),
+        authorities: authorities.clone(),
+        last_finalized: None,
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoints_are_exactly_testnet_genesis_scoped() {
+        assert!(matches!(
+            config(TESTNET_GENESIS, ChainType::Live),
+            Config::TestnetCheckpoints(_)
+        ));
+        assert!(matches!(
+            config(H256::zero(), ChainType::Live),
+            Config::InitialSetId(3)
+        ));
+        assert!(matches!(
+            config(H256::zero(), ChainType::Development),
+            Config::InitialSetId(2)
+        ));
+        assert!(matches!(
+            config(H256::zero(), ChainType::Local),
+            Config::InitialSetId(0)
+        ));
+    }
+
+    #[test]
+    fn testnet_checkpoints_are_ordered_and_share_authorities() {
+        let checkpoints = testnet_checkpoints();
+        let [first, second] = checkpoints.as_slice() else {
+            panic!("expected exactly two testnet warp checkpoints");
+        };
+
+        assert_eq!((first.set_id, first.block.1), (1, 4_589_686));
+        assert_eq!(
+            first.block.0,
+            H256::from(hex_literal::hex!(
+                "2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b"
+            ))
+        );
+        assert_eq!((second.set_id, second.block.1), (3, 5_534_451));
+        assert_eq!(
+            second.block.0,
+            H256::from(hex_literal::hex!(
+                "4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4"
+            ))
+        );
+        assert_eq!(first.authorities.len(), 6);
+        assert_eq!(first.authorities, second.authorities);
+        let authority_ids: Vec<&[u8]> = first
+            .authorities
+            .iter()
+            .map(|(authority_id, _)| AsRef::<[u8]>::as_ref(authority_id))
+            .collect();
+        let expected_authority_ids = [
+            hex_literal::hex!("dc832c3b7bdfc721e90e5ee9e532c06b62a0def3c79dab5324460d938db6600a"),
+            hex_literal::hex!("c8a00ef71912b3868b101cb70ebd029999d1c9b6a1390122a98f60d72b9a0fc4"),
+            hex_literal::hex!("ee70f7b52998c2b4f3d42e509e8360cda92b0cd4ca100cd4d32be5a1ac297909"),
+            hex_literal::hex!("b57a038c9139a060358f3b654df74a1cb6d15bcdb8438bcebd64ce67ec4301eb"),
+            hex_literal::hex!("755f75dfc66aaa3b1e761a8845249509b8bd2fdf0d94cb74e1e12e1e0f4d3519"),
+            hex_literal::hex!("d97a64267f177505b0565a18677c9f5d4284d7f2eb96d515556e7e52217f82e9"),
+        ];
+        let expected_authority_ids = expected_authority_ids
+            .iter()
+            .map(|id| id.as_slice())
+            .collect::<Vec<_>>();
+        assert_eq!(authority_ids, expected_authority_ids);
+    }
+}


### PR DESCRIPTION
## Summary

This change restores GRANDPA warp sync on testnet by:

- supplying trusted authority-set checkpoints for the exact testnet genesis;
- pinning the workspace to the merged Polkadot SDK warp-proof generator change at `a08c7b0f0b6429910a953cbbaec4b4138294fa38`;
- preserving the existing initial-set-ID behavior for every other chain:
  - live chains: set ID 3
  - development chains: set ID 2
  - other chains: set ID 0

## Root cause

Testnet's stored GRANDPA authority-set history cannot be replayed continuously from set ID 0. Historical transitions include a gap for which a proof-serving node cannot reconstruct the required justification.

The previous SDK proof generator began from the earliest stored authority-set transition and failed with `MissingData` when that history was incomplete. Although the node could provide trusted hard-fork authority checkpoints, the generator did not use those checkpoints as valid proof-generation starting points.

The merged SDK change makes finalized, canonical hard-fork checkpoints available to proof generation. Subtensor remains responsible only for supplying the chain-specific checkpoint blocks and authorities.

## Implementation

For the exact testnet genesis hash, the node configures two trusted GRANDPA checkpoints:

- set ID 1 at block 4,589,686;
- set ID 3 at block 5,534,451.

Checkpoint selection is guarded by the full genesis hash rather than chain type, so another development or live chain cannot inherit the testnet authority data accidentally.

[RaoFoundation/polkadot-sdk#28](https://github.com/RaoFoundation/polkadot-sdk/pull/28) has been merged into `polkadot-stable2506-2-otf-patches`. This PR pins all workspace SDK dependencies to its immutable merge commit, `a08c7b0f0b6429910a953cbbaec4b4138294fa38`, and regenerates `Cargo.lock` against that revision.

The workspace SDK dependencies are pinned together because GRANDPA types are shared across the client dependency graph. Mixing SDK revisions for only `sc-consensus-grandpa` would introduce duplicate or incompatible SDK types.

## Mainnet safety

The testnet checkpoint path is unreachable unless the chain genesis exactly matches testnet.

Mainnet retains its existing `InitialSetId(3)` configuration. Development chains retain set ID 2, and other chains retain set ID 0.

The checkpoint configuration is node-service code and does not itself change consensus rules, runtime storage, or on-chain state. The workspace-wide SDK revision still requires the normal dependency and runtime-artifact review before release.

## Validation

Validation after rebasing onto current `main` and pinning the merged SDK revision:

- `cargo metadata --locked --format-version 1 --no-deps`
- `SKIP_WASM_BUILD=1 cargo check -p node-subtensor --locked`
- `cargo fmt --all -- --check`
- `SKIP_WASM_BUILD=1 CARGO_NET_OFFLINE=true cargo test -p node-subtensor grandpa_warp_sync --locked`
  - 2 library-target tests passed
  - 2 binary-target tests passed
- `git diff --check`

Live testnet validation used a patched proof-serving node and a fresh patched client. The client obtained and verified the warp proof through authority set ID 4, progressed beyond `Downloading warp proofs`, completed state synchronization, and caught up to the chain head.

## Rollout order

1. Merge the SDK change into `polkadot-stable2506-2-otf-patches` — complete.
2. Pin this PR and its lockfile to the merged SDK revision — complete.
3. Complete Subtensor CI and runtime-artifact review.
4. Merge this PR.
5. Deploy updated testnet proof-serving nodes before relying on warp sync from updated clients.

This PR now consumes the SDK change from the reviewed, merged integration branch; its dependency no longer points at an unmerged feature head.
