### PR TITLE
Fix stable Python release publishing

### DIFF
--- a/.github/scripts/check-python-release.py
+++ b/.github/scripts/check-python-release.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Check whether the complete, attested stable Python release exists on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import sys
+from collections.abc import Callable
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024
+PUBLISH_PREDICATE = "https://docs.pypi.org/attestations/publish/v1"
+STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+
+
+class ApiError(RuntimeError):
+    """PyPI could not provide authoritative state."""
+
+
+class IncompleteRelease(RuntimeError):
+    """One or more required, correctly attested files are not yet on PyPI."""
+
+
+def fetch_json(url: str, *, timeout: int = 30) -> dict[str, Any] | None:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "subtensor-release-watcher/1",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            data = response.read(MAX_RESPONSE_SIZE + 1)
+    except HTTPError as error:
+        if error.code == 404:
+            return None
+        raise ApiError(f"{url} returned HTTP {error.code}") from error
+    except (OSError, URLError) as error:
+        raise ApiError(f"could not fetch {url}: {error}") from error
+    if len(data) > MAX_RESPONSE_SIZE:
+        raise ApiError(f"{url} exceeded the response size limit")
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ApiError(f"{url} did not return valid JSON") from error
+    if not isinstance(value, dict):
+        raise ApiError(f"{url} did not return a JSON object")
+    return value
+
+
+def _valid_file(entry: object, *, package_type: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    digest = entry.get("digests")
+    return (
+        entry.get("packagetype") == package_type
+        and entry.get("yanked") is False
+        and isinstance(entry.get("filename"), str)
+        and isinstance(digest, dict)
+        and isinstance(digest.get("sha256"), str)
+        and SHA256_RE.fullmatch(digest["sha256"]) is not None
+    )
+
+
+def _core_platform(filename: str, version: str) -> str | None:
+    prefix = f"bittensor_core-{version}-"
+    if not filename.startswith(prefix) or not filename.endswith(".whl"):
+        return None
+    wheel_tags = filename[len(prefix) : -4].split("-", 2)
+    if len(wheel_tags) != 3 or wheel_tags[0] != "cp310" or wheel_tags[1] != "abi3":
+        return None
+    platform = wheel_tags[2]
+    if "manylinux" in platform and platform.endswith("_x86_64"):
+        return "linux-x86_64"
+    if "manylinux" in platform and platform.endswith("_aarch64"):
+        return "linux-aarch64"
+    if platform.startswith("macosx_") and platform.endswith("_x86_64"):
+        return "macos-x86_64"
+    if platform.startswith("macosx_") and platform.endswith("_arm64"):
+        return "macos-arm64"
+    return None
+
+
+def _release_files(
+    metadata: dict[str, Any], *, package: str
+) -> dict[str, dict[str, Any]]:
+    entries = metadata.get("urls")
+    if not isinstance(entries, list):
+        raise ApiError(f"PyPI metadata for {package} has no file list")
+
+    files: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ApiError(f"PyPI metadata for {package} has an invalid file entry")
+        if entry.get("yanked") is not False:
+            filename = entry.get("filename", "<unknown>")
+            raise IncompleteRelease(f"{package} has yanked distribution {filename}")
+        package_type = entry.get("packagetype")
+        if package_type not in {"bdist_wheel", "sdist"} or not _valid_file(
+            entry, package_type=package_type
+        ):
+            filename = entry.get("filename", "<unknown>")
+            raise IncompleteRelease(
+                f"{package} has invalid non-yanked distribution metadata for {filename}"
+            )
+        filename = entry["filename"]
+        if filename in files:
+            raise IncompleteRelease(
+                f"{package} has duplicate non-yanked distribution {filename}"
+            )
+        files[filename] = entry
+    return files
+
+
+def _required_files(
+    sdk_metadata: dict[str, Any], core_metadata: dict[str, Any], sdk: str, core: str
+) -> dict[str, dict[str, Any]]:
+    required: dict[str, dict[str, Any]] = {}
+    expected_sdk = {
+        f"bittensor-{sdk}-py3-none-any.whl": "bdist_wheel",
+        f"bittensor-{sdk}.tar.gz": "sdist",
+    }
+    sdk_files = _release_files(sdk_metadata, package="bittensor")
+    if set(sdk_files) != set(expected_sdk):
+        missing = sorted(set(expected_sdk) - set(sdk_files))
+        unexpected = sorted(set(sdk_files) - set(expected_sdk))
+        details = []
+        if missing:
+            details.append(f"missing {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected {', '.join(unexpected)}")
+        raise IncompleteRelease(
+            f"bittensor {sdk} distribution set is incomplete or unsafe: "
+            + "; ".join(details)
+        )
+    for filename, package_type in expected_sdk.items():
+        entry = sdk_files[filename]
+        if entry["packagetype"] != package_type:
+            raise IncompleteRelease(
+                f"{filename} has package type {entry['packagetype']}, expected {package_type}"
+            )
+        required[f"sdk:{filename}"] = entry
+
+    core_sdist = f"bittensor_core-{core}.tar.gz"
+    core_files = _release_files(core_metadata, package="bittensor-core")
+    core_sdist_entry = core_files.pop(core_sdist, None)
+    if core_sdist_entry is None:
+        raise IncompleteRelease(f"missing non-yanked {core_sdist}")
+    if core_sdist_entry["packagetype"] != "sdist":
+        raise IncompleteRelease(
+            f"{core_sdist} has package type {core_sdist_entry['packagetype']}, expected sdist"
+        )
+    required[f"core:{core_sdist}"] = core_sdist_entry
+
+    expected_platforms = {
+        "linux-x86_64",
+        "linux-aarch64",
+        "macos-x86_64",
+        "macos-arm64",
+    }
+    platform_files: dict[str, dict[str, Any]] = {}
+    unexpected_core: list[str] = []
+    for filename, entry in sorted(core_files.items()):
+        platform = (
+            _core_platform(filename, core)
+            if entry["packagetype"] == "bdist_wheel"
+            else None
+        )
+        if platform is None or platform not in expected_platforms:
+            unexpected_core.append(filename)
+            continue
+        if platform in platform_files:
+            raise IncompleteRelease(
+                f"multiple non-yanked bittensor-core {platform} cp310-abi3 wheels"
+            )
+        platform_files[platform] = entry
+    if unexpected_core:
+        raise IncompleteRelease(
+            "bittensor-core has unexpected non-yanked distributions: "
+            + ", ".join(unexpected_core)
+        )
+    missing_platforms = sorted(expected_platforms - set(platform_files))
+    if missing_platforms:
+        raise IncompleteRelease(
+            "missing non-yanked bittensor-core cp310-abi3 wheels for "
+            + ", ".join(missing_platforms)
+        )
+    for platform, entry in sorted(platform_files.items()):
+        required[f"core:{platform}"] = entry
+    return required
+
+
+def _matching_publish_attestation(
+    provenance: dict[str, Any],
+    *,
+    filename: str,
+    sha256: str,
+    repository: str,
+    workflow: str,
+    environment: str,
+) -> bool:
+    if provenance.get("version") != 1:
+        return False
+    bundles = provenance.get("attestation_bundles")
+    if not isinstance(bundles, list):
+        return False
+    for bundle in bundles:
+        if not isinstance(bundle, dict):
+            continue
+        publisher = bundle.get("publisher")
+        if not isinstance(publisher, dict) or any(
+            (
+                publisher.get("kind") != "GitHub",
+                publisher.get("repository") != repository,
+                publisher.get("workflow") != workflow,
+                publisher.get("environment") != environment,
+            )
+        ):
+            continue
+        attestations = bundle.get("attestations")
+        if not isinstance(attestations, list):
+            continue
+        for attestation in attestations:
+            try:
+                encoded = attestation["envelope"]["statement"]
+                statement = json.loads(base64.b64decode(encoded, validate=True))
+            except (
+                KeyError,
+                TypeError,
+                ValueError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ):
+                continue
+            if not isinstance(statement, dict):
+                continue
+            if (
+                statement.get("_type") != STATEMENT_TYPE
+                or statement.get("predicateType") != PUBLISH_PREDICATE
+            ):
+                continue
+            subjects = statement.get("subject")
+            if not isinstance(subjects, list):
+                continue
+            for subject in subjects:
+                if (
+                    isinstance(subject, dict)
+                    and subject.get("name") == filename
+                    and isinstance(subject.get("digest"), dict)
+                    and subject["digest"].get("sha256") == sha256
+                ):
+                    return True
+    return False
+
+
+def check_release(
+    *,
+    sdk_version: str,
+    core_version: str,
+    repository: str,
+    workflow: str,
+    environment: str,
+    base_url: str = "https://pypi.org",
+    get_json: Callable[[str], dict[str, Any] | None] = fetch_json,
+) -> list[str]:
+    for version in (sdk_version, core_version):
+        if VERSION_RE.fullmatch(version) is None:
+            raise ValueError(f"{version!r} is not a stable X.Y.Z version")
+
+    sdk_url = f"{base_url}/pypi/bittensor/{quote(sdk_version, safe='')}/json"
+    core_url = f"{base_url}/pypi/bittensor-core/{quote(core_version, safe='')}/json"
+    sdk_metadata = get_json(sdk_url)
+    core_metadata = get_json(core_url)
+    if sdk_metadata is None:
+        raise IncompleteRelease(f"bittensor {sdk_version} is not published")
+    if core_metadata is None:
+        raise IncompleteRelease(f"bittensor-core {core_version} is not published")
+
+    required = _required_files(sdk_metadata, core_metadata, sdk_version, core_version)
+    verified: list[str] = []
+    for key, entry in sorted(required.items()):
+        package = "bittensor" if key.startswith("sdk:") else "bittensor-core"
+        filename = entry["filename"]
+        provenance_url = (
+            f"{base_url}/integrity/{package}/"
+            f"{quote(sdk_version if package == 'bittensor' else core_version, safe='')}/"
+            f"{quote(filename, safe='')}/provenance"
+        )
+        provenance = get_json(provenance_url)
+        if provenance is None or not _matching_publish_attestation(
+            provenance,
+            filename=filename,
+            sha256=entry["digests"]["sha256"],
+            repository=repository,
+            workflow=workflow,
+            environment=environment,
+        ):
+            raise IncompleteRelease(
+                f"{filename} has no matching trusted-publisher attestation"
+            )
+        verified.append(filename)
+    return verified
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sdk-version", required=True)
+    parser.add_argument("--core-version", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--workflow", default="watch-mainnet-release.yml")
+    parser.add_argument("--environment", default="mainnet")
+    parser.add_argument("--base-url", default="https://pypi.org")
+    arguments = parser.parse_args()
+    try:
+        verified = check_release(
+            sdk_version=arguments.sdk_version,
+            core_version=arguments.core_version,
+            repository=arguments.repository,
+            workflow=arguments.workflow,
+            environment=arguments.environment,
+            base_url=arguments.base_url.rstrip("/"),
+        )
+    except IncompleteRelease as error:
+        print(f"Python release incomplete: {error}", file=sys.stderr)
+        return 1
+    except (ApiError, ValueError) as error:
+        print(f"could not verify Python release: {error}", file=sys.stderr)
+        return 2
+    print(f"verified {len(verified)} attested Python release files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release-python-versions.py
+++ b/.github/scripts/release-python-versions.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Read the stable Python versions expected from an immutable release commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+SDK_VERSION_RE = re.compile(
+    r'^version = "([0-9]+\.[0-9]+\.[0-9]+)\.dev0"$', re.MULTILINE
+)
+CORE_VERSION_RE = re.compile(r'^version = "([0-9]+\.[0-9]+\.[0-9]+)"$', re.MULTILINE)
+
+
+def release_versions(sdk_manifest: str, core_manifest: str) -> tuple[str, str]:
+    sdk = SDK_VERSION_RE.search(sdk_manifest)
+    if sdk is None:
+        raise ValueError("SDK manifest must declare version X.Y.Z.dev0")
+    core = CORE_VERSION_RE.search(core_manifest)
+    if core is None:
+        raise ValueError("core manifest must declare stable version X.Y.Z")
+    return sdk.group(1), core.group(1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sdk_manifest", type=Path)
+    parser.add_argument("core_manifest", type=Path)
+    arguments = parser.parse_args()
+    try:
+        sdk, core = release_versions(
+            arguments.sdk_manifest.read_text(), arguments.core_manifest.read_text()
+        )
+    except (OSError, ValueError) as error:
+        print(f"could not determine release versions: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps({"sdk": sdk, "core": core}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/resolve-release-artifact.sh
+++ b/.github/scripts/resolve-release-artifact.sh
@@ -31,8 +31,8 @@ repo_id=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.id')
 # Newest-first so that, among equally-trusted artifacts, we take the latest.
 artifacts=$(gh api \
   "repos/$GITHUB_REPOSITORY/actions/artifacts?name=mainnet-upgrade-${spec}&per_page=100" \
-  --paginate --slurp \
-  | jq -c '[.[].artifacts[]] | sort_by(.created_at) | reverse')
+  --paginate \
+  | jq -sc '[.[].artifacts[]] | sort_by(.created_at) | reverse')
 
 count=$(jq 'length' <<<"$artifacts")
 i=0

--- a/.github/scripts/resolve-release-artifact.sh
+++ b/.github/scripts/resolve-release-artifact.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Resolve the id of the `mainnet-upgrade-<spec>` workflow artifact, but only
-# accept one whose provenance proves the release train produced it.
+# accept one whose provenance and contents match the immutable release tag and
+# the runtime bytes finalized on chain.
 #
 # Why this matters: GitHub stores artifacts uploaded by *fork* pull requests in
 # the *base* repository's artifact store. The artifact name is attacker-
@@ -14,19 +15,31 @@
 #
 # We require the artifact's producing run to be:
 #   * from this repository (not a fork)   — head_repository_id == repo id
-#   * a push to the trunk                  — event == push, head_branch == main
+#   * a train run on the trunk             — push/workflow_dispatch on main
 #   * the release train workflow           — path == release-train.yml
+#   * built from the immutable release tag — head_sha == expected commit
 #   * built from a commit on main          — head_sha is an ancestor of main
+#   * the exact finalized runtime          — BLAKE2b-256(wasm) == :code hash
 #
 # Prints the resolved artifact id to stdout on success; exits non-zero if no
 # trustworthy artifact exists.
 set -euo pipefail
 
 spec="${1:?spec_version required}"
+expected_commit="${2:?expected commit required}"
+expected_code_hash="${3:?expected finalized code hash required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
 : "${GH_TOKEN:?GH_TOKEN required}"
 
+[[ "$spec" =~ ^[0-9]+$ ]] || { echo "spec_version must be an integer" >&2; exit 1; }
+[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] \
+  || { echo "expected commit must be a lowercase 40-byte Git SHA" >&2; exit 1; }
+[[ "$expected_code_hash" =~ ^0x[0-9a-f]{64}$ ]] \
+  || { echo "expected code hash must be a lowercase 32-byte hex digest" >&2; exit 1; }
+
 repo_id=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.id')
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
 
 # Newest-first so that, among equally-trusted artifacts, we take the latest.
 artifacts=$(gh api \
@@ -51,12 +64,18 @@ while (( i < count )); do
   [[ -n "$run_id" ]] || continue
   [[ "$head_repo_id" == "$repo_id" ]] || { echo "skip artifact $art_id: not from this repo (head_repository_id=$head_repo_id)" >&2; continue; }
   [[ "$head_branch" == "main" ]] || { echo "skip artifact $art_id: head_branch=$head_branch != main" >&2; continue; }
+  [[ "$head_sha" == "$expected_commit" ]] || { echo "skip artifact $art_id: head_sha=$head_sha != release tag $expected_commit" >&2; continue; }
 
   run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/${run_id}")
   event=$(jq -r '.event' <<<"$run")
   wf_path=$(jq -r '.path' <<<"$run")
-  [[ "$event" == "push" ]] || { echo "skip artifact $art_id: run event=$event != push" >&2; continue; }
+  run_sha=$(jq -r '.head_sha // empty' <<<"$run")
+  run_repo_id=$(jq -r '.head_repository.id // empty' <<<"$run")
+  [[ "$run_repo_id" == "$repo_id" ]] || { echo "skip artifact $art_id: run is not from this repo" >&2; continue; }
+  [[ "$event" == "push" || "$event" == "workflow_dispatch" ]] \
+    || { echo "skip artifact $art_id: unsupported run event=$event" >&2; continue; }
   [[ "$wf_path" == ".github/workflows/release-train.yml" ]] || { echo "skip artifact $art_id: run workflow=$wf_path" >&2; continue; }
+  [[ "$run_sha" == "$expected_commit" ]] || { echo "skip artifact $art_id: run head_sha=$run_sha != release tag $expected_commit" >&2; continue; }
 
   # head_sha must be reachable from main. Use the compare API so we do not need
   # a full local clone: main is "ahead"/"identical" iff head_sha is an ancestor.
@@ -66,9 +85,22 @@ while (( i < count )); do
     *) echo "skip artifact $art_id: head_sha $head_sha not an ancestor of main (compare status=$status)" >&2; continue ;;
   esac
 
+  archive="$temp_dir/artifact-${art_id}.zip"
+  if ! gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${art_id}/zip" > "$archive"; then
+    echo "skip artifact $art_id: could not download archive" >&2
+    continue
+  fi
+  if ! python3 .github/scripts/verify-release-artifact.py "$archive" \
+      --spec "$spec" \
+      --commit "$expected_commit" \
+      --code-hash "$expected_code_hash" >&2; then
+    echo "skip artifact $art_id: contents do not match finalized release" >&2
+    continue
+  fi
+
   echo "$art_id"
   exit 0
 done
 
-echo "no trustworthy mainnet-upgrade-${spec} artifact found (must be produced by a push to main of release-train.yml in this repo)" >&2
+echo "no trustworthy mainnet-upgrade-${spec} artifact matches tag commit ${expected_commit} and finalized code hash ${expected_code_hash}" >&2
 exit 1

--- a/.github/scripts/verify-release-artifact.py
+++ b/.github/scripts/verify-release-artifact.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Verify that a release-train artifact is the runtime finalized on chain."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+HASH_RE = re.compile(r"^(?:0x)?([0-9a-f]{64})$")
+MAX_ARCHIVE_SIZE = 100 * 1024 * 1024
+MAX_JSON_SIZE = 2 * 1024 * 1024
+MAX_WASM_SIZE = 50 * 1024 * 1024
+MAX_CALL_DATA_SIZE = 20 * 1024 * 1024
+
+
+class ValidationError(ValueError):
+    """The artifact does not match the expected immutable release identity."""
+
+
+def _hash(value: str, name: str) -> str:
+    match = HASH_RE.fullmatch(value)
+    if match is None:
+        raise ValidationError(f"{name} must be a lowercase 32-byte hex digest")
+    return match.group(1)
+
+
+def _object(data: bytes, name: str) -> dict[str, Any]:
+    if len(data) > MAX_JSON_SIZE:
+        raise ValidationError(f"{name} is unexpectedly large")
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValidationError(f"{name} is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise ValidationError(f"{name} must contain a JSON object")
+    return value
+
+
+def _require_equal(actual: object, expected: object, name: str) -> None:
+    if actual != expected:
+        raise ValidationError(f"{name} is {actual!r}, expected {expected!r}")
+
+
+def verify_archive(
+    archive: Path,
+    *,
+    expected_spec: int,
+    expected_commit: str,
+    expected_code_hash: str,
+) -> dict[str, object]:
+    """Validate an Actions artifact zip and return its verified identity."""
+    if expected_spec < 0:
+        raise ValidationError("expected spec_version must be non-negative")
+    if SHA_RE.fullmatch(expected_commit) is None:
+        raise ValidationError("expected commit must be a lowercase 40-byte Git SHA")
+    code_hash = _hash(expected_code_hash, "expected code hash")
+
+    try:
+        artifact = zipfile.ZipFile(archive)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise ValidationError("artifact is not a readable zip file") from error
+
+    with artifact:
+        files: dict[str, zipfile.ZipInfo] = {}
+        total_size = 0
+        for member in artifact.infolist():
+            if member.is_dir():
+                continue
+            name = member.filename
+            parts = Path(name).parts
+            if (
+                name.startswith(("/", "\\"))
+                or "\\" in name
+                or ".." in parts
+                or len(parts) != 1
+            ):
+                raise ValidationError(f"artifact contains unsafe member {name!r}")
+            if name in files:
+                raise ValidationError(f"artifact contains duplicate member {name!r}")
+            total_size += member.file_size
+            files[name] = member
+        if total_size > MAX_ARCHIVE_SIZE:
+            raise ValidationError("artifact expands beyond the size limit")
+
+        required = {
+            "subtensor.wasm",
+            "subtensor-digest.json",
+            "proxy_proxy_blob.hex",
+            "pending-release.json",
+            "upgrade-manifest.json",
+        }
+        missing = sorted(required - files.keys())
+        if missing:
+            raise ValidationError(f"artifact is missing: {', '.join(missing)}")
+
+        wasm_info = files["subtensor.wasm"]
+        if not 0 < wasm_info.file_size <= MAX_WASM_SIZE:
+            raise ValidationError("subtensor.wasm has an invalid size")
+        wasm = artifact.read(wasm_info)
+
+        call_data_info = files["proxy_proxy_blob.hex"]
+        if not 0 < call_data_info.file_size <= MAX_CALL_DATA_SIZE:
+            raise ValidationError("proxy_proxy_blob.hex has an invalid size")
+
+        pending = _object(
+            artifact.read(files["pending-release.json"]), "pending-release.json"
+        )
+        digest = _object(
+            artifact.read(files["subtensor-digest.json"]), "subtensor-digest.json"
+        )
+        manifest = _object(
+            artifact.read(files["upgrade-manifest.json"]), "upgrade-manifest.json"
+        )
+
+    _require_equal(
+        pending.get("expected_spec_version"),
+        expected_spec,
+        "pending release spec_version",
+    )
+    _require_equal(pending.get("commit"), expected_commit, "pending release commit")
+
+    wasm_sha256 = hashlib.sha256(wasm).hexdigest()
+    wasm_code_hash = hashlib.blake2b(wasm, digest_size=32).hexdigest()
+    _require_equal(wasm_code_hash, code_hash, "runtime code hash")
+    _require_equal(
+        _hash(str(digest.get("sha256", "")), "srtool sha256"),
+        wasm_sha256,
+        "srtool sha256",
+    )
+
+    _require_equal(manifest.get("spec_version"), expected_spec, "manifest spec_version")
+    _require_equal(manifest.get("commit"), expected_commit, "manifest commit")
+    _require_equal(
+        _hash(str(manifest.get("wasm_sha256", "")), "manifest wasm_sha256"),
+        wasm_sha256,
+        "manifest wasm_sha256",
+    )
+
+    return {
+        "spec_version": expected_spec,
+        "commit": expected_commit,
+        "code_hash": f"0x{wasm_code_hash}",
+        "wasm_sha256": wasm_sha256,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("--spec", type=int, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--code-hash", required=True)
+    arguments = parser.parse_args()
+    try:
+        result = verify_archive(
+            arguments.archive,
+            expected_spec=arguments.spec,
+            expected_commit=arguments.commit,
+            expected_code_hash=arguments.code_hash,
+        )
+    except ValidationError as error:
+        print(f"invalid release artifact: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -321,6 +321,29 @@ jobs:
           : ${base:?could not parse base version from sdk/python/pyproject.toml}
           core_base=$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
           : ${core_base:?could not parse base version from sdk/bittensor-core-py/pyproject.toml}
+
+          # PyPI versions are immutable. Reject an already-published stable
+          # base before producing more release candidates that can never be
+          # promoted to a final release.
+          for package_version in "bittensor:${base}" "bittensor-core:${core_base}"; do
+            package=${package_version%%:*}
+            version=${package_version#*:}
+            status=$(curl -sS --connect-timeout 10 --max-time 30 \
+              -o /dev/null -w '%{http_code}' \
+              "https://pypi.org/pypi/${package}/${version}/json")
+            case "$status" in
+              404) ;;
+              200)
+                echo "${package} ${version} is already published; bump the base version."
+                exit 1
+                ;;
+              *)
+                echo "PyPI availability check for ${package} ${version} returned HTTP ${status}."
+                exit 1
+                ;;
+            esac
+          done
+
           echo "sdk=${base}rc${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
           echo "core=${core_base}rc${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -464,6 +464,45 @@ jobs:
         working-directory: .github/scripts/deploy
         run: npm ci --ignore-scripts
 
+      # Reserve the release identity before any on-chain side effect. Tag
+      # rules make v<spec> immutable; a retry from the same commit is safe,
+      # while changed code must bump spec_version rather than retargeting a
+      # proposal that signers may already be reviewing.
+      - name: Reserve immutable release tag
+        if: steps.guard.outputs.should_propose == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="v${{ needs.build.outputs.spec_version }}"
+          tag_ref="repos/$GITHUB_REPOSITORY/git/ref/tags/$tag"
+
+          if tag_json=$(gh api "$tag_ref" 2>/dev/null); then
+            tag_type=$(jq -er '.object.type' <<<"$tag_json")
+            [ "$tag_type" = commit ] \
+              || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+            tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
+            echo "release tag $tag already exists at $tag_sha"
+          else
+            if gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+                -f ref="refs/tags/$tag" -f sha="$GITHUB_SHA" >/dev/null; then
+              echo "reserved release tag $tag"
+            else
+              # Handle a concurrent same-commit reservation without making
+              # tag creation racy. Any other failure remains fatal here.
+              echo "tag creation raced; verifying the exact tag ref"
+            fi
+            tag_json=$(gh api "$tag_ref")
+            tag_type=$(jq -er '.object.type' <<<"$tag_json")
+            [ "$tag_type" = commit ] \
+              || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+            tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
+          fi
+          [[ "$tag_sha" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "tag $tag did not resolve to a Git commit"; exit 1; }
+          [ "$tag_sha" = "$GITHUB_SHA" ] \
+            || { echo "tag $tag is reserved for $tag_sha, not $GITHUB_SHA; bump spec_version"; exit 1; }
+
       - name: Submit multisig proposal (CI half of deployment multisig)
         if: steps.guard.outputs.should_propose == 'true'
         working-directory: .github/scripts/deploy
@@ -557,19 +596,15 @@ jobs:
           tag="v${spec}"
           url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${tag}"
 
-          # A published (non-prerelease) v<spec> means this spec already
-          # shipped; never touch it. A pre-release for the same spec is a
-          # respun proposal (e.g. the first train failed mid-way): replace it.
-          if existing=$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease' 2>/dev/null); then
-            if [ "$existing" != "true" ]; then
-              echo "release $tag already published as a final release; refusing to overwrite"
-              exit 1
-            fi
-            echo "replacing existing proposal pre-release $tag"
-            gh release delete "$tag" --cleanup-tag --yes
-          fi
-
           commit=$(jq -r '.commit' wasm/pending-release.json)
+          tag_json=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag")
+          tag_type=$(jq -er '.object.type' <<<"$tag_json")
+          [ "$tag_type" = commit ] \
+            || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+          tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
+          [ "$tag_sha" = "$commit" ] \
+            || { echo "immutable tag $tag points at $tag_sha, expected $commit"; exit 1; }
           call_hash=$(jq -r '.proposal.callHash' wasm/pending-release.json)
           height=$(jq -r '.proposal.blockHeight' wasm/pending-release.json)
           index=$(jq -r '.proposal.extrinsicIndex' wasm/pending-release.json)
@@ -625,17 +660,39 @@ jobs:
           | wasm sha256 | \`${sha256}\` |
           EOF
 
-          gh release create "$tag" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$commit" \
-            --prerelease \
-            --title "Runtime ${spec} (proposed)" \
-            --notes-file release-body.md \
-            wasm/subtensor.wasm \
-            wasm/subtensor-digest.json \
-            wasm/proxy_proxy_blob.hex \
-            wasm/pending-release.json \
+          assets=(
+            wasm/subtensor.wasm
+            wasm/subtensor-digest.json
+            wasm/proxy_proxy_blob.hex
+            wasm/pending-release.json
             wasm/upgrade-manifest.json
+          )
+          if release_json=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null); then
+            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            [ "$is_prerelease" = true ] \
+              || { echo "release $tag is already final; refusing to overwrite it"; exit 1; }
+            target_sha=$(jq -er \
+              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
+              <<<"$release_json")
+            [ "$target_sha" = "$commit" ] \
+              || { echo "pre-release target $target_sha does not match $commit"; exit 1; }
+            gh release upload "$tag" \
+              --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Runtime ${spec} (proposed)" \
+              --notes-file release-body.md \
+              --prerelease
+          else
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$commit" \
+              --prerelease \
+              --title "Runtime ${spec} (proposed)" \
+              --notes-file release-body.md \
+              "${assets[@]}"
+          fi
 
           {
             echo "## Share this with the other signers"

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -44,6 +44,7 @@ jobs:
       release_needed: ${{ steps.compare.outputs.release_needed }}
       python_needed: ${{ steps.compare.outputs.python_needed }}
       spec_version: ${{ steps.compare.outputs.spec_version }}
+      release_tag: ${{ steps.compare.outputs.release_tag }}
       sha: ${{ steps.compare.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
@@ -78,15 +79,22 @@ jobs:
 
           # Match both this workflow's tags (v424) and the legacy scheme
           # inherited from upstream (v3.4.9-424). Pre-releases do not count.
-          if gh release list --repo "$GITHUB_REPOSITORY" --limit 300 \
-              --json tagName,isPrerelease \
-              --jq '.[] | select(.isPrerelease | not) | .tagName' \
-              | grep -Eq "^v${chain_spec}$|-${chain_spec}$"; then
+          release_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 300 \
+            --json tagName,isDraft,isPrerelease \
+            | jq -r --arg exact "v${chain_spec}" --arg suffix "-${chain_spec}" \
+              '.[] |
+               select(.isDraft == false and .isPrerelease == false) |
+               select(.tagName == $exact or (.tagName | endswith($suffix))) |
+               .tagName' \
+            | head -n 1)
+          if [ -n "$release_tag" ]; then
             echo "GitHub release for spec_version $chain_spec is complete."
             release_needed=false
           else
+            release_tag="v${chain_spec}"
             release_needed=true
           fi
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
           # v432 and earlier predate this marker. Every later
           # release retries until PyPI succeeds and this exact marker is stored.
@@ -94,7 +102,7 @@ jobs:
             echo "v432 Python publication is handled manually."
             python_needed=false
           else
-            marker_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/v${chain_spec}" \
+            marker_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}" \
               --jq '.assets[] | select(.name == "python-publish-complete.json") | .id' \
               2>/dev/null | head -n 1 || true)
             if [ -z "$marker_id" ]; then
@@ -103,7 +111,7 @@ jobs:
               gh api -H "Accept: application/octet-stream" \
                 "repos/$GITHUB_REPOSITORY/releases/assets/$marker_id" \
                 > /tmp/python-publish-complete.json
-              tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/v${chain_spec}" --jq '.sha')
+              tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/${release_tag}" --jq '.sha')
               jq -e --arg sha "$tag_sha" --argjson spec "$chain_spec" \
                 '.schema == 1 and .spec_version == $spec and .commit == $sha' \
                 /tmp/python-publish-complete.json >/dev/null \
@@ -118,6 +126,18 @@ jobs:
           # A valid marker is the durable terminal state. Resolve the expiring
           # workflow artifact only while release or Python work is pending.
           if [ "$release_needed" = false ] && [ "$python_needed" = false ]; then
+            exit 0
+          fi
+
+          # Once the GitHub release exists, its immutable tag is sufficient
+          # provenance for a Python-only retry. Do not keep the retry path
+          # dependent on the release train's 90-day workflow artifact.
+          if [ "$release_needed" = false ]; then
+            release_sha=$(gh api \
+              "repos/$GITHUB_REPOSITORY/commits/${release_tag}" --jq '.sha')
+            : ${release_sha:?could not resolve released commit from $release_tag}
+            echo "Retrying Python publication from $release_tag at $release_sha"
+            echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -310,23 +330,23 @@ jobs:
         working-directory: sdk/python
         run: uv build --out-dir ../../dist
 
-      # Second half of the v432 recovery: refuse to publish anything but the
-      # intended stable artifacts, so a failed stamp can never leak
-      # 11.0.0.dev0 to PyPI.
-      - name: Verify stable artifacts (v432 recovery)
-        if: needs.check.outputs.spec_version == '432' && needs.check.outputs.sha == '8586e65ec279644a6837cf25b12333064c77474e'
+      # Refuse to publish development or release-candidate artifacts from the
+      # stable channel. Also require the complete SDK/core platform set.
+      - name: Verify stable artifacts
         run: |
+          sdk_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/python/pyproject.toml | head -n 1)
+          core_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
+          : ${sdk_version:?could not parse stable SDK version}
+          : ${core_version:?could not parse stable core version}
+          [[ "$sdk_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "SDK version is not stable: $sdk_version"; exit 1; }
+          [[ "$core_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo "core version is not stable: $core_version"; exit 1; }
           ls -la dist
-          test -f dist/bittensor-11.0.0-py3-none-any.whl
-          test -f dist/bittensor-11.0.0.tar.gz
-          compgen -G 'dist/bittensor_core-0.1.0-*.whl' >/dev/null
-          test -f dist/bittensor_core-0.1.0.tar.gz
-          for f in dist/*; do
-            # *0rc* not *rc*: "aarch64" in wheel platform tags contains "rc"
-            case "$f" in
-              *dev*|*0rc*) echo "unexpected pre-release artifact: $f"; exit 1 ;;
-            esac
-          done
+          test -f "dist/bittensor-${sdk_version}-py3-none-any.whl"
+          test -f "dist/bittensor-${sdk_version}.tar.gz"
+          compgen -G "dist/bittensor_core-${core_version}-*.whl" >/dev/null
+          test -f "dist/bittensor_core-${core_version}.tar.gz"
 
       # PEP 740 provenance: sign every dist with this job's OIDC identity.
       # Must happen here, not in build-core-wheels.yml — PyPI only accepts
@@ -359,7 +379,8 @@ jobs:
             --arg workflow_run "$GITHUB_RUN_ID" \
             '{schema: 1, spec_version: $spec, commit: $sha, workflow_run: $workflow_run}' \
             > python-publish-complete.json
-          gh release upload "v${SPEC_VERSION}" --repo "$GITHUB_REPOSITORY" --clobber \
+          gh release upload "${{ needs.check.outputs.release_tag }}" \
+            --repo "$GITHUB_REPOSITORY" --clobber \
             python-publish-complete.json
 
   publish-crates:

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -129,13 +129,46 @@ jobs:
             exit 0
           fi
 
-          # Once the GitHub release exists, its immutable tag is sufficient
-          # provenance for a Python-only retry. Do not keep the retry path
-          # dependent on the release train's 90-day workflow artifact.
+          # The final release carries pending-release.json copied from the
+          # provenance-gated workflow artifact. Use that durable manifest for
+          # Python-only retries, and fail closed if the release target or tag
+          # has moved away from its verified commit.
           if [ "$release_needed" = false ]; then
-            release_sha=$(gh api \
+            release_json=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}")
+            manifest_id=$(jq -r \
+              '.assets[] | select(.name == "pending-release.json") | .id' \
+              <<<"$release_json" | head -n 1)
+            : ${manifest_id:?release $release_tag has no pending-release.json provenance asset}
+            gh api -H "Accept: application/octet-stream" \
+              "repos/$GITHUB_REPOSITORY/releases/assets/${manifest_id}" \
+              > /tmp/released-pending-release.json
+
+            release_sha=$(jq -er \
+              '.commit | strings | select(test("^[0-9a-f]{40}$"))' \
+              /tmp/released-pending-release.json)
+            manifest_spec=$(jq -er '.expected_spec_version | numbers' \
+              /tmp/released-pending-release.json)
+            [ "$manifest_spec" = "$chain_spec" ] \
+              || { echo "release manifest expects spec $manifest_spec, chain runs $chain_spec"; exit 1; }
+
+            target_sha=$(jq -er \
+              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
+              <<<"$release_json")
+            tag_sha=$(gh api \
               "repos/$GITHUB_REPOSITORY/commits/${release_tag}" --jq '.sha')
-            : ${release_sha:?could not resolve released commit from $release_tag}
+            [ "$release_sha" = "$target_sha" ] \
+              || { echo "release target $target_sha does not match manifest commit $release_sha"; exit 1; }
+            [ "$release_sha" = "$tag_sha" ] \
+              || { echo "tag $release_tag moved from manifest commit $release_sha to $tag_sha"; exit 1; }
+
+            status=$(gh api \
+              "repos/$GITHUB_REPOSITORY/compare/${release_sha}...main" --jq '.status')
+            case "$status" in
+              ahead|identical) ;;
+              *) echo "released commit $release_sha is not an ancestor of main"; exit 1 ;;
+            esac
+
             echo "Retrying Python publication from $release_tag at $release_sha"
             echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -2,9 +2,11 @@ name: Watch Mainnet Release
 
 # The mainnet upgrade is executed by the triumvirate signing the multisig
 # proposal submitted by the release train (release-train.yml). This watcher
-# polls the chain; once an upgrade executes, it cuts the release. Stable Python
-# publication has its own completion marker so a later run can retry a failed
-# or partial PyPI upload even when the GitHub release already exists:
+# polls the finalized chain state; once an upgrade executes, it cuts the
+# release. The immutable release tag, protected mainnet mirror, and finalized
+# runtime hash must all identify the same release-train commit. PyPI itself is
+# the terminal state for stable Python publication, so a later run can retry a
+# failed or partial upload:
 #   1. GitHub release v<spec_version>, with the srtool wasm + digest and
 #      multisig call data from the release train attached as assets
 #   2. Docker images via explicit dispatch of docker.yml and
@@ -14,9 +16,10 @@ name: Watch Mainnet Release
 #   3. Python SDK + bittensor-core wheels to PyPI
 #   4. Publishable Rust crates to crates.io
 #   5. Production website/docs deployment on Vercel
-#   6. The `mainnet` branch is force-updated to the release-train commit,
-#      so it always contains the code running on mainnet (the devnet and
-#      testnet branches are updated by release-train.yml at deploy time)
+#   6. Before finalizing the GitHub release, the `mainnet` branch is
+#      force-updated to the release-train commit, so it always contains the
+#      code running on mainnet (the devnet and testnet branches are updated by
+#      release-train.yml at deploy time)
 
 on:
   schedule:
@@ -46,6 +49,10 @@ jobs:
       spec_version: ${{ steps.compare.outputs.spec_version }}
       release_tag: ${{ steps.compare.outputs.release_tag }}
       sha: ${{ steps.compare.outputs.sha }}
+      artifact_id: ${{ steps.compare.outputs.artifact_id }}
+      code_hash: ${{ steps.compare.outputs.code_hash }}
+      sdk_version: ${{ steps.compare.outputs.sdk_version }}
+      core_version: ${{ steps.compare.outputs.core_version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -59,15 +66,27 @@ jobs:
           local_spec=$(grep -Eo 'spec_version: *[0-9]+' runtime/src/lib.rs | head -n 1 | grep -Eo '[0-9]+')
           : ${local_spec:?could not parse spec_version from runtime/src/lib.rs}
 
+          finalized_head=$(curl -sf -H "Content-Type: application/json" \
+            -d '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]}' \
+            "$MAINNET_HTTP" | jq -er \
+              '.result | strings | select(test("^0x[0-9a-f]{64}$"))')
+          runtime_request=$(jq -cn --arg block "$finalized_head" \
+            '{id: 1, jsonrpc: "2.0", method: "state_getRuntimeVersion", params: [$block]}')
           chain_spec=$(curl -sf -H "Content-Type: application/json" \
-            -d '{"id":1,"jsonrpc":"2.0","method":"state_getRuntimeVersion","params":[]}' \
-            "$MAINNET_HTTP" | jq -r '.result.specVersion')
-          : ${chain_spec:?could not fetch chain spec_version}
+            -d "$runtime_request" "$MAINNET_HTTP" | jq -er '.result.specVersion')
+          code_hash_request=$(jq -cn --arg block "$finalized_head" \
+            '{id: 1, jsonrpc: "2.0", method: "state_getStorageHash",
+              params: ["0x3a636f6465", $block]}')
+          chain_code_hash=$(curl -sf -H "Content-Type: application/json" \
+            -d "$code_hash_request" "$MAINNET_HTTP" | jq -er \
+              '.result | strings | select(test("^0x[0-9a-f]{64}$"))')
           [[ "$local_spec" =~ ^[0-9]+$ && "$chain_spec" =~ ^[0-9]+$ ]] \
             || { echo "spec_version values must be integers"; exit 1; }
 
           echo "main spec_version:     $local_spec"
           echo "on-chain spec_version: $chain_spec"
+          echo "finalized block:       $finalized_head"
+          echo "runtime code hash:     $chain_code_hash"
 
           if [ "$chain_spec" -gt "$local_spec" ]; then
             echo "Main does not contain the on-chain runtime yet; refusing to publish."
@@ -76,128 +95,120 @@ jobs:
             exit 0
           fi
           echo "spec_version=$chain_spec" >> "$GITHUB_OUTPUT"
+          echo "code_hash=$chain_code_hash" >> "$GITHUB_OUTPUT"
 
-          # Match both this workflow's tags (v424) and the legacy scheme
-          # inherited from upstream (v3.4.9-424). Pre-releases do not count.
-          release_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 300 \
-            --json tagName,isDraft,isPrerelease \
-            | jq -r --arg exact "v${chain_spec}" --arg suffix "-${chain_spec}" \
-              '.[] |
-               select(.isDraft == false and .isPrerelease == false) |
-               select(.tagName == $exact or (.tagName | endswith($suffix))) |
-               .tagName' \
-            | head -n 1)
-          if [ -n "$release_tag" ]; then
-            echo "GitHub release for spec_version $chain_spec is complete."
-            release_needed=false
-          else
-            release_tag="v${chain_spec}"
-            release_needed=true
+          # Old releases used several tag formats and predate automated stable
+          # Python publication. They are terminal historical state, not inputs
+          # to the immutable release flow below.
+          if [ "$chain_spec" -le 432 ]; then
+            release_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 300 \
+              --json tagName,isDraft,isPrerelease \
+              | jq -r --arg exact "v${chain_spec}" --arg suffix "-${chain_spec}" \
+                '.[] |
+                 select(.isDraft == false and .isPrerelease == false) |
+                 select(.tagName == $exact or (.tagName | endswith($suffix))) |
+                 .tagName' \
+              | head -n 1)
+            : ${release_tag:?historical runtime v${chain_spec} has no final GitHub release}
+            echo "Historical release $release_tag is complete; Python was handled manually."
+            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "python_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          release_tag="v${chain_spec}"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
-          # v432 and earlier predate this marker. Every later
-          # release retries until PyPI succeeds and this exact marker is stored.
-          if [ "$chain_spec" -le 432 ]; then
-            echo "v432 Python publication is handled manually."
-            python_needed=false
-          else
-            marker_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}" \
-              --jq '.assets[] | select(.name == "python-publish-complete.json") | .id' \
-              2>/dev/null | head -n 1 || true)
-            if [ -z "$marker_id" ]; then
-              python_needed=true
-            else
-              gh api -H "Accept: application/octet-stream" \
-                "repos/$GITHUB_REPOSITORY/releases/assets/$marker_id" \
-                > /tmp/python-publish-complete.json
-              tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/${release_tag}" --jq '.sha')
-              jq -e --arg sha "$tag_sha" --argjson spec "$chain_spec" \
-                '.schema == 1 and .spec_version == $spec and .commit == $sha' \
-                /tmp/python-publish-complete.json >/dev/null \
-                || { echo "invalid Python publish marker for v${chain_spec}"; exit 1; }
-              echo "Stable Python packages are already published."
-              python_needed=false
+          # The release train reserves this exact lightweight tag before
+          # submitting the multisig. Never accept an ambiguously named branch.
+          tag_json=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/tags/${release_tag}")
+          tag_type=$(jq -er '.object.type' <<<"$tag_json")
+          [ "$tag_type" = commit ] \
+            || { echo "release tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+          release_sha=$(jq -er '.object.sha' <<<"$tag_json")
+          [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "release tag did not resolve to a Git commit"; exit 1; }
+          status=$(gh api \
+            "repos/$GITHUB_REPOSITORY/compare/${release_sha}...main" --jq '.status')
+          case "$status" in
+            ahead|identical) ;;
+            *) echo "tagged commit $release_sha is not an ancestor of main"; exit 1 ;;
+          esac
+          echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+
+          release_needed=true
+          release_json=""
+          if release_json=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}" 2>/dev/null); then
+            is_draft=$(jq -er '.draft | booleans' <<<"$release_json")
+            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            if [ "$is_draft" = false ] && [ "$is_prerelease" = false ]; then
+              release_needed=false
+              target_sha=$(jq -er \
+                '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
+                <<<"$release_json")
+              [ "$target_sha" = "$release_sha" ] \
+                || { echo "release target $target_sha does not match tag $release_sha"; exit 1; }
             fi
           fi
-          echo "release_needed=$release_needed" >> "$GITHUB_OUTPUT"
-          echo "python_needed=$python_needed" >> "$GITHUB_OUTPUT"
 
-          # A valid marker is the durable terminal state. Resolve the expiring
-          # workflow artifact only while release or Python work is pending.
-          if [ "$release_needed" = false ] && [ "$python_needed" = false ]; then
-            exit 0
-          fi
-
-          # The final release carries pending-release.json copied from the
-          # provenance-gated workflow artifact. Use that durable manifest for
-          # Python-only retries, and fail closed if the release target or tag
-          # has moved away from its verified commit.
+          # Once final, the independently protected mainnet branch must point
+          # to the tag before any downstream publication is considered.
           if [ "$release_needed" = false ]; then
-            release_json=$(gh api \
-              "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}")
-            manifest_id=$(jq -r \
-              '.assets[] | select(.name == "pending-release.json") | .id' \
-              <<<"$release_json" | head -n 1)
-            : ${manifest_id:?release $release_tag has no pending-release.json provenance asset}
-            gh api -H "Accept: application/octet-stream" \
-              "repos/$GITHUB_REPOSITORY/releases/assets/${manifest_id}" \
-              > /tmp/released-pending-release.json
-
-            release_sha=$(jq -er \
-              '.commit | strings | select(test("^[0-9a-f]{40}$"))' \
-              /tmp/released-pending-release.json)
-            manifest_spec=$(jq -er '.expected_spec_version | numbers' \
-              /tmp/released-pending-release.json)
-            [ "$manifest_spec" = "$chain_spec" ] \
-              || { echo "release manifest expects spec $manifest_spec, chain runs $chain_spec"; exit 1; }
-
-            target_sha=$(jq -er \
-              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
-              <<<"$release_json")
-            tag_sha=$(gh api \
-              "repos/$GITHUB_REPOSITORY/commits/${release_tag}" --jq '.sha')
-            [ "$release_sha" = "$target_sha" ] \
-              || { echo "release target $target_sha does not match manifest commit $release_sha"; exit 1; }
-            [ "$release_sha" = "$tag_sha" ] \
-              || { echo "tag $release_tag moved from manifest commit $release_sha to $tag_sha"; exit 1; }
-
-            # The mainnet mirror is moved by the release job through its
-            # protected deploy key only after the on-chain upgrade executes.
-            # Unlike release metadata, it is an independent trust anchor.
-            mainnet_sha=$(gh api \
-              "repos/$GITHUB_REPOSITORY/commits/mainnet" --jq '.sha')
+            mainnet_json=$(gh api \
+              "repos/$GITHUB_REPOSITORY/git/ref/heads/mainnet")
+            mainnet_type=$(jq -er '.object.type' <<<"$mainnet_json")
+            [ "$mainnet_type" = commit ] \
+              || { echo "protected mainnet mirror did not resolve to a commit"; exit 1; }
+            mainnet_sha=$(jq -er '.object.sha' <<<"$mainnet_json")
             [ "$release_sha" = "$mainnet_sha" ] \
               || { echo "protected mainnet mirror $mainnet_sha does not match release commit $release_sha"; exit 1; }
-
-            status=$(gh api \
-              "repos/$GITHUB_REPOSITORY/compare/${release_sha}...main" --jq '.status')
-            case "$status" in
-              ahead|identical) ;;
-              *) echo "released commit $release_sha is not an ancestor of main"; exit 1 ;;
-            esac
-
-            echo "Retrying Python publication from $release_tag at $release_sha"
-            echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
-            exit 0
           fi
 
-          # Resolve what actually runs on chain, not HEAD: main can advance
-          # while a multisig waits for its final signature. The provenance gate
-          # admits artifacts only from release-train.yml pushes to main.
-          artifact_id=$(.github/scripts/resolve-release-artifact.sh "$chain_spec")
-          : ${artifact_id:?no trustworthy mainnet-upgrade-${chain_spec} artifact found — did the release train run?}
-          rm -rf /tmp/release-artifact /tmp/release-artifact.zip
-          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${artifact_id}/zip" > /tmp/release-artifact.zip
-          unzip -o /tmp/release-artifact.zip -d /tmp/release-artifact
-          release_sha=$(jq -r '.commit' /tmp/release-artifact/pending-release.json)
-          : ${release_sha:?pending-release.json missing commit field}
-          expected_spec=$(jq -er '.expected_spec_version | numbers' \
-            /tmp/release-artifact/pending-release.json)
-          [ "$expected_spec" = "$chain_spec" ] \
-            || { echo "artifact expects spec $expected_spec, chain runs $chain_spec"; exit 1; }
-          echo "Release train commit: $release_sha"
-          echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+          # Derive the exact stable Python versions from the immutable tag,
+          # never from the moving default branch or mutable release metadata.
+          gh api -H "Accept: application/vnd.github.raw+json" \
+            "repos/$GITHUB_REPOSITORY/contents/sdk/python/pyproject.toml?ref=${release_sha}" \
+            > /tmp/release-sdk-pyproject.toml
+          gh api -H "Accept: application/vnd.github.raw+json" \
+            "repos/$GITHUB_REPOSITORY/contents/sdk/bittensor-core-py/pyproject.toml?ref=${release_sha}" \
+            > /tmp/release-core-pyproject.toml
+          versions=$(python3 .github/scripts/release-python-versions.py \
+            /tmp/release-sdk-pyproject.toml /tmp/release-core-pyproject.toml)
+          sdk_version=$(jq -er '.sdk' <<<"$versions")
+          core_version=$(jq -er '.core' <<<"$versions")
+          echo "sdk_version=$sdk_version" >> "$GITHUB_OUTPUT"
+          echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
+
+          if [ "$release_needed" = true ]; then
+            # The exact artifact is needed only until its bytes have been
+            # verified and attached to the final release.
+            artifact_id=$(.github/scripts/resolve-release-artifact.sh \
+              "$chain_spec" "$release_sha" "$chain_code_hash")
+            : ${artifact_id:?no artifact matches the immutable tag and finalized runtime}
+            echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
+            python_needed=true
+          elif python3 .github/scripts/check-python-release.py \
+              --sdk-version "$sdk_version" \
+              --core-version "$core_version" \
+              --repository "$GITHUB_REPOSITORY"; then
+            echo "Stable Python packages are complete on PyPI."
+            python_needed=false
+          else
+            python_status=$?
+            if [ "$python_status" -eq 1 ]; then
+              echo "Stable Python publication is incomplete and will be retried."
+              python_needed=true
+            else
+              echo "PyPI could not provide authoritative release state."
+              exit "$python_status"
+            fi
+          fi
+
+          echo "release_needed=$release_needed" >> "$GITHUB_OUTPUT"
+          echo "python_needed=$python_needed" >> "$GITHUB_OUTPUT"
 
   release:
     name: Cut GitHub release
@@ -229,12 +240,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           spec="${{ needs.check.outputs.spec_version }}"
-          artifact_id=$(.github/scripts/resolve-release-artifact.sh "$spec")
-          : ${artifact_id:?no trustworthy mainnet-upgrade-${spec} artifact found — did the release train run?}
+          artifact_id="${{ needs.check.outputs.artifact_id }}"
+          : ${artifact_id:?check job did not resolve a release artifact}
           gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${artifact_id}/zip" > artifact.zip
+          python3 .github/scripts/verify-release-artifact.py artifact.zip \
+            --spec "$spec" \
+            --commit "${{ needs.check.outputs.sha }}" \
+            --code-hash "${{ needs.check.outputs.code_hash }}"
           mkdir -p wasm
           unzip -o artifact.zip -d wasm
           ls -la wasm
+
+      # Mirror first. If this protected push fails, the proposal stays a
+      # pre-release and the next scheduled watcher run can retry safely.
+      - name: Point mainnet branch at released commit
+        run: |
+          release_sha="${{ needs.check.outputs.sha }}"
+          git push --force origin "${release_sha}:refs/heads/mainnet"
+          mirrored_sha=$(git ls-remote origin refs/heads/mainnet | awk '{print $1}')
+          [ "$mirrored_sha" = "$release_sha" ] \
+            || { echo "mainnet mirror is $mirrored_sha, expected $release_sha"; exit 1; }
 
       - name: Create or promote release with runtime assets
         env:
@@ -251,43 +276,51 @@ jobs:
           )
           [ -f wasm/upgrade-manifest.json ] && assets+=(wasm/upgrade-manifest.json)
 
-          # The release train published the proposal as a pre-release at this
-          # tag; the upgrade has now executed on chain, so promote it to the
-          # final release. Assets are re-uploaded from the provenance-gated
-          # workflow artifact so the release always carries the trusted bytes.
-          # Fall back to creating the release for trains that predate the
-          # proposal pre-release flow.
-          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" --jq '.object.sha' || true)
-            if [ -n "$tag_sha" ] && [ "$tag_sha" != "$RELEASE_SHA" ]; then
-              echo "tag $tag points at $tag_sha but the released commit is $RELEASE_SHA;"
-              echo "the proposal pre-release does not match the executed upgrade — resolve manually."
-              exit 1
-            fi
-            notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f tag_name="$tag" -f target_commitish="$RELEASE_SHA" --jq '.body' || true)
-            gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
-            gh release edit "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "Runtime ${SPEC_VERSION}" \
-              ${notes:+--notes "$notes"} \
-              --prerelease=false \
-              --latest
+          tag_json=$(gh api \
+            "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag")
+          tag_type=$(jq -er '.object.type' <<<"$tag_json")
+          [ "$tag_type" = commit ] \
+            || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+          tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
+          [ "$tag_sha" = "$RELEASE_SHA" ] \
+            || { echo "tag $tag points at $tag_sha, expected $RELEASE_SHA"; exit 1; }
+
+          # The release train published the proposal as a pre-release. Assets
+          # are re-uploaded from the exact artifact verified against finalized
+          # on-chain bytes, then the same release is promoted. A missing
+          # pre-release is recoverable, but an existing final release is not
+          # rewritten by a retry.
+          if release_json=$(gh api \
+              "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null); then
+            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            [ "$is_prerelease" = true ] \
+              || { echo "release $tag is already final; refusing to rewrite it"; exit 1; }
+            target_sha=$(jq -er \
+              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
+              <<<"$release_json")
+            [ "$target_sha" = "$RELEASE_SHA" ] \
+              || { echo "release target $target_sha does not match $RELEASE_SHA"; exit 1; }
           else
+            # Create only a pre-release here. If a later asset upload fails,
+            # the next watcher run can safely resume instead of finding an
+            # incomplete final release.
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
               --target "$RELEASE_SHA" \
-              --title "Runtime ${SPEC_VERSION}" \
-              --generate-notes \
-              "${assets[@]}"
+              --prerelease \
+              --title "Runtime ${SPEC_VERSION} (finalizing)" \
+              --notes "Runtime finalized on chain; release assets are being attached."
           fi
 
-      # Mirror: the mainnet branch always points at the code now running on
-      # mainnet (the release-train commit, not HEAD of main). Pushed over
-      # SSH with the mirror deploy key configured by the checkout above,
-      # the only actor allowed past the network-branch-mirrors ruleset.
-      - name: Point mainnet branch at released commit
-        run: git push --force origin "${{ needs.check.outputs.sha }}:refs/heads/mainnet"
+          notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$tag" -f target_commitish="$RELEASE_SHA" --jq '.body' || true)
+          gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
+          gh release edit "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Runtime ${SPEC_VERSION}" \
+            ${notes:+--notes "$notes"} \
+            --prerelease=false \
+            --latest
 
   publish-docker:
     name: Dispatch Docker image publishing
@@ -333,7 +366,7 @@ jobs:
     environment: mainnet
     permissions:
       id-token: write
-      contents: write # attach the durable completion marker to the release
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -374,6 +407,9 @@ jobs:
       # Refuse to publish development or release-candidate artifacts from the
       # stable channel. Also require the complete SDK/core platform set.
       - name: Verify stable artifacts
+        env:
+          EXPECTED_SDK_VERSION: ${{ needs.check.outputs.sdk_version }}
+          EXPECTED_CORE_VERSION: ${{ needs.check.outputs.core_version }}
         run: |
           sdk_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/python/pyproject.toml | head -n 1)
           core_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
@@ -383,6 +419,10 @@ jobs:
             || { echo "SDK version is not stable: $sdk_version"; exit 1; }
           [[ "$core_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || { echo "core version is not stable: $core_version"; exit 1; }
+          [ "$sdk_version" = "$EXPECTED_SDK_VERSION" ] \
+            || { echo "SDK version $sdk_version != expected $EXPECTED_SDK_VERSION"; exit 1; }
+          [ "$core_version" = "$EXPECTED_CORE_VERSION" ] \
+            || { echo "core version $core_version != expected $EXPECTED_CORE_VERSION"; exit 1; }
           ls -la dist
           test -f "dist/bittensor-${sdk_version}-py3-none-any.whl"
           test -f "dist/bittensor-${sdk_version}.tar.gz"
@@ -406,23 +446,30 @@ jobs:
           uv publish --trusted-publishing always \
             --check-url https://pypi.org/simple/ dist/*
 
-      # This is the only durable state for Python publication. It is written
-      # after uv reports that every distribution was uploaded or already exists.
-      - name: Record successful Python publication
+      # PyPI is the authoritative terminal state. Its JSON and Integrity APIs
+      # can lag an upload briefly, so poll for the complete SDK/core platform
+      # set and the trusted-publisher attestation on every file.
+      - name: Verify complete publication on PyPI
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_SHA: ${{ needs.check.outputs.sha }}
-          SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          SDK_VERSION: ${{ needs.check.outputs.sdk_version }}
+          CORE_VERSION: ${{ needs.check.outputs.core_version }}
         run: |
-          jq -n \
-            --arg sha "$RELEASE_SHA" \
-            --argjson spec "$SPEC_VERSION" \
-            --arg workflow_run "$GITHUB_RUN_ID" \
-            '{schema: 1, spec_version: $spec, commit: $sha, workflow_run: $workflow_run}' \
-            > python-publish-complete.json
-          gh release upload "${{ needs.check.outputs.release_tag }}" \
-            --repo "$GITHUB_REPOSITORY" --clobber \
-            python-publish-complete.json
+          for attempt in $(seq 1 12); do
+            status=0
+            python3 .github/scripts/check-python-release.py \
+              --sdk-version "$SDK_VERSION" \
+              --core-version "$CORE_VERSION" \
+              --repository "$GITHUB_REPOSITORY" || status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 12 ]; then
+              echo "PyPI state not authoritative yet (attempt $attempt/12); retrying."
+              sleep 10
+            fi
+          done
+          echo "PyPI did not expose the complete attested release within two minutes."
+          exit 1
 
   publish-crates:
     name: Publish Rust crates to crates.io

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -162,6 +162,14 @@ jobs:
             [ "$release_sha" = "$tag_sha" ] \
               || { echo "tag $release_tag moved from manifest commit $release_sha to $tag_sha"; exit 1; }
 
+            # The mainnet mirror is moved by the release job through its
+            # protected deploy key only after the on-chain upgrade executes.
+            # Unlike release metadata, it is an independent trust anchor.
+            mainnet_sha=$(gh api \
+              "repos/$GITHUB_REPOSITORY/commits/mainnet" --jq '.sha')
+            [ "$release_sha" = "$mainnet_sha" ] \
+              || { echo "protected mainnet mirror $mainnet_sha does not match release commit $release_sha"; exit 1; }
+
             status=$(gh api \
               "repos/$GITHUB_REPOSITORY/compare/${release_sha}...main" --jq '.status')
             case "$status" in

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -94,11 +94,11 @@ GitHub release. The marker is written only after PyPI accepts every SDK and
 `bittensor-core` distribution, so a failed or partial upload is retried on the
 next watcher run even if the GitHub release already exists or the release-train
 artifact has expired. Retries use the release's provenance manifest and require
-its commit to still match both the release target and tag. The SDK's committed
-`X.Y.Z.dev0` version is stamped to `X.Y.Z` for this build. The release train
-rejects a base SDK or core version that already exists on PyPI before
-publishing release candidates. The already-deployed v432 release predates the
-marker and is recovered manually.
+its commit to still match the release target, tag, and protected `mainnet`
+mirror. The SDK's committed `X.Y.Z.dev0` version is stamped to `X.Y.Z` for this
+build. The release train rejects a base SDK or core version that already exists
+on PyPI before publishing release candidates. The already-deployed v432 release
+predates the marker and is recovered manually.
 
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -93,10 +93,12 @@ Stable Python publication has an independent completion marker attached to the
 GitHub release. The marker is written only after PyPI accepts every SDK and
 `bittensor-core` distribution, so a failed or partial upload is retried on the
 next watcher run even if the GitHub release already exists or the release-train
-artifact has expired. The SDK's committed `X.Y.Z.dev0` version is stamped to
-`X.Y.Z` for this build. The release train rejects a base SDK or core version
-that already exists on PyPI before publishing release candidates. The
-already-deployed v432 release predates the marker and is recovered manually.
+artifact has expired. Retries use the release's provenance manifest and require
+its commit to still match both the release target and tag. The SDK's committed
+`X.Y.Z.dev0` version is stamped to `X.Y.Z` for this build. The release train
+rejects a base SDK or core version that already exists on PyPI before
+publishing release candidates. The already-deployed v432 release predates the
+marker and is recovered manually.
 
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -62,11 +62,13 @@ independent image builds run.
 
 ### The mainnet multisig ceremony
 
-CI never upgrades mainnet directly. The train's final job submits a **multisig
-proposal**: the CI key is one half of a 2-of-2 deployment multisig that holds
-a `SudoUncheckedSetCode` proxy on the sudo key. The triumvirate then approves
-the proposal 2-of-3 **out-of-band** — no GitHub credential can unilaterally
-change the mainnet runtime. Until they sign, nothing happens on chain.
+CI never upgrades mainnet directly. Before any on-chain action, the train
+reserves the immutable `v<spec_version>` tag at the exact source commit. Its
+final job then submits a **multisig proposal**: the CI key is one half of a
+2-of-2 deployment multisig that holds a `SudoUncheckedSetCode` proxy on the
+sudo key. The triumvirate then approves the proposal 2-of-3 **out-of-band** —
+no GitHub credential can unilaterally change the mainnet runtime. Until they
+sign, nothing happens on chain.
 
 For rehearsal, the `mainnet-clone` PR label spins up a live clone of mainnet
 running your runtime with a public endpoint
@@ -75,8 +77,10 @@ running your runtime with a public endpoint
 ## The release watcher
 
 `watch-mainnet-release.yml` polls mainnet every 10 minutes. When an upgrade
-executes, it resolves the release-train artifact for the `spec_version`
-actually running on chain and cuts the release:
+executes, it resolves the release-train artifact whose commit matches the
+immutable tag and whose runtime hash matches the finalized on-chain `:code`.
+It moves the protected `mainnet` mirror to that exact commit before cutting
+the release:
 
 1. **GitHub release** `v<spec_version>`
 2. **Production Docker images** tagged `v<spec_version>` and `latest`
@@ -89,16 +93,18 @@ actually running on chain and cuts the release:
 This ordering means the release always reflects what is *actually running on
 mainnet*, not what was merged.
 
-Stable Python publication has an independent completion marker attached to the
-GitHub release. The marker is written only after PyPI accepts every SDK and
-`bittensor-core` distribution, so a failed or partial upload is retried on the
-next watcher run even if the GitHub release already exists or the release-train
-artifact has expired. Retries use the release's provenance manifest and require
-its commit to still match the release target, tag, and protected `mainnet`
-mirror. The SDK's committed `X.Y.Z.dev0` version is stamped to `X.Y.Z` for this
-build. The release train rejects a base SDK or core version that already exists
-on PyPI before publishing release candidates. The already-deployed v432 release
-predates the marker and is recovered manually.
+PyPI is the terminal state for stable Python publication. The watcher requires
+the SDK wheel and source distribution plus the full `bittensor-core` Linux and
+macOS wheel matrix and source distribution. Every file must carry a PEP 740
+attestation from this repository's mainnet release workflow. A failed or
+partial upload is retried on the next watcher run even if the GitHub release
+already exists or the release-train artifact has expired. Retries require the
+release target, immutable tag, protected `mainnet` mirror, and finalized
+runtime bytes to agree. The SDK's committed `X.Y.Z.dev0` version is stamped to
+`X.Y.Z` for this build. The release train rejects a base SDK or core version
+that already exists on PyPI before publishing release candidates. Releases
+through v432 predate automated stable Python publication and are handled as
+historical state.
 
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -92,9 +92,11 @@ mainnet*, not what was merged.
 Stable Python publication has an independent completion marker attached to the
 GitHub release. The marker is written only after PyPI accepts every SDK and
 `bittensor-core` distribution, so a failed or partial upload is retried on the
-next watcher run even if the GitHub release already exists. The SDK's committed
-`X.Y.Z.dev0` version is stamped to `X.Y.Z` for this build. The already-deployed
-v432 release predates the marker and is recovered manually.
+next watcher run even if the GitHub release already exists or the release-train
+artifact has expired. The SDK's committed `X.Y.Z.dev0` version is stamped to
+`X.Y.Z` for this build. The release train rejects a base SDK or core version
+that already exists on PyPI before publishing release candidates. The
+already-deployed v432 release predates the marker and is recovered manually.
 
 The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
 because releases created with the default `GITHUB_TOKEN` do not emit another

--- a/sdk/bittensor-core-py/pyproject.toml
+++ b/sdk/bittensor-core-py/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "bittensor-core"
 # Static (not read from Cargo.toml) so the release train can stamp PEP 440
 # rc/dev suffixes that cargo's semver would reject.
-version = "0.1.0"
+version = "0.1.1"
 description = "The chain-defined compute core for Bittensor clients: sp-core keys, keyfiles, drand timelock, ML-KEM, SCALE codec, and RFC-0078 metadata digest, built from the bittensor monorepo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bittensor"
-version = "11.0.0.dev0"
+version = "11.0.1.dev0"
 description = "A lean Python SDK (import bittensor) and CLI (btcli) for the Bittensor chain."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -18,7 +18,7 @@ dependencies = [
     # Keys, keyfiles, timelock, ML-KEM crypto, and the SCALE codec/runtime
     # engine: the in-repo Rust core, built against the same crate revisions
     # as the runtime.
-    "bittensor-core>=0.1.0,<0.2.0",
+    "bittensor-core>=0.1.1,<0.2.0",
     # `btcli` terminal UI. The CLI is a first-class part of the package, so
     # its dependencies are unconditional.
     "typer>=0.12.0",

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+from importlib.metadata import version as package_version
 
 import pytest
 from typer.testing import CliRunner
@@ -77,7 +78,7 @@ class TestOffline:
     def test_version(self):
         result = invoke("--version")
         assert result.exit_code == 0
-        assert "11.0.0" in result.output
+        assert result.output.strip() == package_version("bittensor")
 
     def test_tools_catalog(self):
         result = invoke("tools")

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "bittensor"
-version = "11.0.0.dev0"
+version = "11.0.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bittensor-core" },
@@ -137,7 +137,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.0"
+version = "0.1.1"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]


### PR DESCRIPTION
## Summary

- Move the v438 stable package bases to unused versions: `bittensor 11.0.1.dev0` (published as `11.0.1`) and `bittensor-core 0.1.1`.
- Fail the release train before RC publication if either intended stable version already exists on PyPI.
- Reserve the exact lightweight `v<spec>` Git tag before submitting the on-chain proposal. Every later lookup uses the explicit tag ref, so a same-named branch cannot substitute for the immutable release identity.
- Bind release promotion to one finalized block: its runtime spec version and `:code` hash must match the tagged release-train artifact and its embedded manifests.
- Accept artifacts only from this repository's release-train workflow on `main`, from the exact tagged commit, for both push and manual workflow-dispatch runs.
- Treat PyPI itself as the durable completion state. A completed release must contain exactly the expected SDK wheel/sdist and four `cp310-abi3` core wheels plus core sdist; every file must be non-yanked and carry matching trusted-publisher provenance from this workflow and the `mainnet` environment.
- Require the final release target, exact tag, and protected `mainnet` branch ref to identify the same commit before a Python-only retry.

## Why

PyPI versions and uploaded filenames are immutable. The previous stable bases are already occupied, and the existing watcher could either attempt to publish development-version metadata or lose retry state when its release-train artifact expired.

The release now has immutable, independently checked inputs:

1. The release train reserves `v<spec>` before any on-chain side effect.
2. Once the runtime upgrade finalizes, the watcher reads the spec version and runtime code hash from the same finalized block.
3. It resolves the exact tag and the release-train artifact produced from that commit.
4. The artifact verifier checks its repository/workflow provenance, manifests, commit, spec version, runtime SHA-256 digest, and BLAKE2b-256 hash against finalized `:code`.
5. The watcher moves the protected `mainnet` mirror to that commit and promotes the matching GitHub release.
6. Stable Python publication retries until PyPI exposes the complete, exact, trusted-publisher-attested file set. No mutable GitHub completion marker controls the result.

An incomplete upload is retryable. Unexpected, yanked, unattested, or incorrectly published files fail closed.

## Rollout

Merge this change into `v438-release` before that branch reaches `main`.

The merge to `main` starts the release train and publishes only release candidates after the testnet stage. It does not publish stable packages.

After mainnet finalizes runtime spec 438, the watcher promotes GitHub release `v438` and publishes:

- `bittensor==11.0.1`
- `bittensor-core==0.1.1`

If publication is partial, a later watcher run rechecks PyPI and uploads the missing artifacts with `skip-existing`. It stops only after all seven expected files and their trusted-publisher attestations verify.

## Verification

- `actionlint` on both modified release workflows
- shell syntax validation for the artifact resolver
- Python compile, Ruff formatting, and Ruff lint checks for all new release helpers
- adversarial file-set tests covering missing, unexpected, duplicate-platform, yanked, and incorrectly attested distributions
- live read-only verification of all seven files and attestations for the current stable SDK/core release
- live read-only resolution and byte verification of an existing manually dispatched release-train artifact against finalized runtime data
- exact Git tag and protected branch-ref checks against existing repository refs
- `uv lock --check`
- SDK distribution preparation test
- full SDK suite: 984 passed, 1 skipped
