### PR TITLE
Fix drand pulse bootstrap on localnet

### DIFF
--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -690,12 +690,10 @@ impl<T: Config> Pallet<T> {
                     return InvalidTransaction::Stale.into();
                 }
 
-                // Reject rounds that would advance LastStoredRound too far in a single
-                // step. A leap past unfillable rounds wedges the reveals and timelocks
-                // that reference them (#2794). `MAX_PULSES_TO_FETCH` is the most rounds
-                // the offchain worker ever submits in one catch-up run, so anything
-                // further ahead is not a legitimate pulse and is dropped before dispatch.
-                if r > last.saturating_add(MAX_PULSES_TO_FETCH) {
+                // A fresh chain's live round exceeds the catch-up window. Let the
+                // first pulse establish the anchor, matching `write_pulse`.
+                let is_first_storage = last == 0 && OldestStoredRound::<T>::get() == 0;
+                if !is_first_storage && r > last.saturating_add(MAX_PULSES_TO_FETCH) {
                     return InvalidTransaction::Stale.into();
                 }
 

--- a/pallets/drand/src/tests.rs
+++ b/pallets/drand/src/tests.rs
@@ -393,6 +393,38 @@ fn test_validate_unsigned_write_pulse() {
 }
 
 #[test]
+fn validate_unsigned_accepts_first_live_round_as_storage_anchor() {
+    // On a fresh chain the current drand round is far beyond the normal catch-up
+    // window. It must be admitted so `write_pulse` can anchor both round markers.
+    new_test_ext().execute_with(|| {
+        let block_number = 100_000_000;
+        let alice = sp_keyring::Sr25519Keyring::Alice;
+        System::set_block_number(block_number);
+
+        assert_eq!(LastStoredRound::<Test>::get(), 0);
+        assert_eq!(OldestStoredRound::<Test>::get(), 0);
+
+        let pulse = Pulse {
+            round: crate::MAX_PULSES_TO_FETCH + 1,
+            randomness: frame_support::BoundedVec::truncate_from(vec![0u8; 32]),
+            signature: frame_support::BoundedVec::truncate_from(vec![1u8; 96]),
+        };
+        let pulses_payload = PulsesPayload {
+            block_number,
+            pulses: vec![pulse],
+            public: alice.public(),
+        };
+        let signature = alice.sign(&pulses_payload.encode());
+        let call = Call::write_pulse {
+            pulses_payload,
+            signature: Some(signature),
+        };
+
+        assert_ok!(Drand::validate_unsigned(TransactionSource::Local, &call));
+    });
+}
+
+#[test]
 fn validate_unsigned_rejects_round_too_far_ahead() {
     // A round that would leap LastStoredRound by more than the offchain worker ever
     // submits in one run is not a legitimate catch-up pulse. Drop it at the mempool


### PR DESCRIPTION
## Motivation

Fresh local chains start with both drand round markers at zero, while the live drand round is already far beyond the normal catch-up window. Unsigned validation therefore rejected the first pulse before `write_pulse` could establish the initial storage anchor.

## Changes

- Treat `LastStoredRound == 0` and `OldestStoredRound == 0` as fresh storage during unsigned validation.
- Allow the first valid pulse to establish the round anchor regardless of the normal catch-up window.
- Preserve the existing leap-ahead limit after storage has been initialized.
- Add a regression test covering a first live round beyond `MAX_PULSES_TO_FETCH`.

## Files of interest

- `pallets/drand/src/lib.rs`
- `pallets/drand/src/tests.rs`

## Behavioral impact

Local and newly initialized chains can bootstrap drand from the current live round. Existing chains retain the prior stale and leap-ahead protections.

## Migration and runtime version

No storage migration is required. The PR does not change storage layout.

## Testing

Added `validate_unsigned_accepts_first_live_round_as_storage_anchor` to exercise the bootstrap validation path.