### PR TITLE
Support Ledger-friendly signatures in pallet-limit-orders

### DIFF
--- a/pallets/limit-orders/README.md
+++ b/pallets/limit-orders/README.md
@@ -85,9 +85,11 @@ encoding (`OrderId`) is persisted.
 ### `SignedOrder<AccountId>`
 
 Envelope submitted by the relayer: the `VersionedOrder` payload plus the user's
-sr25519 signature over the SCALE encoding of the `VersionedOrder` (including the
-version discriminant). Only sr25519 signatures are accepted. Signature
-verification uses the inner `order.signer` as the expected public key.
+sr25519 or ed25519 signature. The signature may cover either the SCALE encoding
+of the `VersionedOrder` (including the version discriminant), or `<Bytes>` plus
+its blake2-256 hash plus `</Bytes>` for Ledger compatibility. Signature
+verification uses the inner `order.signer` as the expected public key; ECDSA is
+not accepted.
 
 ### `OrderStatus`
 

--- a/pallets/limit-orders/src/benchmarking.rs
+++ b/pallets/limit-orders/src/benchmarking.rs
@@ -21,12 +21,10 @@ fn sign_order<T: crate::Config>(
     public: sp_core::sr25519::Public,
     order: &crate::VersionedOrder<T::AccountId>,
 ) -> crate::SignedOrder<T::AccountId> {
-    let sig = sp_io::crypto::sr25519_sign(
-        sp_core::crypto::key_types::ACCOUNT,
-        &public,
-        &order.encode(),
-    )
-    .unwrap();
+    let order_hash = sp_io::hashing::blake2_256(&order.encode());
+    let payload = [b"<Bytes>".as_slice(), &order_hash, b"</Bytes>".as_slice()].concat();
+    let sig = sp_io::crypto::sr25519_sign(sp_core::crypto::key_types::ACCOUNT, &public, &payload)
+        .unwrap();
     crate::SignedOrder {
         order: order.clone(),
         signature: MultiSignature::Sr25519(sig),

--- a/pallets/limit-orders/src/lib.rs
+++ b/pallets/limit-orders/src/lib.rs
@@ -131,18 +131,18 @@ impl<AccountId: Encode + Decode + TypeInfo + MaxEncodedLen + Clone> VersionedOrd
 }
 
 /// The envelope the admin submits on-chain: the versioned order payload plus
-/// the user's signature over the SCALE-encoded `VersionedOrder`.
+/// the user's signature over the order.
 ///
 /// Signature verification is performed against `order.inner().signer` (the AccountId)
-/// directly. Only sr25519 signatures are accepted; ed25519 and ecdsa variants
-/// of `MultiSignature` are rejected at validation time.
+/// directly. Sr25519 and ed25519 signatures over either the SCALE-encoded order or its
+/// `<Bytes>`-wrapped blake2-256 hash are accepted; ecdsa is rejected at validation time.
 #[freeze_struct("9dd5a8ac812dc504")]
 #[derive(
     Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, Clone, PartialEq, Eq, Debug,
 )]
 pub struct SignedOrder<AccountId: Encode + Decode + TypeInfo + MaxEncodedLen + Clone> {
     pub order: VersionedOrder<AccountId>,
-    /// Sr25519 signature over `SCALE_ENCODE(VersionedOrder)`.
+    /// Sr25519 or ed25519 signature over the raw order or its wrapped hash.
     pub signature: MultiSignature,
     /// Whether we want a partial fill for this order
     pub partial_fill: Option<u64>,
@@ -614,10 +614,22 @@ pub mod pallet {
                 Error::<T>::ChainIdMismatch
             );
             ensure!(
-                matches!(signed_order.signature, MultiSignature::Sr25519(_))
-                    && signed_order
-                        .signature
-                        .verify(signed_order.order.encode().as_slice(), &order.signer),
+                matches!(
+                    signed_order.signature,
+                    MultiSignature::Sr25519(_) | MultiSignature::Ed25519(_)
+                ) && (signed_order
+                    .signature
+                    .verify(signed_order.order.encode().as_slice(), &order.signer)
+                    || signed_order.signature.verify(
+                        [
+                            b"<Bytes>".as_slice(),
+                            order_id.as_bytes(),
+                            b"</Bytes>".as_slice(),
+                        ]
+                        .concat()
+                        .as_slice(),
+                        &order.signer,
+                    )),
                 Error::<T>::InvalidSignature
             );
             let order_status = Orders::<T>::get(order_id);

--- a/pallets/limit-orders/src/tests/auxiliary.rs
+++ b/pallets/limit-orders/src/tests/auxiliary.rs
@@ -1474,14 +1474,42 @@ fn is_order_valid_invalid_signature_returns_error() {
 }
 
 #[test]
-fn is_order_valid_non_sr25519_signature_returns_error() {
+fn is_order_valid_accepts_wrapped_ed25519_signature() {
+    new_test_ext().execute_with(|| {
+        MockTime::set(1_000_000);
+        MockSwap::set_price(1.0);
+        let (signed, _) = make_valid_signed_order();
+        let ed_pair = sp_core::ed25519::Pair::from_legacy_string("//Alice", None);
+        let order = crate::VersionedOrder::V1(crate::Order {
+            signer: AccountId::from(ed_pair.public()),
+            ..signed.order.inner().clone()
+        });
+        let id = H256(sp_io::hashing::blake2_256(&order.encode()));
+        let payload = [b"<Bytes>".as_slice(), id.as_bytes(), b"</Bytes>".as_slice()].concat();
+        let signed = crate::SignedOrder {
+            order,
+            signature: MultiSignature::Ed25519(ed_pair.sign(&payload)),
+            partial_fill: None,
+        };
+        let price = MockSwap::current_alpha_price(netuid());
+        assert_ok!(LimitOrders::<Test>::is_order_valid(
+            &signed,
+            id,
+            1_000_000,
+            price,
+            &bob()
+        ));
+    });
+}
+
+#[test]
+fn is_order_valid_ecdsa_signature_returns_error() {
     new_test_ext().execute_with(|| {
         MockTime::set(1_000_000);
         MockSwap::set_price(1.0);
         let (mut signed, id) = make_valid_signed_order();
-        let ed_pair = sp_core::ed25519::Pair::from_legacy_string("//Alice", None);
-        let ed_sig = ed_pair.sign(&signed.order.encode());
-        signed.signature = MultiSignature::Ed25519(ed_sig);
+        let pair = sp_core::ecdsa::Pair::from_legacy_string("//Alice", None);
+        signed.signature = MultiSignature::Ecdsa(pair.sign(&signed.order.encode()));
         let price = MockSwap::current_alpha_price(netuid());
         assert_noop!(
             LimitOrders::<Test>::is_order_valid(&signed, id, 1_000_000, price, &bob()),

--- a/pallets/limit-orders/src/tests/auxiliary.rs
+++ b/pallets/limit-orders/src/tests/auxiliary.rs
@@ -1409,7 +1409,10 @@ fn collect_fees_no_transfer_when_zero_fees() {
 use crate::Error;
 use codec::Encode;
 use sp_core::Pair;
-use sp_runtime::MultiSignature;
+use sp_runtime::{
+    MultiSignature, MultiSigner,
+    traits::{IdentifyAccount, Verify},
+};
 use subtensor_swap_interface::OrderSwapInterface;
 
 fn make_valid_signed_order() -> (crate::SignedOrder<AccountId>, sp_core::H256) {
@@ -1555,9 +1558,21 @@ fn is_order_valid_ecdsa_signature_returns_error() {
     new_test_ext().execute_with(|| {
         MockTime::set(1_000_000);
         MockSwap::set_price(1.0);
-        let (mut signed, id) = make_valid_signed_order();
+        let (signed, _) = make_valid_signed_order();
         let pair = sp_core::ecdsa::Pair::from_legacy_string("//Alice", None);
-        signed.signature = MultiSignature::Ecdsa(pair.sign(&signed.order.encode()));
+        let signer = MultiSigner::from(pair.public()).into_account();
+        let order = crate::VersionedOrder::V1(crate::Order {
+            signer,
+            ..signed.order.inner().clone()
+        });
+        let id = H256(sp_io::hashing::blake2_256(&order.encode()));
+        let signature = MultiSignature::Ecdsa(pair.sign(&order.encode()));
+        assert!(signature.verify(order.encode().as_slice(), &order.inner().signer));
+        let signed = crate::SignedOrder {
+            order,
+            signature,
+            partial_fill: None,
+        };
         let price = MockSwap::current_alpha_price(netuid());
         assert_noop!(
             LimitOrders::<Test>::is_order_valid(&signed, id, 1_000_000, price, &bob()),

--- a/pallets/limit-orders/src/tests/auxiliary.rs
+++ b/pallets/limit-orders/src/tests/auxiliary.rs
@@ -1474,6 +1474,54 @@ fn is_order_valid_invalid_signature_returns_error() {
 }
 
 #[test]
+fn is_order_valid_accepts_raw_ed25519_signature() {
+    new_test_ext().execute_with(|| {
+        MockTime::set(1_000_000);
+        MockSwap::set_price(1.0);
+        let (signed, _) = make_valid_signed_order();
+        let ed_pair = sp_core::ed25519::Pair::from_legacy_string("//Alice", None);
+        let order = crate::VersionedOrder::V1(crate::Order {
+            signer: AccountId::from(ed_pair.public()),
+            ..signed.order.inner().clone()
+        });
+        let id = H256(sp_io::hashing::blake2_256(&order.encode()));
+        let signature = ed_pair.sign(&order.encode());
+        let signed = crate::SignedOrder {
+            order,
+            signature: MultiSignature::Ed25519(signature),
+            partial_fill: None,
+        };
+        let price = MockSwap::current_alpha_price(netuid());
+        assert_ok!(LimitOrders::<Test>::is_order_valid(
+            &signed,
+            id,
+            1_000_000,
+            price,
+            &bob()
+        ));
+    });
+}
+
+#[test]
+fn is_order_valid_accepts_wrapped_sr25519_signature() {
+    new_test_ext().execute_with(|| {
+        MockTime::set(1_000_000);
+        MockSwap::set_price(1.0);
+        let (mut signed, id) = make_valid_signed_order();
+        let payload = [b"<Bytes>".as_slice(), id.as_bytes(), b"</Bytes>".as_slice()].concat();
+        signed.signature = MultiSignature::Sr25519(AccountKeyring::Alice.pair().sign(&payload));
+        let price = MockSwap::current_alpha_price(netuid());
+        assert_ok!(LimitOrders::<Test>::is_order_valid(
+            &signed,
+            id,
+            1_000_000,
+            price,
+            &bob()
+        ));
+    });
+}
+
+#[test]
 fn is_order_valid_accepts_wrapped_ed25519_signature() {
     new_test_ext().execute_with(|| {
         MockTime::set(1_000_000);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 437,
+    spec_version: 438,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/tests/limit_orders.rs
+++ b/runtime/tests/limit_orders.rs
@@ -20,8 +20,8 @@ use pallet_limit_orders::{
 use pallet_subtensor::{SubnetAlphaIn, SubnetMechanism, SubnetTAO};
 use sp_core::{Get, H256, Pair};
 use sp_keyring::Sr25519Keyring;
-use sp_runtime::traits::AccountIdConversion;
-use sp_runtime::{MultiSignature, Perbill};
+use sp_runtime::traits::{AccountIdConversion, IdentifyAccount, Verify};
+use sp_runtime::{MultiSignature, MultiSigner, Perbill};
 use subtensor_runtime_common::{AccountId, AlphaBalance, NetUid, TaoBalance, Token};
 
 fn new_test_ext() -> sp_io::TestExternalities {
@@ -300,12 +300,13 @@ fn cancel_order_works() {
 #[test]
 fn execute_orders_ecdsa_signature_rejected() {
     new_test_ext().execute_with(|| {
-        let alice_id = Sr25519Keyring::Alice.to_account_id();
+        let pair = sp_core::ecdsa::Pair::from_legacy_string("//Alice", None);
+        let ecdsa_id = MultiSigner::from(pair.public()).into_account();
         let bob_id = Sr25519Keyring::Bob.to_account_id();
         let fee_recipient = Sr25519Keyring::Charlie.to_account_id();
 
         let order = VersionedOrder::V1(Order {
-            signer: alice_id.clone(),
+            signer: ecdsa_id.clone(),
             hotkey: bob_id,
             netuid: NetUid::from(1u16),
             order_type: OrderType::LimitBuy,
@@ -322,19 +323,19 @@ fn execute_orders_ecdsa_signature_rejected() {
         });
         let id = order_id(&order);
 
-        // Sign with ecdsa — valid signature, unsupported scheme.
-        let pair = sp_core::ecdsa::Pair::from_legacy_string("//Alice", None);
-        let signature = pair.sign(&order.encode());
+        // The signature matches the order signer; only the scheme is unsupported.
+        let signature = MultiSignature::Ecdsa(pair.sign(&order.encode()));
+        assert!(signature.verify(order.encode().as_slice(), &ecdsa_id));
         let signed = SignedOrder {
             order,
-            signature: MultiSignature::Ecdsa(signature),
+            signature,
             partial_fill: None,
         };
 
         let orders = make_order_batch(vec![signed]);
 
         assert_ok!(LimitOrders::execute_orders(
-            RuntimeOrigin::signed(alice_id),
+            RuntimeOrigin::signed(ecdsa_id),
             orders,
             false,
         ));

--- a/runtime/tests/limit_orders.rs
+++ b/runtime/tests/limit_orders.rs
@@ -294,11 +294,11 @@ fn cancel_order_works() {
     });
 }
 
-/// An order signed with an Ed25519 key is rejected at validation time even
+/// An order signed with an ECDSA key is rejected at validation time even
 /// though the signature itself is cryptographically valid. The order must not
 /// appear in the Orders storage map after the batch runs.
 #[test]
-fn execute_orders_ed25519_signature_rejected() {
+fn execute_orders_ecdsa_signature_rejected() {
     new_test_ext().execute_with(|| {
         let alice_id = Sr25519Keyring::Alice.to_account_id();
         let bob_id = Sr25519Keyring::Bob.to_account_id();
@@ -322,12 +322,12 @@ fn execute_orders_ed25519_signature_rejected() {
         });
         let id = order_id(&order);
 
-        // Sign with ed25519 — valid signature, wrong scheme.
-        let ed_pair = sp_core::ed25519::Pair::from_legacy_string("//Alice", None);
-        let ed_sig = ed_pair.sign(&order.encode());
+        // Sign with ecdsa — valid signature, unsupported scheme.
+        let pair = sp_core::ecdsa::Pair::from_legacy_string("//Alice", None);
+        let signature = pair.sign(&order.encode());
         let signed = SignedOrder {
             order,
-            signature: MultiSignature::Ed25519(ed_sig),
+            signature: MultiSignature::Ecdsa(signature),
             partial_fill: None,
         };
 

--- a/runtime/tests/limit_orders.rs
+++ b/runtime/tests/limit_orders.rs
@@ -450,6 +450,45 @@ fn limit_buy_order_executes_and_stakes_alpha() {
     });
 }
 
+/// A Ledger-style, wrapped Sr25519 signature is accepted by the runtime and
+/// executes the signed order.
+#[test]
+fn execute_orders_wrapped_sr25519_signature_executes() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let alice = Sr25519Keyring::Alice;
+        let alice_id = alice.to_account_id();
+        let bob_id = Sr25519Keyring::Bob.to_account_id();
+        let relayer = Sr25519Keyring::Charlie.to_account_id();
+
+        setup_subnet(netuid);
+        fund_account(&alice_id);
+        let _ = SubtensorModule::create_account_if_non_existent(&alice_id, &bob_id);
+
+        let mut signed = make_signed_order(
+            alice,
+            bob_id,
+            netuid,
+            OrderType::LimitBuy,
+            min_default_stake().into(),
+            u64::MAX,
+            u64::MAX,
+            Perbill::zero(),
+            relayer.clone(),
+        );
+        let id = order_id(&signed.order);
+        let payload = [b"<Bytes>".as_slice(), id.as_bytes(), b"</Bytes>".as_slice()].concat();
+        signed.signature = MultiSignature::Sr25519(alice.pair().sign(&payload));
+
+        assert_ok!(LimitOrders::execute_orders(
+            RuntimeOrigin::signed(relayer),
+            make_order_batch(vec![signed]),
+            false,
+        ));
+        assert_eq!(Orders::<Runtime>::get(id), Some(OrderStatus::Fulfilled));
+    });
+}
+
 /// A TakeProfit order whose price condition is satisfied executes against the pool,
 /// marks the order as Fulfilled, and burns the seller's staked alpha position.
 #[test]

--- a/ts-tests/suites/dev/subtensor/limit-orders/test-execute-orders-ed25519-wrapped.ts
+++ b/ts-tests/suites/dev/subtensor/limit-orders/test-execute-orders-ed25519-wrapped.ts
@@ -1,0 +1,116 @@
+import { beforeAll, describeSuite, expect } from "@moonwall/cli";
+import type { KeyringPair } from "@moonwall/util";
+import type { ApiPromise } from "@polkadot/api";
+import { generateKeyringPair, tao } from "../../../../utils";
+import {
+    devAssociateHotKey,
+    devEnableSubtoken,
+    devExecuteOrders,
+    devForceSetBalance,
+    devGetAlphaStake,
+    devRegisterSubnet,
+    devSudoSetLockReductionInterval,
+} from "../../../../utils/dev-helpers.js";
+import {
+    FAR_FUTURE,
+    buildWrappedSignedOrder,
+    fetchChainId,
+    filterEvents,
+    getOrderStatus,
+    orderId,
+    registerLimitOrderTypes,
+} from "../../../../utils/limit-orders.js";
+
+// One subnet per file — this test submits a real buy order signed by an
+// ed25519 key over the `<Bytes>`-wrapped order hash (the Ledger / signRaw
+// form).  It exercises the runtime's alternative `is_order_valid` path:
+//   signature.verify(b"<Bytes>" ++ blake2_256(SCALE(VersionedOrder)) ++ b"</Bytes>", signer)
+// with an Ed25519 signature.
+
+describeSuite({
+    id: "DEV_SUB_LIMIT_ORDERS_ED25519_WRAPPED",
+    title: "execute_orders — ed25519 + <Bytes>-wrapped LimitBuy execution",
+    foundationMethods: "dev",
+    testCases: ({ it, context }) => {
+        let polkadotJs: ApiPromise;
+        let alice: KeyringPair;
+        let aliceHotKey: KeyringPair;
+        let edSigner: KeyringPair;
+        let edHotKey: KeyringPair;
+        let netuid: number;
+        let chainId: bigint;
+
+        beforeAll(async () => {
+            polkadotJs = context.polkadotJs();
+
+            alice = context.keyring.alice;
+            aliceHotKey = generateKeyringPair("sr25519");
+
+            // ed25519 coldkey/signer that signs the wrapped order hash, with an
+            // sr25519 hotkey associated to it.
+            edSigner = generateKeyringPair("ed25519");
+            edHotKey = generateKeyringPair("sr25519");
+
+            registerLimitOrderTypes(polkadotJs);
+            chainId = await fetchChainId(polkadotJs);
+
+            await devForceSetBalance(polkadotJs, context, alice.address, tao(10_000));
+            await devForceSetBalance(polkadotJs, context, edSigner.address, tao(10_000));
+
+            await devSudoSetLockReductionInterval(polkadotJs, context, alice, 1);
+
+            netuid = await devRegisterSubnet(polkadotJs, context, alice, aliceHotKey);
+
+            // Enable subtoken
+            await devEnableSubtoken(polkadotJs, context, alice, netuid);
+            // Associate hotkeys — the ed25519 signer associates its own hotkey.
+            await devAssociateHotKey(polkadotJs, context, alice, aliceHotKey.address);
+            await devAssociateHotKey(polkadotJs, context, edSigner, edHotKey.address);
+        });
+
+        it({
+            id: "T01",
+            title: "LimitBuy executes with an ed25519 <Bytes>-wrapped signature",
+            test: async () => {
+                const stakeBefore = await devGetAlphaStake(polkadotJs, edHotKey.address, edSigner.address, netuid);
+                const taoBalanceBefore = (
+                    (await polkadotJs.query.system.account(edSigner.address)) as any
+                ).data.free.toBigInt();
+
+                const signed = buildWrappedSignedOrder(polkadotJs, {
+                    signer: edSigner,
+                    hotkey: edHotKey.address,
+                    netuid,
+                    orderType: "LimitBuy",
+                    amount: tao(100),
+                    limitPrice: FAR_FUTURE,
+                    expiry: FAR_FUTURE,
+                    feeRate: 0,
+                    feeRecipient: edSigner.address,
+                    chainId,
+                });
+
+                // Alice relays/submits the ed25519-signed order.
+                await devExecuteOrders(polkadotJs, context, alice, [signed]);
+
+                const events = await polkadotJs.query.system.events();
+                const executed = filterEvents(events, "OrderExecuted");
+                expect(executed.length).toBe(1);
+
+                // OrderId should be stored as Fulfilled
+                const id = orderId(polkadotJs, signed.order);
+                expect(await getOrderStatus(polkadotJs, id)).toBe("Fulfilled");
+
+                // Alpha stake for the ed25519 signer's hotkey should have increased
+                const stakeAfter = await devGetAlphaStake(polkadotJs, edHotKey.address, edSigner.address, netuid);
+                expect(stakeAfter).toBeGreaterThan(stakeBefore);
+
+                // ed25519 signer's TAO balance should have decreased
+                const taoBalanceAfter = (
+                    (await polkadotJs.query.system.account(edSigner.address)) as any
+                ).data.free.toBigInt();
+                expect(taoBalanceAfter).toBeLessThan(taoBalanceBefore);
+            },
+        });
+    },
+});

--- a/ts-tests/utils/limit-orders.ts
+++ b/ts-tests/utils/limit-orders.ts
@@ -2,8 +2,8 @@ import type { KeyringPair } from "@moonwall/util";
 import type { TypedApi } from "polkadot-api";
 import type { subtensor } from "@polkadot-api/descriptors";
 import { Keyring } from "@polkadot/keyring";
-import { u8aToHex } from "@polkadot/util";
-import { blake2AsHex } from "@polkadot/util-crypto";
+import { u8aToHex, u8aWrapBytes } from "@polkadot/util";
+import { blake2AsHex, blake2AsU8a } from "@polkadot/util-crypto";
 import { waitForTransactionWithRetry } from "./transactions.js";
 import { MultiAddress } from "@polkadot-api/descriptors";
 
@@ -62,11 +62,11 @@ export const EXPIRED = BigInt(1); // 1ms — always in the past
 // ── Order building & signing ──────────────────────────────────────────────────
 
 /**
- * Build a SignedOrder ready for submission to execute_orders /
- * execute_batched_orders.  The Order struct is SCALE-encoded via the
- * polkadot.js registry and then signed with the signer's sr25519 key.
+ * Build the `VersionedOrder` (V1) struct from the supplied params.  Shared by
+ * `buildSignedOrder` (raw signing) and `buildWrappedSignedOrder` (Ledger /
+ * signRaw `<Bytes>`-wrapped signing) so the field mapping stays identical.
  */
-export function buildSignedOrder(api: any, params: OrderParams): SignedOrder {
+function buildVersionedOrder(params: OrderParams): VersionedOrder {
     const inner: Order = {
         signer: params.signer.address,
         hotkey: params.hotkey,
@@ -83,7 +83,16 @@ export function buildSignedOrder(api: any, params: OrderParams): SignedOrder {
         partial_fills_enabled: params.partialFillsEnabled ?? false,
     };
 
-    const versionedOrder: VersionedOrder = { V1: inner };
+    return { V1: inner };
+}
+
+/**
+ * Build a SignedOrder ready for submission to execute_orders /
+ * execute_batched_orders.  The Order struct is SCALE-encoded via the
+ * polkadot.js registry and then signed with the signer's sr25519 key.
+ */
+export function buildSignedOrder(api: any, params: OrderParams): SignedOrder {
+    const versionedOrder = buildVersionedOrder(params);
 
     // SCALE-encode the VersionedOrder so the signature covers the version tag.
     const encoded = api.registry.createType("LimitVersionedOrder", versionedOrder);
@@ -92,6 +101,46 @@ export function buildSignedOrder(api: any, params: OrderParams): SignedOrder {
     return {
         order: versionedOrder,
         signature: { Sr25519: u8aToHex(sig) as `0x${string}` },
+        partial_fill: null,
+    };
+}
+
+/**
+ * Build a SignedOrder whose signature is over the `<Bytes>`-wrapped order hash
+ * (the Ledger / `signRaw` form).  This exercises the runtime's alternative
+ * verification path:
+ *
+ *     signature.verify(b"<Bytes>" ++ blake2_256(SCALE(VersionedOrder)) ++ b"</Bytes>", signer)
+ *
+ * The signed payload is the raw 32-byte blake2-256 hash of the SCALE-encoded
+ * VersionedOrder, wrapped by `u8aWrapBytes` (which prepends `<Bytes>` and
+ * appends `</Bytes>`).  This is byte-for-byte what the runtime reconstructs
+ * from `order_id.as_bytes()`, so the hash must be wrapped raw — never
+ * hex-encoded before wrapping.
+ *
+ * The signature scheme tag (`Sr25519` vs `Ed25519`) follows the signer's
+ * keypair type, so the same helper works for both schemes.
+ */
+export function buildWrappedSignedOrder(api: any, params: OrderParams): SignedOrder {
+    const versionedOrder = buildVersionedOrder(params);
+
+    // SCALE-encode the VersionedOrder, then hash it (this is the OrderId).
+    const encoded = api.registry.createType("LimitVersionedOrder", versionedOrder);
+    const hash = blake2AsU8a(encoded.toU8a(), 256);
+
+    // Wrap the raw 32-byte hash in the signRaw envelope: <Bytes>..hash..</Bytes>.
+    const wrapped = u8aWrapBytes(hash);
+    const sig = params.signer.sign(wrapped);
+
+    // Tag the signature variant from the keypair type.
+    const signature =
+        params.signer.type === "ed25519"
+            ? { Ed25519: u8aToHex(sig) as `0x${string}` }
+            : { Sr25519: u8aToHex(sig) as `0x${string}` };
+
+    return {
+        order: versionedOrder,
+        signature,
         partial_fill: null,
     };
 }


### PR DESCRIPTION
## Motivation

Limit orders currently accept only sr25519 signatures over the SCALE-encoded `VersionedOrder`. This change aims to broaden signature compatibility by accepting ed25519 signatures and signatures over a `<Bytes>`-wrapped Blake2-256 order hash.

## Changes

- Allow sr25519 and ed25519 `MultiSignature` variants during order validation while continuing to reject ECDSA.
- Verify either the raw SCALE-encoded order or the `<Bytes>`-wrapped order hash.
- Update the benchmark signing fixture to use the wrapped-hash form.
- Add unit coverage for wrapped ed25519 signatures and ECDSA rejection.
- Update the pallet documentation and runtime rejection test.

Files of interest are `pallets/limit-orders/src/lib.rs`, `pallets/limit-orders/src/tests/auxiliary.rs`, and `pallets/limit-orders/src/benchmarking.rs`.

## Behavioral impact

Existing sr25519 orders remain valid. The accepted signature surface expands to ed25519 and wrapped-hash signatures; ECDSA remains unsupported. The order hash remains bound to the complete SCALE-encoded order.

## Testing

The PR adds pallet-level coverage for wrapped ed25519 acceptance and ECDSA rejection and updates the benchmark fixture. End-to-end coverage using the supported Ledger client is still required.