### PR TITLE
Prevent parent-child key closed loops

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1075,7 +1075,12 @@ mod dispatches {
         /// 8. **New Children Assignment**: Assigns the new child to the hotkey and updates the parent list for the new child.
         // TODO: Benchmark this call
         #[pallet::call_index(67)]
-        #[pallet::weight((<T as Config>::WeightInfo::set_children(children.len() as u32), DispatchClass::Normal, Pays::Yes))]
+        #[pallet::weight((
+            <T as Config>::WeightInfo::set_children(children.len() as u32)
+                .saturating_add(crate::Pallet::<T>::set_children_cycle_check_weight()),
+            DispatchClass::Normal,
+            Pays::Yes
+        ))]
         pub fn set_children(
             origin: OriginFor<T>,
             hotkey: T::AccountId,

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -4,6 +4,13 @@ use sp_runtime::PerU16;
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 use subtensor_runtime_common::NetUid;
 
+/// Maximum number of existing child edges followed from a proposed child.
+/// Keeping this deliberately small bounds both execution time and hierarchy depth.
+pub const MAX_CHILDKEY_REACHABILITY_DEPTH: u8 = 4;
+
+/// Maximum number of distinct hotkeys inspected by one cycle check.
+pub const MAX_CHILDKEY_REACHABILITY_NODES: u32 = 32;
+
 pub struct PCRelations<T: Config> {
     /// The distinguished `hotkey` this structure is built around.
     pivot: T::AccountId,
@@ -157,6 +164,67 @@ impl<T: Config> PCRelations<T> {
 }
 
 impl<T: Config> Pallet<T> {
+    /// Weight reserved for the bounded cycle check. Each visited hotkey reads
+    /// `PendingChildKeys` and, when no pending replacement exists, `ChildKeys`.
+    pub fn set_children_cycle_check_weight() -> Weight {
+        T::DbWeight::get().reads(MAX_CHILDKEY_REACHABILITY_NODES.saturating_mul(2).into())
+    }
+
+    /// Reject a proposed `parent -> children` update when a child can already
+    /// reach `parent`. Pending child updates take precedence over active edges,
+    /// matching the graph that will exist once the pending queue is applied.
+    ///
+    /// The walk fails closed when either bound is reached. This prevents an
+    /// attacker from constructing an expensive graph and also places a small
+    /// upper bound on childkey hierarchy depth.
+    fn ensure_bounded_childkey_reachability(
+        parent: &T::AccountId,
+        netuid: NetUid,
+        children: &[(u64, T::AccountId)],
+    ) -> DispatchResult {
+        let mut seen = BTreeSet::<T::AccountId>::new();
+        let mut stack = Vec::<(T::AccountId, u8)>::new();
+
+        for (_, child) in children {
+            ensure!(child != parent, Error::<T>::InvalidChild);
+            if seen.insert(child.clone()) {
+                ensure!(
+                    seen.len() <= MAX_CHILDKEY_REACHABILITY_NODES as usize,
+                    Error::<T>::ChildParentInconsistency
+                );
+                stack.push((child.clone(), 0));
+            }
+        }
+
+        while let Some((hotkey, depth)) = stack.pop() {
+            let descendants = PendingChildKeys::<T>::try_get(netuid, &hotkey)
+                .map(|(pending, _)| pending)
+                .unwrap_or_else(|_| ChildKeys::<T>::get(&hotkey, netuid));
+
+            if descendants.is_empty() {
+                continue;
+            }
+
+            ensure!(
+                depth < MAX_CHILDKEY_REACHABILITY_DEPTH,
+                Error::<T>::ChildParentInconsistency
+            );
+
+            for (_, descendant) in descendants {
+                ensure!(descendant != *parent, Error::<T>::ChildParentInconsistency);
+                if seen.insert(descendant.clone()) {
+                    ensure!(
+                        seen.len() <= MAX_CHILDKEY_REACHABILITY_NODES as usize,
+                        Error::<T>::ChildParentInconsistency
+                    );
+                    stack.push((descendant, depth.saturating_add(1)));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Set childkeys vector making sure there are no empty vectors in the state
     fn set_childkeys(parent: T::AccountId, netuid: NetUid, childkey_vec: Vec<(u64, T::AccountId)>) {
         if childkey_vec.is_empty() {
@@ -525,6 +593,7 @@ impl<T: Config> Pallet<T> {
         //  - Bipartite separation (no A <-> B relations)
         let relations = Self::load_child_parent_relations(&hotkey, netuid)?;
         relations.ensure_pending_consistency(&children)?;
+        Self::ensure_bounded_childkey_reachability(&hotkey, netuid, &children)?;
 
         // Check that the parent key has at least the minimum own stake
         // if children vector is not empty

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -44,6 +44,103 @@ fn test_do_set_child_singular_success() {
     });
 }
 
+#[test]
+fn test_set_children_rejects_three_node_active_cycle() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey_a = U256::from(1);
+        let hotkey_a = U256::from(2);
+        let coldkey_b = U256::from(3);
+        let hotkey_b = U256::from(4);
+        let coldkey_c = U256::from(5);
+        let hotkey_c = U256::from(6);
+
+        add_network(netuid, 13, 0);
+        register_ok_neuron(netuid, hotkey_a, coldkey_a, 0);
+        register_ok_neuron(netuid, hotkey_b, coldkey_b, 0);
+        register_ok_neuron(netuid, hotkey_c, coldkey_c, 0);
+
+        mock_schedule_children(&coldkey_a, &hotkey_a, netuid, &[(u64::MAX, hotkey_b)]);
+        mock_schedule_children(&coldkey_b, &hotkey_b, netuid, &[(u64::MAX, hotkey_c)]);
+
+        assert_noop!(
+            SubtensorModule::do_schedule_children(
+                RuntimeOrigin::signed(coldkey_c),
+                hotkey_c,
+                netuid,
+                vec![(u64::MAX, hotkey_a)],
+            ),
+            Error::<Test>::ChildParentInconsistency
+        );
+    });
+}
+
+#[test]
+fn test_set_children_rejects_three_node_pending_cycle() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey_a = U256::from(11);
+        let hotkey_a = U256::from(12);
+        let coldkey_b = U256::from(13);
+        let hotkey_b = U256::from(14);
+        let coldkey_c = U256::from(15);
+        let hotkey_c = U256::from(16);
+
+        add_network(netuid, 13, 0);
+        SubtokenEnabled::<Test>::insert(netuid, true);
+        register_ok_neuron(netuid, hotkey_a, coldkey_a, 0);
+        register_ok_neuron(netuid, hotkey_b, coldkey_b, 0);
+        register_ok_neuron(netuid, hotkey_c, coldkey_c, 0);
+
+        mock_schedule_children(&coldkey_a, &hotkey_a, netuid, &[(u64::MAX, hotkey_b)]);
+        mock_schedule_children(&coldkey_b, &hotkey_b, netuid, &[(u64::MAX, hotkey_c)]);
+
+        assert_noop!(
+            SubtensorModule::do_schedule_children(
+                RuntimeOrigin::signed(coldkey_c),
+                hotkey_c,
+                netuid,
+                vec![(u64::MAX, hotkey_a)],
+            ),
+            Error::<Test>::ChildParentInconsistency
+        );
+    });
+}
+
+#[test]
+fn test_set_children_rejects_hierarchy_beyond_reachability_depth() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkeys: Vec<U256> = (21..28).map(U256::from).collect();
+        let hotkeys: Vec<U256> = (31..38).map(U256::from).collect();
+
+        add_network(netuid, 13, 0);
+        for (coldkey, hotkey) in coldkeys.iter().zip(hotkeys.iter()) {
+            register_ok_neuron(netuid, *hotkey, *coldkey, 0);
+        }
+
+        // Build from the tail so every accepted update is within the bound.
+        for index in (1..hotkeys.len() - 1).rev() {
+            mock_schedule_children(
+                &coldkeys[index],
+                &hotkeys[index],
+                netuid,
+                &[(u64::MAX, hotkeys[index + 1])],
+            );
+        }
+
+        assert_noop!(
+            SubtensorModule::do_schedule_children(
+                RuntimeOrigin::signed(coldkeys[0]),
+                hotkeys[0],
+                netuid,
+                vec![(u64::MAX, hotkeys[1])],
+            ),
+            Error::<Test>::ChildParentInconsistency
+        );
+    });
+}
+
 // 2: Attempt to set child in non-existent network
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::children::test_do_set_child_singular_network_does_not_exist --exact --show-output --nocapture
 #[test]


### PR DESCRIPTION
## Description

Parent-child graphs can contain cycles longer than two nodes. Validation prevents self-links
```
Direct A → B plus B → A
```

It does not traverse the graph. Therefore `A → B → C → A` is accepted. The same applies when relationships are still pending.

Fix: before scheduling a relationship, perform a bounded reachability check from each proposed child and reject any path returning to the proposed parent.
