### PR TITLE
Make srtool builder provisioning fast and bounded

### DIFF
--- a/scripts/srtool/Dockerfile
+++ b/scripts/srtool/Dockerfile
@@ -1,0 +1,84 @@
+# Pinned copy of paritytech/srtool's Dockerfile at the commit in
+# build-srtool-image.sh. The local copy lets CI select a bounded, nearby Ubuntu
+# mirror without changing the deterministic srtool source context.
+FROM docker.io/library/ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+
+LABEL maintainer="chevdor@gmail.com"
+LABEL description="This image contains tools for Substrate blockchains runtimes."
+
+ARG RUSTC_VERSION="1.84.0"
+ENV RUSTC_VERSION=$RUSTC_VERSION
+ENV DOCKER_IMAGE="paritytech/srtool"
+ENV PROFILE=release
+ENV PACKAGE=polkadot-runtime
+ENV BUILDER=builder
+ARG UID=1001
+ARG GID=1001
+
+ENV SRTOOL_TEMPLATES=/srtool/templates
+
+RUN groupadd -g $GID $BUILDER && \
+    useradd --no-log-init -m -u $UID -s /bin/bash -d /home/$BUILDER -r -g $BUILDER $BUILDER
+RUN mkdir -p ${SRTOOL_TEMPLATES} && \
+    mkdir /build && chown -R $BUILDER /build && \
+    mkdir /out && chown -R $BUILDER /out
+
+WORKDIR /tmp
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Tooling
+ARG SUBWASM_VERSION=0.21.0
+ARG TERA_CLI_VERSION=0.2.4
+ARG TOML_CLI_VERSION=0.2.4
+ARG UBUNTU_MIRROR="http://ubuntu.mirrors.ovh.net/ubuntu"
+
+COPY ./templates ${SRTOOL_TEMPLATES}/
+RUN sed -i "s|http://archive.ubuntu.com/ubuntu|${UBUNTU_MIRROR}|g" /etc/apt/sources.list && \
+    printf '%s\n' \
+        'Acquire::Retries "5";' \
+        'Acquire::http::Timeout "30";' \
+        'Acquire::https::Timeout "30";' \
+        'APT::Update::Error-Mode "any";' \
+        > /etc/apt/apt.conf.d/80-srtool-network && \
+    timeout --foreground --kill-after=15s 300s sh -c 'apt-get update && \
+        apt-get upgrade -y && \
+        apt-get install --no-install-recommends -y \
+            cmake pkg-config libssl-dev make protobuf-compiler \
+            git clang bsdmainutils ca-certificates curl' && \
+    curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 --output /usr/bin/jq && chmod a+x /usr/bin/jq && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && apt-get clean
+
+RUN curl -L https://github.com/chevdor/subwasm/releases/download/v${SUBWASM_VERSION}/subwasm_linux_amd64_v${SUBWASM_VERSION}.deb --output subwasm.deb && dpkg -i subwasm.deb && subwasm --version && \
+    curl -L https://github.com/chevdor/tera-cli/releases/download/v${TERA_CLI_VERSION}/tera-cli_linux_amd64.deb --output tera_cli.deb && dpkg -i tera_cli.deb && tera --version && \
+    curl -L https://github.com/chevdor/toml-cli/releases/download/v${TOML_CLI_VERSION}/toml_linux_amd64_v${TOML_CLI_VERSION}.deb --output toml.deb && dpkg -i toml.deb && toml --version && \
+    rm -rf /tmp/*
+
+COPY ./scripts/* /srtool/
+COPY VERSION /srtool/
+COPY RUSTC_VERSION /srtool/
+RUN printf '%s\n' "$RUSTC_VERSION" > /srtool/RUSTC_VERSION
+
+USER $BUILDER
+ENV RUSTUP_HOME="/home/${BUILDER}/rustup"
+ENV CARGO_HOME="/home/${BUILDER}/cargo"
+ENV PATH="/srtool:$PATH"
+
+RUN echo $SHELL && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none && \
+    . $CARGO_HOME/env && \
+    rustup toolchain add --profile minimal ${RUSTC_VERSION} && \
+    rustup target add wasm32-unknown-unknown --toolchain $RUSTC_VERSION && \
+    rustup target add wasm32v1-none --toolchain $RUSTC_VERSION && \
+    rustup component add rust-src --toolchain $RUSTC_VERSION && \
+    rustup default $RUSTC_VERSION && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
+    rustup show && rustc -V
+
+RUN git config --global --add safe.directory /build && \
+    /srtool/version && \
+    echo 'PATH=".:$HOME/cargo/bin:$PATH"' >> $HOME/.bashrc
+
+VOLUME [ "/build", "$CARGO_HOME", "/out" ]
+WORKDIR /srtool
+
+CMD ["/srtool/build"]

--- a/scripts/srtool/build-srtool-image.sh
+++ b/scripts/srtool/build-srtool-image.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Pinned to the commit behind srtool v0.18.3 so the builder cannot change
 # under a re-used tag. Optional first argument overrides the image tag.
 IMAGE_TAG="${1:-srtool}"
 SRTOOL_COMMIT="0a446889c5e60abe92a41e426377276f5c7295e6"
+SRTOOL_CONTEXT="https://github.com/paritytech/srtool.git#${SRTOOL_COMMIT}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
 
-docker build --build-arg RUSTC_VERSION="1.89.0" -t "$IMAGE_TAG" "https://github.com/paritytech/srtool.git#${SRTOOL_COMMIT}"
+build_image() {
+  local ubuntu_mirror="$1"
+
+  docker build \
+    --platform linux/amd64 \
+    --build-arg RUSTC_VERSION="1.89.0" \
+    --build-arg UBUNTU_MIRROR="${ubuntu_mirror}" \
+    --file - \
+    --tag "${IMAGE_TAG}" \
+    "${SRTOOL_CONTEXT}" < "${DOCKERFILE}"
+}
+
+if ! build_image "http://ubuntu.mirrors.ovh.net/ubuntu"; then
+  echo >&2 "OVH Ubuntu mirror build failed; retrying with Ubuntu's geographic mirror service."
+  build_image "mirror+http://mirrors.ubuntu.com/mirrors.txt"
+fi


### PR DESCRIPTION
## Summary
- build the pinned srtool source with a reviewable local Dockerfile
- use the OVH Ubuntu archive first, with Ubuntu geographic mirror fallback
- bound APT provisioning with retries, network timeouts, and a five-minute hard limit
- pin the tested Ubuntu base digest and `linux/amd64` platform
- install only Rust 1.89.0 and report the correct toolchain metadata

The deterministic runtime build command, srtool version, features, and release workflow behavior are unchanged.

## Validation
- `bash -n scripts/srtool/build-srtool-image.sh`
- Docker BuildKit structural check: no warnings
- complete local `linux/amd64` image build passed
- APT image layer completed in 46.7 seconds during the full build
- image contract confirmed srtool 0.18.3, Rust 1.89.0, both required WASM targets, and all builder tools