### PR TITLE
Expose a public read-only substrate RPC view

### DIFF
--- a/docs/concepts/client.mdx
+++ b/docs/concepts/client.mdx
@@ -74,6 +74,31 @@ info = await client.runtime(bt.runtime_api.NeuronInfoRuntimeApi.get_neurons_lite
 The `bt.storage`, `bt.constants`, `bt.runtime_api`, and `bt.calls` modules
 are generated from chain metadata and cover the entire runtime surface.
 
+## Low-level read-only RPC
+
+For standard node RPCs that are not represented by the generated runtime
+surface, `client.substrate` provides one controlled method:
+
+```python
+# Async
+async with bt.Subtensor("test") as client:
+    health = await client.substrate.rpc_request("system_health")
+
+# Blocking (connects lazily)
+sub = bt.Subtensor("test")
+health = sub.substrate.rpc_request("system_health")
+```
+
+`rpc_request()` returns the JSON-RPC `result` value. It accepts an explicit
+allowlist of standard read-only `chain_*`, `state_*`, account-index, and system
+health methods. Subscriptions, transaction RPCs, and unclassified custom
+methods are rejected before anything is sent to the node.
+
+Unlike v10, `client.substrate` is not the underlying connection. It does not
+expose `.raw`, websocket sessions, caches, signing, or submission helpers.
+Submit mutations through `execute(...)` or `submit_call(...)`; `_substrate` and
+everything under `bittensor._transport` remain private implementation details.
+
 ## Typed results: the metagraph
 
 The richest typed result is the metagraph — a whole subnet as one object.

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -159,6 +159,26 @@ snap = await client.at(block)          # Snapshot: same read surface, one block
 bal = await snap.balances.get("5F...")
 ```
 
+### Low-level Substrate RPC
+
+In v10, `.substrate` exposed the underlying connection and its full transport
+surface. Starting in v11.0.2, the name exists again as a controlled read-only
+view:
+
+```python
+# Blocking
+health = bt.Subtensor("test").substrate.rpc_request("system_health")
+
+# Async
+async with bt.Subtensor("test") as client:
+    health = await client.substrate.rpc_request("system_health")
+```
+
+Only explicitly approved standard read RPCs are accepted. There is no `.raw`
+connection, websocket session, signing helper, subscription API, or direct
+transaction submission compatibility with v10. Use `execute(...)` or
+`submit_call(...)` for mutations.
+
 ## Environment variables and configuration
 
 | v10 SDK / v9 CLI | v11 |

--- a/sdk/bittensor-core-py/pyproject.toml
+++ b/sdk/bittensor-core-py/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "bittensor-core"
 # Static (not read from Cargo.toml) so the release train can stamp PEP 440
 # rc/dev suffixes that cargo's semver would reject.
-version = "0.1.1"
+version = "0.1.2"
 description = "The chain-defined compute core for Bittensor clients: sp-core keys, keyfiles, drand timelock, ML-KEM, SCALE codec, and RFC-0078 metadata digest, built from the bittensor monorepo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -191,6 +191,23 @@ async def main():
 asyncio.run(main())
 ```
 
+For low-level standard node reads, `substrate.rpc_request()` returns the
+JSON-RPC `result`:
+
+```python
+# Blocking (connects lazily)
+health = bt.Subtensor("test").substrate.rpc_request("system_health")
+
+# Async
+async with bt.Subtensor("test") as client:
+    health = await client.substrate.rpc_request("system_health")
+```
+
+This is an allowlisted, read-only view, not the raw v10 Substrate connection.
+Subscriptions, transaction RPCs, and unknown custom methods are rejected
+before network dispatch. It exposes no `.raw`, websocket, signing, or
+submission helpers; use `execute(...)` or `submit_call(...)` for mutations.
+
 ### Writing: intents, plan, execute
 
 A mutation is an **intent** — a serializable dataclass. `plan` previews it

--- a/sdk/python/bittensor/__init__.py
+++ b/sdk/python/bittensor/__init__.py
@@ -39,7 +39,7 @@ import logging as _logging
 from . import evm, http_auth, intents, reads, timelock, wallets
 from ._generated import calls, constants, storage
 from ._generated import runtime_apis as runtime_api
-from ._substrate import RpcSubstrate, Substrate
+from ._substrate import ReadOnlySubstrate, RpcSubstrate, Substrate
 from ._subtensor import Subtensor, close_shared_clients, set_weights
 from ._transport.contract import SigningContext, UnsignedExtrinsic
 from .balance import Balance, UnitMismatchError, alpha, rao, tao
@@ -128,6 +128,7 @@ __all__ = [
     # Client(substrate=...) accepts any Substrate implementation.
     "Substrate",
     "RpcSubstrate",
+    "ReadOnlySubstrate",
     "Snapshot",
     "BlockHeader",
     "BlockInfo",

--- a/sdk/python/bittensor/_substrate.py
+++ b/sdk/python/bittensor/_substrate.py
@@ -15,7 +15,16 @@ network at all).
 from __future__ import annotations
 
 import asyncio
-from typing import Any, AsyncIterator, Awaitable, Callable, Optional, Protocol, TypeVar
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Optional,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
 
 from ._transport import SubstrateConnection
 from ._transport.contract import (
@@ -27,6 +36,7 @@ from ._transport.contract import (
 from ._transport.errors import StateDiscardedError, SubstrateRequestException
 from .balance import Balance
 from .result import (
+    BittensorError,
     ChainError,
     ConnectionNotReady,
     ExtrinsicResult,
@@ -35,6 +45,78 @@ from .result import (
 from .settings import DEFAULT_ERA_PERIOD, SS58_FORMAT, explorer_extrinsic_url
 
 T = TypeVar("T")
+
+# Public low-level access is deliberately an exact allowlist. Prefix checks
+# would make newly-added or node-specific RPC methods public by accident.
+_READ_ONLY_RPC_METHODS = frozenset(
+    {
+        "account_nextIndex",
+        "author_hasKey",
+        "author_hasSessionKeys",
+        "author_pendingExtrinsics",
+        "beefy_getFinalizedHead",
+        "chain_getBlock",
+        "chain_getBlockHash",
+        "chain_getFinalizedHead",
+        "chain_getHead",
+        "chain_getHeader",
+        "childstate_getKeys",
+        "childstate_getKeysPaged",
+        "childstate_getReadProof",
+        "childstate_getStorage",
+        "childstate_getStorageHash",
+        "childstate_getStorageSize",
+        "grandpa_proveFinality",
+        "grandpa_roundState",
+        "mmr_generateProof",
+        "mmr_root",
+        "payment_queryFeeDetails",
+        "payment_queryInfo",
+        "rpc_methods",
+        "state_call",
+        "state_getKeys",
+        "state_getKeysPaged",
+        "state_getMetadata",
+        "state_getPairs",
+        "state_getReadProof",
+        "state_getRuntimeVersion",
+        "state_getStorage",
+        "state_getStorageAt",
+        "state_getStorageHash",
+        "state_getStorageSize",
+        "state_queryStorage",
+        "state_queryStorageAt",
+        "sync_state_genSyncSpec",
+        "system_accountNextIndex",
+        "system_chain",
+        "system_chainType",
+        "system_dryRun",
+        "system_health",
+        "system_localListenAddresses",
+        "system_localPeerId",
+        "system_name",
+        "system_nodeRoles",
+        "system_peers",
+        "system_properties",
+        "system_syncState",
+        "system_version",
+    }
+)
+
+
+def _require_read_only_rpc_method(method: str) -> None:
+    if not isinstance(method, str) or method not in _READ_ONLY_RPC_METHODS:
+        raise BittensorError(
+            f"RPC method {method!r} is not an approved read-only method. "
+            "Use client.execute(...) or client.submit_call(...) for transactions."
+        )
+
+
+@runtime_checkable
+class _RpcRequester(Protocol):
+    """Optional capability for injected backends that support low-level reads."""
+
+    async def rpc_request(self, method: str, params: Optional[list] = None) -> Any: ...
 
 
 class Substrate(Protocol):
@@ -246,6 +328,30 @@ class Substrate(Protocol):
         ...
 
 
+class ReadOnlySubstrate:
+    """Controlled low-level RPC view exposed as :attr:`Client.substrate`.
+
+    Only explicitly approved read-only JSON-RPC methods are accepted. The
+    underlying chain-access backend and transport are intentionally not
+    exposed.
+    """
+
+    __slots__ = ("__backend",)
+
+    def __init__(self, backend: Substrate):
+        self.__backend = backend
+
+    async def rpc_request(self, method: str, params: Optional[list] = None) -> Any:
+        """Call an approved read-only JSON-RPC method and return its ``result``."""
+        _require_read_only_rpc_method(method)
+        if not isinstance(self.__backend, _RpcRequester):
+            raise BittensorError(
+                "This injected substrate backend does not support the optional "
+                "read-only RPC capability `rpc_request(method, params)`."
+            )
+        return await self.__backend.rpc_request(method, params)
+
+
 class RpcSubstrate:
     def __init__(
         self,
@@ -343,6 +449,11 @@ class RpcSubstrate:
             self._archive_substrate = None
 
     # Reads ------------------------------------------------------------------
+
+    async def rpc_request(self, method: str, params: Optional[list] = None) -> Any:
+        """Call an approved read-only JSON-RPC method through the resilient transport."""
+        _require_read_only_rpc_method(method)
+        return await self._read(lambda raw: raw.rpc_request(method, params))
 
     async def block_hash(self, block: Optional[int] = None) -> str:
         if block is None:

--- a/sdk/python/bittensor/client.py
+++ b/sdk/python/bittensor/client.py
@@ -25,7 +25,7 @@ from typing import Any, AsyncIterator, Optional, Union
 from . import config
 from . import reads as read_registry
 from ._generated import storage as _st
-from ._substrate import RpcSubstrate, Substrate
+from ._substrate import ReadOnlySubstrate, RpcSubstrate, Substrate
 from ._transport.contract import UnsignedExtrinsic
 from .balance import Balance
 from .executor import Executor
@@ -178,6 +178,7 @@ class Client:
                 archive_endpoints=archive_endpoints,
                 retry_forever=retry_forever,
             )
+        self.substrate = ReadOnlySubstrate(self._substrate)
         self._executor = Executor(self._substrate, policy=policy)
 
         # Typed read namespaces: projections over the read registry

--- a/sdk/python/bittensor/sync.py
+++ b/sdk/python/bittensor/sync.py
@@ -19,7 +19,7 @@ import weakref
 from datetime import datetime
 from typing import Any, Callable, Iterator, Optional
 
-from ._substrate import Substrate
+from ._substrate import ReadOnlySubstrate, Substrate
 from .client import BlockHeader, Client
 from .intents import Policy
 from .namespaces import NAMESPACES
@@ -121,6 +121,19 @@ class _SyncNamespace:
         return wrapper
 
 
+class _SyncReadOnlySubstrate:
+    """Typed blocking facade over :class:`ReadOnlySubstrate`."""
+
+    __slots__ = ("_call", "_target")
+
+    def __init__(self, target: ReadOnlySubstrate, call: Callable[[Any], Any]):
+        self._target = target
+        self._call = call
+
+    def rpc_request(self, method: str, params: Optional[list] = None) -> Any:
+        return self._call(self._target.rpc_request(method, params))
+
+
 class SyncSnapshot:
     """Blocking facade over a block-pinned :class:`Snapshot`.
 
@@ -183,6 +196,7 @@ class SyncSnapshot:
 class SyncClient:
     # Explicit so type checkers see the same namespace surface as ``Client``
     # (a loop of setattr alone is invisible to them).
+    substrate: _SyncReadOnlySubstrate
     balances: _SyncNamespace
     chain: _SyncNamespace
     delegation: _SyncNamespace
@@ -224,6 +238,7 @@ class SyncClient:
         # completely cold.
         self._loop_thread: Optional[_Loop] = None
         self._finalizer: Optional[weakref.finalize] = None
+        self.substrate = _SyncReadOnlySubstrate(self._client.substrate, self._call)
         # Keep in sync with namespaces.NAMESPACES / Client (explicit so type
         # checkers see each attribute; a setattr loop is invisible to them).
         self.balances = _SyncNamespace(self._client.balances, self._call)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bittensor"
-version = "11.0.1.dev0"
+version = "11.0.2.dev0"
 description = "A lean Python SDK (import bittensor) and CLI (btcli) for the Bittensor chain."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -18,7 +18,7 @@ dependencies = [
     # Keys, keyfiles, timelock, ML-KEM crypto, and the SCALE codec/runtime
     # engine: the in-repo Rust core, built against the same crate revisions
     # as the runtime.
-    "bittensor-core>=0.1.1,<0.2.0",
+    "bittensor-core>=0.1.2,<0.2.0",
     # `btcli` terminal UI. The CLI is a first-class part of the package, so
     # its dependencies are unconditional.
     "typer>=0.12.0",

--- a/sdk/python/tests/harness/fake_substrate.py
+++ b/sdk/python/tests/harness/fake_substrate.py
@@ -140,6 +140,9 @@ class FakeSubstrate:
         self._constants: dict[tuple[str, str], Any] = dict(DEFAULT_CONSTANTS)
         # (api, method) -> value, or callable(params) -> value
         self._runtime: dict[tuple[str, str], Any] = dict(DEFAULT_RUNTIME)
+        # JSON-RPC method -> value, or callable(params) -> value.
+        self._rpc: dict[str, Any] = {}
+        self.rpc_requests: list[tuple[str, Optional[list]]] = []
 
         self.fee = Balance.from_rao(124_414)
         self.weight = {"ref_time": 1_000_000, "proof_size": 3_593}
@@ -172,6 +175,10 @@ class FakeSubstrate:
         """``value`` may be a plain result or a callable of the params list."""
         self._runtime[(api, method)] = value
 
+    def seed_rpc(self, method: str, value: Any) -> None:
+        """``value`` may be a plain result or a callable of the params list."""
+        self._rpc[method] = value
+
     def queue_result(self, result: ExtrinsicResult) -> None:
         self.pending_results.append(result)
 
@@ -197,6 +204,12 @@ class FakeSubstrate:
         self.closed = True
 
     # -- reads -----------------------------------------------------------------
+
+    async def rpc_request(self, method: str, params: Optional[list] = None) -> Any:
+        forwarded_params = None if params is None else list(params)
+        self.rpc_requests.append((method, forwarded_params))
+        value = self._rpc.get(method)
+        return value(forwarded_params) if callable(value) else value
 
     async def block_hash(self, block: Optional[int] = None) -> str:
         return f"0x{(self.block if block is None else block):064x}"

--- a/sdk/python/tests/unit/test_substrate_surface.py
+++ b/sdk/python/tests/unit/test_substrate_surface.py
@@ -1,0 +1,182 @@
+"""Tests for the controlled public ``client.substrate`` RPC surface."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, cast
+
+import pytest
+
+from bittensor import Client, ReadOnlySubstrate, Subtensor
+from bittensor._substrate import RpcSubstrate
+from bittensor._transport import SubstrateConnection
+from bittensor._transport.errors import StateDiscardedError, SubstrateRequestException
+from bittensor.result import BittensorError, ChainError, ConnectionNotReady
+from tests.harness.fake_node import FakeNode
+from tests.harness.fake_substrate import FakeSubstrate
+
+
+class _StubConnection:
+    def __init__(self, *, result: Any = None, error: Exception | None = None):
+        self.result = result
+        self.error = error
+        self.requests: list[tuple[str, list | None]] = []
+
+    async def rpc_request(self, method: str, params: list | None = None) -> Any:
+        self.requests.append((method, params))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _BackendWithoutRpc(FakeSubstrate):
+    """A complete injected backend without the optional low-level capability."""
+
+    rpc_request = None
+
+
+def _public_names(value: object) -> set[str]:
+    return {name for name in dir(value) if not name.startswith("_")}
+
+
+async def test_async_rpc_forwards_method_params_and_result():
+    backend = FakeSubstrate()
+    backend.seed_rpc("state_getStorageAt", lambda params: {"params": params})
+    client = Client("local", substrate=backend)
+
+    result = await client.substrate.rpc_request("state_getStorageAt", ["0xkey", "0xblock"])
+
+    assert result == {"params": ["0xkey", "0xblock"]}
+    assert backend.rpc_requests == [
+        ("state_getStorageAt", ["0xkey", "0xblock"]),
+    ]
+
+
+def test_blocking_subtensor_connects_lazily_and_returns_value():
+    backend = FakeSubstrate()
+    backend.seed_rpc("system_health", {"isSyncing": False, "peers": 4})
+    client = Subtensor("local", substrate=backend)
+    try:
+        assert backend.connected is False
+
+        result = client.substrate.rpc_request("system_health")
+
+        assert result == {"isSyncing": False, "peers": 4}
+        assert not inspect.isawaitable(result)
+        assert backend.connected is True
+        assert backend.rpc_requests == [("system_health", None)]
+        assert _public_names(client.substrate) == {"rpc_request"}
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "author_submitExtrinsic",
+        "chain_subscribeNewHeads",
+        "chain_unsubscribeNewHeads",
+        "custom_getThing",
+    ],
+)
+async def test_unsafe_subscription_and_unknown_methods_are_rejected_before_dispatch(method):
+    backend = FakeSubstrate()
+    client = Client("local", substrate=backend)
+
+    with pytest.raises(BittensorError, match="not an approved read-only method"):
+        await client.substrate.rpc_request(method, [])
+
+    assert backend.rpc_requests == []
+
+
+async def test_injected_backend_with_rpc_capability_is_supported():
+    backend = FakeSubstrate()
+    backend.seed_rpc("account_nextIndex", 9)
+    client = Client("local", substrate=backend)
+
+    assert await client.substrate.rpc_request("account_nextIndex", ["5F..."]) == 9
+
+
+async def test_injected_backend_without_rpc_capability_fails_only_when_used():
+    backend = _BackendWithoutRpc()
+    client = Client("local", substrate=backend)
+
+    assert await client.block() == 100
+
+    with pytest.raises(BittensorError, match=r"does not support.*read-only RPC capability"):
+        await client.substrate.rpc_request("system_health")
+
+
+async def test_public_view_does_not_expose_transport_or_submission_helpers():
+    client = Client("local", substrate=FakeSubstrate())
+
+    assert isinstance(client.substrate, ReadOnlySubstrate)
+    assert _public_names(client.substrate) == {"rpc_request"}
+
+
+async def test_rpc_requires_an_open_connection():
+    client = Client("local", substrate=RpcSubstrate("ws://unused"))
+
+    with pytest.raises(ConnectionNotReady, match="connection is not open"):
+        await client.substrate.rpc_request("system_health")
+
+
+async def test_rpc_normalizes_node_errors_to_chain_error():
+    backend = RpcSubstrate("ws://unused")
+    raw = _StubConnection(error=SubstrateRequestException("node rejected the request"))
+    backend._substrate = cast(Any, raw)
+    client = Client("local", substrate=backend)
+
+    with pytest.raises(ChainError, match="node rejected the request"):
+        await client.substrate.rpc_request("state_getStorage", ["0xkey"])
+
+
+async def test_rpc_retries_discarded_state_on_archive_backend():
+    backend = RpcSubstrate("ws://primary", archive_endpoints=["wss://archive"])
+    primary = _StubConnection(error=StateDiscardedError("0xold"))
+    archive = _StubConnection(result="0xvalue")
+    backend._substrate = cast(Any, primary)
+    backend._archive_substrate = cast(Any, archive)
+    client = Client("local", substrate=backend)
+
+    result = await client.substrate.rpc_request("state_getStorage", ["0xkey", "0xold"])
+
+    assert result == "0xvalue"
+    assert primary.requests == [("state_getStorage", ["0xkey", "0xold"])]
+    assert archive.requests == [("state_getStorage", ["0xkey", "0xold"])]
+
+
+async def test_public_rpc_uses_reconnecting_transport():
+    node = FakeNode()
+    calls = 0
+
+    def flaky_health(fake: FakeNode, request):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            fake.current.kill()
+            return None
+        return {"isSyncing": False, "peers": 3}
+
+    node.handlers["system_health"] = flaky_health
+    raw = SubstrateConnection(
+        "ws://fake:1",
+        connect_factory=node.connection,
+        max_retries=2,
+        response_timeout=0.5,
+    )
+    await raw._session.connect()
+    backend = RpcSubstrate("ws://unused")
+    backend._substrate = raw
+    client = Client("local", substrate=backend)
+    try:
+        result = await asyncio.wait_for(
+            client.substrate.rpc_request("system_health"),
+            timeout=3,
+        )
+        assert result == {"isSyncing": False, "peers": 3}
+        assert calls == 2
+        assert len(node.connections) == 2
+    finally:
+        await backend.close()

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "bittensor"
-version = "11.0.1.dev0"
+version = "11.0.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bittensor-core" },
@@ -165,7 +165,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.1"
+version = "0.1.2"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]


### PR DESCRIPTION
## What

- add a typed, read-only `client.substrate.rpc_request(...)` surface for async and blocking SDK clients
- route supported RPCs through the existing reconnecting backend
- reject subscriptions, mutation-capable methods, and unclassified RPCs before network dispatch
- preserve injected backends through an optional runtime-checked RPC capability
- document the async and blocking APIs and advance the coordinated SDK/core development versions

## Why

Low-level read operations currently require reaching into private transport internals. This provides a supported public surface without exposing raw connections, signing helpers, transaction submission, caches, or websocket sessions.

## Safety and compatibility

- the allowlist is explicit and limited to standard read-only RPCs already used by the SDK
- transaction submission remains on `execute(...)` and `submit_call(...)`
- existing injected backends remain valid; unsupported backends fail only if the optional RPC view is used
- the change is additive and follows the existing async-client plus blocking-facade convention

## Validation

- `ruff check .`
- `ruff format --check .`
- `ty check --exit-zero-on-warning bittensor`
- full SDK suite: `997 passed, 1 skipped`
- codegen coverage, names, and units checks
- wheel and sdist build
- clean-wheel async and blocking `system_health` smoke tests against testnet

The unrelated generated namespace documentation drift is intentionally excluded and submitted separately in #2981.
