### PR TITLE
Fix BlocksSinceLastStep can exceed Tempo + 1 issue

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -391,10 +391,17 @@ impl<T: Config> Pallet<T> {
         let mut epochs_run_this_block: u32 = 0;
 
         for &netuid in subnets.iter() {
-            // Increment blocks since last *successful* step (existing semantics).
-            BlocksSinceLastStep::<T>::mutate(netuid, |total| *total = total.saturating_add(1));
+            // Keep the scheduler age bounded per subnet. `tempo + 1` is enough to
+            // record that a due epoch missed its slot while avoiding an unbounded
+            // public counter when the epoch is repeatedly deferred or its input
+            // state remains inconsistent.
+            let tempo = Self::get_tempo(netuid);
+            let max_blocks_since_last_step = u64::from(tempo).saturating_add(1);
+            BlocksSinceLastStep::<T>::mutate(netuid, |total| {
+                *total = total.saturating_add(1).min(max_blocks_since_last_step)
+            });
 
-            if !Self::should_run_epoch(netuid, current_block) {
+            if !Self::should_run_epoch_with_tempo(netuid, current_block, tempo) {
                 continue;
             }
 
@@ -1143,6 +1150,12 @@ impl<T: Config> Pallet<T> {
     /// * `bool`: True if the epoch should run, false otherwise.
     pub fn should_run_epoch(netuid: NetUid, current_block: u64) -> bool {
         let tempo = Self::get_tempo(netuid);
+        Self::should_run_epoch_with_tempo(netuid, current_block, tempo)
+    }
+
+    /// Same predicate as `should_run_epoch`, using an already-loaded tempo so
+    /// callers that also need the tempo do not charge a duplicate storage read.
+    fn should_run_epoch_with_tempo(netuid: NetUid, current_block: u64, tempo: u16) -> bool {
         if tempo == 0 {
             return false;
         }
@@ -1150,7 +1163,7 @@ impl<T: Config> Pallet<T> {
         if pending > 0 && current_block >= pending {
             return true;
         }
-        if BlocksSinceLastStep::<T>::get(netuid) > MAX_TEMPO as u64 {
+        if BlocksSinceLastStep::<T>::get(netuid) > u64::from(tempo) {
             return true;
         }
         let last = LastEpochBlock::<T>::get(netuid);
@@ -1161,7 +1174,7 @@ impl<T: Config> Pallet<T> {
     /// Returns the number of blocks remaining before the next automatic epoch under the
     /// stateful scheduler (period `tempo`, anchored on `LastEpochBlock`). Does NOT account for:
     ///     - `PendingEpochAt` (owner-triggered manual fire — could happen sooner),
-    ///     - `BlocksSinceLastStep > MAX_TEMPO` safety-net,
+    ///     - `BlocksSinceLastStep > tempo` safety-net,
     ///     - per-block-cap defer (could push the actual fire one or more blocks later)
     /// Used by the admin-freeze-window predicate and external tooling. Returns `u64::MAX` when
     /// `tempo == 0` (legacy defensive short-circuit).
@@ -1178,7 +1191,7 @@ impl<T: Config> Pallet<T> {
     /// Returns the absolute block number at which the next epoch is expected to fire for the
     /// given subnet, considering both the automatic schedule (`LastEpochBlock + tempo`) and
     /// any owner-triggered `PendingEpochAt`. Returns `None` if `tempo == 0` (subnet does not run).
-    /// Does NOT account for the per-block cap deferral or the `BlocksSinceLastStep > MAX_TEMPO`
+    /// Does NOT account for the per-block cap deferral or the `BlocksSinceLastStep > tempo`
     /// safety-net (which can fire earlier under extreme drift).
     pub fn get_next_epoch_start_block(netuid: NetUid) -> Option<u64> {
         let tempo = Self::get_tempo(netuid);

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2089,7 +2089,7 @@ pub mod pallet {
     pub type MinerBurned<T> =
         StorageMap<_, Identity, NetUid, U96F32, ValueQuery, DefaultMinerBurned<T>>;
 
-    /// MAP ( netuid ) --> blocks_since_last_step
+    /// MAP ( netuid ) --> blocks_since_last_step, capped at the subnet's `tempo + 1`
     #[pallet::storage]
     pub type BlocksSinceLastStep<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultBlocksSinceLastStep<T>>;

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -3850,6 +3850,66 @@ fn test_coinbase_drain_pending_increments_blockssincelaststep() {
 }
 
 #[test]
+fn test_coinbase_drain_pending_caps_blockssincelaststep_when_epoch_is_deferred() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
+        let tempo = 1;
+        Tempo::<Test>::insert(netuid, tempo);
+        PendingEpochAt::<Test>::insert(netuid, 1);
+        SubtensorModule::set_max_epochs_per_block(0);
+
+        for block in 1..=10 {
+            SubtensorModule::drain_pending(&[netuid], block);
+        }
+
+        assert_eq!(
+            BlocksSinceLastStep::<Test>::get(netuid),
+            u64::from(tempo) + 1
+        );
+        assert!(SubtensorModule::should_run_epoch(netuid, 11));
+    });
+}
+
+#[test]
+fn test_coinbase_drain_pending_caps_blockssincelaststep_for_inconsistent_epoch() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
+        let tempo = 1;
+        Tempo::<Test>::insert(netuid, tempo);
+        PendingEpochAt::<Test>::insert(netuid, 1);
+
+        let duplicate_hotkey = U256::from(99);
+        Keys::<Test>::insert(netuid, 0, duplicate_hotkey);
+        Keys::<Test>::insert(netuid, 1, duplicate_hotkey);
+        assert!(!SubtensorModule::is_epoch_input_state_consistent(netuid));
+
+        for block in 1..=10 {
+            SubtensorModule::drain_pending(&[netuid], block);
+        }
+
+        assert_eq!(
+            BlocksSinceLastStep::<Test>::get(netuid),
+            u64::from(tempo) + 1
+        );
+        assert!(SubtensorModule::should_run_epoch(netuid, 11));
+    });
+}
+
+#[test]
+fn test_should_run_epoch_uses_subnet_tempo_for_step_age_safety_net() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
+        let tempo = 1;
+        Tempo::<Test>::insert(netuid, tempo);
+        LastEpochBlock::<Test>::insert(netuid, 100);
+        PendingEpochAt::<Test>::insert(netuid, 0);
+        BlocksSinceLastStep::<Test>::insert(netuid, u64::from(tempo) + 1);
+
+        assert!(SubtensorModule::should_run_epoch(netuid, 2));
+    });
+}
+
+#[test]
 fn test_coinbase_drain_pending_resets_blockssincelaststep() {
     new_test_ext(1).execute_with(|| {
         let zero = U96F32::saturating_from_num(0);


### PR DESCRIPTION
## Description

The counter increments every block but only resets after a successful epoch:
Repeated per-block-cap deferrals can postpone a subnet for multiple blocks.
An inconsistent epoch input state prevents reset indefinitely.
The safety check compares against global MAX_TEMPO, not the subnet’s configured tempo.
A tempo-one subnet can therefore exceed two blocks since its last successful step.

Fix: either cap the observable counter at tempo + 1, or redefine it as an uncapped successful-step age and expose a separate bounded scheduler counter.

