### PR TITLE
Fix release workflow boolean parsing

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -669,7 +669,9 @@ jobs:
           )
           if release_json=$(gh api \
               "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null); then
-            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            is_prerelease=$(jq -er \
+              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
+              <<<"$release_json")
             [ "$is_prerelease" = true ] \
               || { echo "release $tag is already final; refusing to overwrite it"; exit 1; }
             target_sha=$(jq -er \

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -142,8 +142,12 @@ jobs:
           release_json=""
           if release_json=$(gh api \
               "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}" 2>/dev/null); then
-            is_draft=$(jq -er '.draft | booleans' <<<"$release_json")
-            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            is_draft=$(jq -er \
+              '.draft | if type == "boolean" then tostring else error("draft must be boolean") end' \
+              <<<"$release_json")
+            is_prerelease=$(jq -er \
+              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
+              <<<"$release_json")
             if [ "$is_draft" = false ] && [ "$is_prerelease" = false ]; then
               release_needed=false
               target_sha=$(jq -er \
@@ -292,7 +296,9 @@ jobs:
           # rewritten by a retry.
           if release_json=$(gh api \
               "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null); then
-            is_prerelease=$(jq -er '.prerelease | booleans' <<<"$release_json")
+            is_prerelease=$(jq -er \
+              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
+              <<<"$release_json")
             [ "$is_prerelease" = true ] \
               || { echo "release $tag is already final; refusing to rewrite it"; exit 1; }
             target_sha=$(jq -er \


### PR DESCRIPTION
## Summary

- Parse GitHub release `draft` and `prerelease` fields without treating the valid JSON value `false` as a command failure.
- Apply the same strict parsing to every equivalent release-state read in the watcher and release train.
- Continue rejecting missing or non-boolean release fields.

## Root cause

The workflows used `jq -e` directly on a JSON boolean. `jq -e` exits non-zero when its result is `false`, so `set -e` terminated the watcher while reading the valid v438 prerelease state (`draft: false`, `prerelease: true`).

The watcher had already confirmed finalized runtime spec 438 and its runtime code hash, but stopped before moving the protected mirror, promoting the GitHub release, or publishing any packages.

The corrected expression first validates that the field is a boolean and then converts it to the string `true` or `false`. Both valid values therefore exit successfully, while malformed API responses still fail closed.

## Rollout safety

This PR changes only workflow files under `.github/workflows/`. Those paths do not match the release train's `push` path filter, so merging this PR into `main` will not start another runtime release train.

After merge, manually dispatching **Watch Mainnet Release** (or waiting for its next schedule) will continue the existing v438 release.

## Verification

- Parsed the live v438 prerelease response: `draft=false`, `prerelease=true`.
- Verified both valid boolean values exit successfully.
- Verified missing and string-valued fields fail.
- `actionlint` passed for both changed workflows.
- `git diff --check` passed.
- Confirmed the changed paths do not match any release-train push path.
