### PR TITLE
fix(cli): skip wallet prompt for Ledger and Vault signers

### DIFF
--- a/sdk/python/bittensor/cli/tx.py
+++ b/sdk/python/bittensor/cli/tx.py
@@ -230,15 +230,16 @@ def _make_command(intent_cls: type[Intent]):
             source is not None
             and kwargs.get(source[0]) is None
             and not app_ctx.assume_yes
-            and not app_ctx.uses_extension_signer()
+            and not app_ctx.uses_external_signer()
             and interactive(app_ctx)
         ):
             hotkey_field, netuid_field = source
             missing = [spec for spec in missing if spec.field != hotkey_field]
             missing.insert(0, stake_source_spec(hotkey_field, netuid_field))
         # The signing wallet is confirmed too (Enter accepts the configured
-        # default); --yes and the extension signer keep the flag-only flow.
-        if not app_ctx.assume_yes and not app_ctx.uses_extension_signer():
+        # default); --yes and external signers (extension, Ledger, Vault) keep
+        # the flag-only flow — the signing key lives outside the wallet files.
+        if not app_ctx.assume_yes and not app_ctx.uses_external_signer():
             missing = (
                 signer_specs(
                     app_ctx,

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -171,6 +171,33 @@ class TestTransactions:
         assert (call.module, call.function) == ("Balances", "transfer_keep_alive")
         assert call.params["value"] == 1_500_000_000
 
+    def test_ledger_signer_skips_wallet_prompt(self, fake: FakeSubstrate, monkeypatch):
+        """`--ledger` must not confirm the signing wallet: the key lives on the
+        device, so the wallet prompt (and its non-interactive default) does not
+        apply — same flag-only flow as the extension signer."""
+        import bittensor.cli.tx as cli_tx
+
+        signer_spec_calls = []
+        real_signer_specs = cli_tx.signer_specs
+
+        def tracked_signer_specs(*args, **kwargs):
+            signer_spec_calls.append(args)
+            return real_signer_specs(*args, **kwargs)
+
+        monkeypatch.setattr(cli_tx, "signer_specs", tracked_signer_specs)
+        submitted = []
+        monkeypatch.setattr(
+            cli_context.AppContext, "submit", lambda self, *a, **k: submitted.append(a)
+        )
+
+        invoke("tx", "transfer", "--dest", BOB, "--amount-tao", "1.5", "--ledger")
+        assert signer_spec_calls == []
+        assert len(submitted) == 1
+
+        # The default wallet-signer flow still confirms the signing wallet.
+        invoke("tx", "transfer", "--dest", BOB, "--amount-tao", "1.5")
+        assert len(signer_spec_calls) == 1
+
     def test_failed_extrinsic_exits_nonzero(self, fake: FakeSubstrate):
         from bittensor.result import ChainError, ExtrinsicResult
 


### PR DESCRIPTION
## Description

`--ledger` (and `--signer vault`) on any generated `tx` command still prompted for the signing wallet, even though the signing key lives on the device, not in local wallet files:

```
$ btcli tx multisig-execute ... --ledger
  --wallet  Wallet whose coldkey signs this transaction.
  wallet [default]:
```

Without a valid local wallet to name, the command fails (`keyfile at '.../coldkeypub.txt' does not exist`); the workaround was passing `-w <any-existing-wallet>` that is then ignored for signing.

Cause: the generated tx commands in `sdk/python/bittensor/cli/tx.py` gate the signer confirmation (and the stake-source picker) on `uses_extension_signer()` only. The sibling path `confirm_wallet` in `context.py` already gates on `uses_external_signer()` (extension, Ledger, Vault) — whose docstring says exactly that wallet confirmation doesn't apply. This PR aligns the tx-command gates with it.

Found while running a 2-of-3 Ledger multisig round on testnet with `btcli tx multisig-execute --ledger`.

## Related Issue(s)

- N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly (N/A — Python SDK only)
- [ ] I have made corresponding changes to the documentation (N/A — behavior now matches the documented Ledger flow)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)

`tests/unit/test_cli.py` passes 21/21 with the fix; the new `test_ledger_signer_skips_wallet_prompt` fails without it. Remaining `tests/unit` failures in my environment are pre-existing table/codec mismatches from testing against the published `bittensor-core` wheel rather than the in-repo core (identical counts on a clean checkout).

## Screenshots (if applicable)

N/A

## Additional Notes

The stake-source picker gate (line 233) is included in the same change: with an external signer the interactive position picker reads the local wallet's coldkey positions, which is equally inapplicable.
