### PR TITLE
Add a test for getNetworkRegistrationBlock precompile

### DIFF
--- a/precompiles/src/subnet.rs
+++ b/precompiles/src/subnet.rs
@@ -1351,6 +1351,19 @@ mod tests {
                 ),
                 U256::from(registration_block),
             );
+
+            pallet_subtensor::NetworkRegisteredAt::<Runtime>::remove(netuid);
+
+            assert_static_call(
+                &precompiles,
+                caller,
+                precompile_addr,
+                encode_with_selector(
+                    selector_u32("getNetworkRegistrationBlock(uint16)"),
+                    (TEST_NETUID_U16,),
+                ),
+                U256::zero(),
+            );
         });
     }
 


### PR DESCRIPTION
## Motivation

Add regression coverage for the `getNetworkRegistrationBlock(uint16)` subnet precompile when its backing storage entry is absent.

## Changes

Extends `subnet_precompile_gets_network_registered_block` in `precompiles/src/subnet.rs` to remove `NetworkRegisteredAt` for the test subnet and verify that the precompile returns zero, matching the storage map's configured `ValueQuery` default.

## Behavioral impact

There is no production behavior change; this PR only adds test coverage for the existing precompile contract.

## Migration and spec version

No migration or runtime spec-version bump is required because only test code changes.

## Testing

The existing subnet precompile test now covers both a populated registration block and a missing storage entry. No additional test command was reported in the PR.