### PR TITLE
Add EVM precompile support for miner conviction and stake locks

### DIFF
--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -584,5 +584,235 @@
     "outputs": [],
     "stateMutability": "",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getColdkeyLock",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "hotkey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "locked_mass",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint128",
+            "name": "conviction",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "last_update",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "is_perpetual",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IStaking.ColdkeyLockInfo",
+        "name": "lockInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "hotkeys",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "getHotkeyConvictions",
+    "outputs": [
+      {
+        "internalType": "uint128[]",
+        "name": "convictions",
+        "type": "uint128[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getHotkeyLock",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "locked_mass",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint128",
+            "name": "conviction",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct IStaking.HotkeyLockInfo",
+        "name": "lockInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLockRates",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "unlockRate",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maturityRate",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRejectLockedAlpha",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "lockStake",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "destinationHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "moveLock",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setPerpetualLock",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setRejectLockedAlpha",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
   }
 ]

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -9,6 +9,23 @@ interface IStaking {
         uint256 stake;
     }
 
+    /// One coldkey's stake lock, rolled forward to the queried block.
+    struct ColdkeyLockInfo {
+        bool exists;
+        bytes32 hotkey;
+        uint256 locked_mass;
+        uint128 conviction;
+        uint64 last_update;
+        bool is_perpetual;
+    }
+
+    /// Rolled aggregate lock state targeting one hotkey.
+    struct HotkeyLockInfo {
+        bool exists;
+        uint256 locked_mass;
+        uint128 conviction;
+    }
+
     /**
      * @dev Adds a subtensor stake `amount` associated with the `hotkey`.
      *
@@ -238,6 +255,101 @@ interface IStaking {
         external
         view
         returns (uint256 defaultMinStake);
+
+    /**
+     * @dev Locks existing alpha stake on a subnet and builds conviction for a hotkey.
+     *
+     * The lock is a subnet-wide unstaking floor for the caller. It does not
+     * move stake and may target a different hotkey from the staked positions.
+     * Repeated calls top up the same lock; use `moveLock` to change its target.
+     *
+     * @param hotkey Hotkey that receives the conviction.
+     * @param amount Alpha to add to the lock.
+     * @param netuid Subnet on which the alpha is locked.
+     */
+    function lockStake(
+        bytes32 hotkey,
+        uint256 amount,
+        uint256 netuid
+    ) external payable;
+
+    /**
+     * @dev Moves the caller's existing subnet lock to another hotkey.
+     *
+     * Current decayed mass is preserved. Conviction is preserved when the
+     * source and destination hotkeys share an owner; otherwise it resets.
+     */
+    function moveLock(
+        bytes32 destinationHotkey,
+        uint256 netuid
+    ) external payable;
+
+    /**
+     * @dev Selects perpetual or decaying behavior for the caller's subnet lock.
+     *
+     * There is no direct unlock operation. Disabling perpetual mode lets the
+     * locked mass decay according to the runtime unlock rate.
+     */
+    function setPerpetualLock(
+        uint256 netuid,
+        bool enabled
+    ) external payable;
+
+    /**
+     * @dev Sets whether the caller rejects incoming alpha that carries a lock.
+     *
+     * Rejection is enabled by default. Pass false to opt into receiving locked
+     * alpha through compatible stake transfers or coldkey swaps.
+     */
+    function setRejectLockedAlpha(bool enabled) external payable;
+
+    /**
+     * @dev Returns a coldkey's lock rolled forward to the current block.
+     *
+     * `conviction` is exact unsigned Q64.64 bits. Divide it by 2^64 to obtain
+     * conviction in alpha rao.
+     */
+    function getColdkeyLock(
+        bytes32 coldkey,
+        uint256 netuid
+    ) external view returns (ColdkeyLockInfo memory lockInfo);
+
+    /**
+     * @dev Returns rolled aggregate lock state targeting a hotkey.
+     *
+     * Perpetual and decaying buckets are combined. For the subnet owner hotkey,
+     * the owner-specific buckets are included as well.
+     */
+    function getHotkeyLock(
+        bytes32 hotkey,
+        uint256 netuid
+    ) external view returns (HotkeyLockInfo memory lockInfo);
+
+    /**
+     * @dev Returns exact rolled Q64.64 conviction for distinct candidate hotkeys.
+     *
+     * Results align with `hotkeys`. The list is capped at 64 to keep gas and
+     * storage work bounded; larger metagraphs can be queried in batches.
+     */
+    function getHotkeyConvictions(
+        uint256 netuid,
+        bytes32[] calldata hotkeys
+    ) external view returns (uint128[] memory convictions);
+
+    /**
+     * @dev Returns `(unlockRate, maturityRate)` in blocks.
+     */
+    function getLockRates()
+        external
+        view
+        returns (uint64 unlockRate, uint64 maturityRate);
+
+    /**
+     * @dev Returns whether a coldkey rejects incoming locked alpha.
+     */
+    function getRejectLockedAlpha(
+        bytes32 coldkey
+    ) external view returns (bool);
 
     /**
      * @dev Adds a subtensor stake `amount` associated with the `hotkey` within a price limit.

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -307,7 +307,8 @@ interface IStaking {
      * @dev Returns a coldkey's lock rolled forward to the current block.
      *
      * `conviction` is exact unsigned Q64.64 bits. Divide it by 2^64 to obtain
-     * conviction in alpha rao.
+     * conviction in alpha rao. `exists` is false once the rolled lock crosses
+     * the runtime cleanup threshold, even if its stale storage row remains.
      */
     function getColdkeyLock(
         bytes32 coldkey,
@@ -318,7 +319,8 @@ interface IStaking {
      * @dev Returns rolled aggregate lock state targeting a hotkey.
      *
      * Perpetual and decaying buckets are combined. For the subnet owner hotkey,
-     * the owner-specific buckets are included as well.
+     * the owner-specific buckets are included as well. `exists` is derived
+     * from the rolled aggregate, so fully expired stale buckets do not count.
      */
     function getHotkeyLock(
         bytes32 hotkey,

--- a/precompiles/src/solidity/subnet.abi
+++ b/precompiles/src/solidity/subnet.abi
@@ -1122,5 +1122,42 @@
 		"outputs": [],
 		"stateMutability": "payable",
 		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			}
+		],
+		"name": "getOwnerCutAutoLockEnabled",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			},
+			{
+				"internalType": "bool",
+				"name": "enabled",
+				"type": "bool"
+			}
+		],
+		"name": "setOwnerCutAutoLockEnabled",
+		"outputs": [],
+		"stateMutability": "payable",
+		"type": "function"
 	}
 ]

--- a/precompiles/src/solidity/subnet.sol
+++ b/precompiles/src/solidity/subnet.sol
@@ -103,7 +103,7 @@ interface ISubnet {
 
     function getAlphaSigmoidSteepness(
         uint16 netuid
-    ) external view returns (unt16);
+    ) external view returns (uint16);
 
     function setAlphaSigmoidSteepness(
         uint16 netuid,
@@ -151,6 +151,22 @@ interface ISubnet {
     function getMaxBurn(uint16 netuid) external view returns (uint64);
 
     function setMaxBurn(uint16 netuid, uint64 maxBurn) external payable;
+
+    /**
+     * @dev Returns whether owner-cut emission is automatically stake-locked.
+     */
+    function getOwnerCutAutoLockEnabled(
+        uint16 netuid
+    ) external view returns (bool);
+
+    /**
+     * @dev Sets whether owner-cut emission is automatically stake-locked.
+     * Callable by root or the subnet owner.
+     */
+    function setOwnerCutAutoLockEnabled(
+        uint16 netuid,
+        bool enabled
+    ) external payable;
 
     function getDifficulty(uint16 netuid) external view returns (uint64);
 

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -48,7 +48,8 @@ use precompile_utils::prelude::{Address, BoundedVec, revert};
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable, StaticLookup, UniqueSaturatedInto};
 use sp_std::vec;
-use subtensor_runtime_common::{NetUid, ProxyType, Token};
+use substrate_fixed::types::U64F64;
+use subtensor_runtime_common::{AlphaBalance, NetUid, ProxyType, Token};
 
 use crate::{PrecompileExt, PrecompileHandleExt};
 
@@ -59,6 +60,11 @@ const STAKE_INFO_READS_PER_HOTKEY: u64 = 7;
 // Conservative charge for decoding and validating each 32-byte hotkey.
 const STAKE_INFO_INPUT_GAS_PER_HOTKEY: u64 = 64;
 const MAX_STAKE_INFO_HOTKEYS: usize = 64;
+const MAX_CONVICTION_HOTKEYS: usize = 64;
+// Individual state reads the lock row, mode, owner hotkey, and global rates.
+const COLDKEY_LOCK_READS: u64 = 5;
+// Aggregate state reads the owner hotkey, global rates, and up to four buckets.
+const HOTKEY_LOCK_READS: u64 = 7;
 
 /// Prefix for the Allowances map in Substrate storage.
 pub struct AllowancesPrefix;
@@ -451,6 +457,241 @@ where
         Ok(pallet_subtensor::DefaultMinStake::<R>::get()
             .to_u64()
             .into())
+    }
+
+    /// Lock existing subnet alpha and begin building conviction for `hotkey`.
+    #[precompile::public("lockStake(bytes32,uint256,uint256)")]
+    #[precompile::payable]
+    fn lock_stake(
+        handle: &mut impl PrecompileHandle,
+        hotkey: H256,
+        amount_alpha: U256,
+        netuid: U256,
+    ) -> EvmResult<()> {
+        let call = pallet_subtensor::Call::<R>::lock_stake {
+            hotkey: R::AccountId::from(hotkey.0),
+            netuid: NetUid::from(try_u16_from_u256(netuid)?),
+            amount: try_u64_from_u256(amount_alpha)?.into(),
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
+    /// Re-point the caller's lock on a subnet to another hotkey.
+    #[precompile::public("moveLock(bytes32,uint256)")]
+    #[precompile::payable]
+    fn move_lock(
+        handle: &mut impl PrecompileHandle,
+        destination_hotkey: H256,
+        netuid: U256,
+    ) -> EvmResult<()> {
+        let call = pallet_subtensor::Call::<R>::move_lock {
+            destination_hotkey: R::AccountId::from(destination_hotkey.0),
+            netuid: NetUid::from(try_u16_from_u256(netuid)?),
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
+    /// Select perpetual or normally decaying behavior for the caller's lock.
+    #[precompile::public("setPerpetualLock(uint256,bool)")]
+    #[precompile::payable]
+    fn set_perpetual_lock(
+        handle: &mut impl PrecompileHandle,
+        netuid: U256,
+        enabled: bool,
+    ) -> EvmResult<()> {
+        let call = pallet_subtensor::Call::<R>::set_perpetual_lock {
+            netuid: NetUid::from(try_u16_from_u256(netuid)?),
+            enabled,
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
+    /// Set whether the caller rejects incoming stake that carries a lock.
+    #[precompile::public("setRejectLockedAlpha(bool)")]
+    #[precompile::payable]
+    fn set_reject_locked_alpha(handle: &mut impl PrecompileHandle, enabled: bool) -> EvmResult<()> {
+        let call = pallet_subtensor::Call::<R>::set_reject_locked_alpha { enabled };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
+    /// Return one coldkey's lock, rolled forward to the current block.
+    ///
+    /// Conviction is returned as exact unsigned Q64.64 bits.
+    #[precompile::public("getColdkeyLock(bytes32,uint256)")]
+    #[precompile::view]
+    fn get_coldkey_lock(
+        handle: &mut impl PrecompileHandle,
+        coldkey: H256,
+        netuid: U256,
+    ) -> EvmResult<(bool, H256, U256, u128, u64, bool)> {
+        handle.record_db_reads::<R>(COLDKEY_LOCK_READS)?;
+        let coldkey = R::AccountId::from(coldkey.0);
+        let netuid = NetUid::from(try_u16_from_u256(netuid)?);
+        let perpetual = pallet_subtensor::DecayingLock::<R>::get(&coldkey, netuid) == Some(false);
+
+        let Some((hotkey, lock)) =
+            pallet_subtensor::Lock::<R>::iter_prefix((&coldkey, netuid)).next()
+        else {
+            return Ok((false, H256::zero(), U256::zero(), 0, 0, perpetual));
+        };
+
+        let now = pallet_subtensor::Pallet::<R>::get_current_block_as_u64();
+        let owner_lock = hotkey == pallet_subtensor::SubnetOwnerHotkey::<R>::get(netuid);
+        let (lock, _) = pallet_subtensor::staking::lock::ConvictionModel::roll_forward_lock(
+            lock,
+            now,
+            pallet_subtensor::UnlockRate::<R>::get(),
+            pallet_subtensor::MaturityRate::<R>::get(),
+            owner_lock,
+            perpetual,
+        );
+        let hotkey: [u8; 32] = hotkey.into();
+
+        Ok((
+            true,
+            hotkey.into(),
+            lock.locked_mass.to_u64().into(),
+            lock.conviction.to_bits(),
+            lock.last_update,
+            perpetual,
+        ))
+    }
+
+    /// Return the rolled aggregate lock and conviction for a hotkey.
+    ///
+    /// This combines perpetual and decaying general buckets and, when the
+    /// hotkey is the subnet owner, both owner buckets.
+    #[precompile::public("getHotkeyLock(bytes32,uint256)")]
+    #[precompile::view]
+    fn get_hotkey_lock(
+        handle: &mut impl PrecompileHandle,
+        hotkey: H256,
+        netuid: U256,
+    ) -> EvmResult<(bool, U256, u128)> {
+        handle.record_db_reads::<R>(HOTKEY_LOCK_READS)?;
+        let hotkey = R::AccountId::from(hotkey.0);
+        let netuid = NetUid::from(try_u16_from_u256(netuid)?);
+        let now = pallet_subtensor::Pallet::<R>::get_current_block_as_u64();
+        let unlock_rate = pallet_subtensor::UnlockRate::<R>::get();
+        let maturity_rate = pallet_subtensor::MaturityRate::<R>::get();
+        let is_owner = hotkey == pallet_subtensor::SubnetOwnerHotkey::<R>::get(netuid);
+
+        let mut locked = AlphaBalance::ZERO;
+        let mut conviction = U64F64::from_bits(0);
+        let mut exists = false;
+        let mut add_bucket = |maybe_lock: Option<pallet_subtensor::staking::lock::LockState>,
+                              owner_lock: bool,
+                              perpetual_lock: bool| {
+            if let Some(lock) = maybe_lock {
+                exists = true;
+                let (lock, _) = pallet_subtensor::staking::lock::ConvictionModel::roll_forward_lock(
+                    lock,
+                    now,
+                    unlock_rate,
+                    maturity_rate,
+                    owner_lock,
+                    perpetual_lock,
+                );
+                locked = locked.saturating_add(lock.locked_mass);
+                conviction = conviction.saturating_add(lock.conviction);
+            }
+        };
+
+        add_bucket(
+            pallet_subtensor::HotkeyLock::<R>::get(netuid, &hotkey),
+            false,
+            true,
+        );
+        add_bucket(
+            pallet_subtensor::DecayingHotkeyLock::<R>::get(netuid, &hotkey),
+            false,
+            false,
+        );
+        if is_owner {
+            add_bucket(pallet_subtensor::OwnerLock::<R>::get(netuid), true, true);
+            add_bucket(
+                pallet_subtensor::DecayingOwnerLock::<R>::get(netuid),
+                true,
+                false,
+            );
+        }
+
+        Ok((exists, locked.to_u64().into(), conviction.to_bits()))
+    }
+
+    /// Return exact rolled conviction for up to 64 distinct candidate hotkeys.
+    ///
+    /// This bounded form avoids the runtime's unbounded all-hotkey scan. The
+    /// returned values align one-for-one with `hotkeys`.
+    #[precompile::public("getHotkeyConvictions(uint256,bytes32[])")]
+    #[precompile::view]
+    fn get_hotkey_convictions(
+        handle: &mut impl PrecompileHandle,
+        netuid: U256,
+        hotkeys: BoundedVec<H256, ConstU32<{ MAX_CONVICTION_HOTKEYS as u32 }>>,
+    ) -> EvmResult<Vec<u128>> {
+        let hotkey_count: u64 = hotkeys.len().unique_saturated_into();
+        handle.record_cost(hotkey_count.saturating_mul(STAKE_INFO_INPUT_GAS_PER_HOTKEY))?;
+        let hotkeys: Vec<H256> = hotkeys.into();
+        let netuid = NetUid::from(try_u16_from_u256(netuid)?);
+
+        let mut seen = BTreeSet::new();
+        for hotkey in &hotkeys {
+            if !seen.insert(hotkey) {
+                return Err(revert("duplicate conviction hotkey"));
+            }
+        }
+
+        handle.record_db_reads::<R>(hotkey_count.saturating_mul(HOTKEY_LOCK_READS))?;
+
+        Ok(hotkeys
+            .into_iter()
+            .map(|hotkey| {
+                let hotkey = R::AccountId::from(hotkey.0);
+                pallet_subtensor::Pallet::<R>::hotkey_conviction(&hotkey, netuid).to_bits()
+            })
+            .collect())
+    }
+
+    /// Return the global lock decay and conviction maturity timescales.
+    #[precompile::public("getLockRates()")]
+    #[precompile::view]
+    fn get_lock_rates(handle: &mut impl PrecompileHandle) -> EvmResult<(u64, u64)> {
+        handle.record_db_reads::<R>(2)?;
+        Ok((
+            pallet_subtensor::UnlockRate::<R>::get(),
+            pallet_subtensor::MaturityRate::<R>::get(),
+        ))
+    }
+
+    /// Return whether a coldkey rejects incoming locked alpha.
+    #[precompile::public("getRejectLockedAlpha(bytes32)")]
+    #[precompile::view]
+    fn get_reject_locked_alpha(
+        handle: &mut impl PrecompileHandle,
+        coldkey: H256,
+    ) -> EvmResult<bool> {
+        handle.record_db_reads::<R>(1)?;
+        let coldkey = R::AccountId::from(coldkey.0);
+        Ok(pallet_subtensor::Pallet::<R>::account_rejects_locked_alpha(
+            &coldkey,
+        ))
     }
 
     #[precompile::public("addProxy(bytes32)")]
@@ -1444,6 +1685,373 @@ mod tests {
                 .with_static_call(true)
                 .expect_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())
                 .execute_returns(U256::from(threshold.to_u64()));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_manages_and_reads_stake_lock_lifecycle() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1120);
+            let coldkey = mapped_account(caller);
+            let origin_hotkey = AccountId::from([0x61; 32]);
+            let destination_hotkey = AccountId::from([0x62; 32]);
+            let locked = 8_000_000_000_u64;
+            let precompiles = precompiles::<StakingPrecompileV2<Runtime>>();
+            let precompile_addr = addr_from_index(StakingPrecompileV2::<Runtime>::INDEX);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &origin_hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            pallet_subtensor::Owner::<Runtime>::insert(&origin_hotkey, &coldkey);
+            pallet_subtensor::Owner::<Runtime>::insert(&destination_hotkey, &coldkey);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("lockStake(bytes32,uint256,uint256)"),
+                        (
+                            H256::from_slice(origin_hotkey.as_ref()),
+                            U256::from(locked),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .execute_returns(());
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("setPerpetualLock(uint256,bool)"),
+                        (U256::from(TEST_NETUID_U16), true),
+                    ),
+                )
+                .execute_returns(());
+            assert_eq!(
+                pallet_subtensor::DecayingLock::<Runtime>::get(&coldkey, netuid),
+                Some(false)
+            );
+
+            frame_system::Pallet::<Runtime>::set_block_number(1_000);
+            let expected = pallet_subtensor::Pallet::<Runtime>::get_coldkey_lock(&coldkey, netuid)
+                .expect("lock exists");
+            assert_eq!(expected.locked_mass.to_u64(), locked);
+            assert!(expected.conviction > U64F64::from_num(0));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getColdkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(COLDKEY_LOCK_READS),
+                )
+                .execute_returns((
+                    true,
+                    H256::from_slice(origin_hotkey.as_ref()),
+                    U256::from(expected.locked_mass.to_u64()),
+                    expected.conviction.to_bits(),
+                    expected.last_update,
+                    true,
+                ));
+
+            let expected_hotkey_conviction =
+                pallet_subtensor::Pallet::<Runtime>::hotkey_conviction(&origin_hotkey, netuid);
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getHotkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(origin_hotkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(HOTKEY_LOCK_READS),
+                )
+                .execute_returns((
+                    true,
+                    U256::from(expected.locked_mass.to_u64()),
+                    expected_hotkey_conviction.to_bits(),
+                ));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("moveLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(destination_hotkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .execute_returns(());
+
+            let moved =
+                pallet_subtensor::Lock::<Runtime>::get((&coldkey, netuid, &destination_hotkey))
+                    .expect("lock moved to destination");
+            assert_eq!(moved.locked_mass, expected.locked_mass);
+            assert_eq!(moved.conviction, expected.conviction);
+            assert!(!pallet_subtensor::Lock::<Runtime>::contains_key((
+                &coldkey,
+                netuid,
+                &origin_hotkey
+            )));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("setPerpetualLock(uint256,bool)"),
+                        (U256::from(TEST_NETUID_U16), false),
+                    ),
+                )
+                .execute_returns(());
+            frame_system::Pallet::<Runtime>::set_block_number(2_000);
+            let decayed = pallet_subtensor::Pallet::<Runtime>::get_coldkey_lock(&coldkey, netuid)
+                .expect("decaying lock remains above the cleanup threshold");
+            assert!(decayed.locked_mass < moved.locked_mass);
+            assert_eq!(
+                pallet_subtensor::DecayingLock::<Runtime>::get(&coldkey, netuid),
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_exposes_lock_rates_conviction_batches_and_recipient_flag() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1121);
+            let coldkey = mapped_account(caller);
+            let hotkey = AccountId::from([0x63; 32]);
+            let empty_hotkey = AccountId::from([0x64; 32]);
+            let precompiles = precompiles::<StakingPrecompileV2<Runtime>>();
+            let precompile_addr = addr_from_index(StakingPrecompileV2::<Runtime>::INDEX);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            ensure_hotkey_exists(&empty_hotkey);
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("lockStake(bytes32,uint256,uint256)"),
+                        (
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(5_000_000_000_u64),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .execute_returns(());
+            frame_system::Pallet::<Runtime>::set_block_number(1_000);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(selector_u32("getLockRates()"), ()),
+                )
+                .with_static_call(true)
+                .expect_cost(RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(2))
+                .execute_returns((
+                    pallet_subtensor::UnlockRate::<Runtime>::get(),
+                    pallet_subtensor::MaturityRate::<Runtime>::get(),
+                ));
+
+            let candidates = vec![
+                H256::from_slice(hotkey.as_ref()),
+                H256::from_slice(empty_hotkey.as_ref()),
+            ];
+            let expected = vec![
+                pallet_subtensor::Pallet::<Runtime>::hotkey_conviction(&hotkey, netuid).to_bits(),
+                0,
+            ];
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getHotkeyConvictions(uint256,bytes32[])"),
+                        (U256::from(TEST_NETUID_U16), candidates),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    stake_info_validation_cost(2).saturating_add(
+                        RuntimeHelper::<Runtime>::db_read_gas_cost()
+                            .saturating_mul(2 * HOTKEY_LOCK_READS),
+                    ),
+                )
+                .execute_returns(expected);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getRejectLockedAlpha(bytes32)"),
+                        (H256::from_slice(coldkey.as_ref()),),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())
+                .execute_returns(true);
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(selector_u32("setRejectLockedAlpha(bool)"), (false,)),
+                )
+                .execute_returns(());
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getRejectLockedAlpha(bytes32)"),
+                        (H256::from_slice(coldkey.as_ref()),),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())
+                .execute_returns(false);
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_reports_empty_lock_and_preconfigured_perpetual_mode() {
+        new_test_ext().execute_with(|| {
+            setup_staking_subnet();
+            let caller = addr_from_index(0x1123);
+            let coldkey = mapped_account(caller);
+            let hotkey = hotkey();
+            let precompiles = precompiles::<StakingPrecompileV2<Runtime>>();
+            let precompile_addr = addr_from_index(StakingPrecompileV2::<Runtime>::INDEX);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("setPerpetualLock(uint256,bool)"),
+                        (U256::from(TEST_NETUID_U16), true),
+                    ),
+                )
+                .execute_returns(());
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getColdkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(COLDKEY_LOCK_READS),
+                )
+                .execute_returns((false, H256::zero(), U256::zero(), 0_u128, 0_u64, true));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getHotkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(HOTKEY_LOCK_READS),
+                )
+                .execute_returns((false, U256::zero(), 0_u128));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_rejects_invalid_lock_inputs() {
+        new_test_ext().execute_with(|| {
+            setup_staking_subnet();
+            let caller = addr_from_index(0x1122);
+            let coldkey = mapped_account(caller);
+            let hotkey = hotkey();
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        selector_u32("lockStake(bytes32,uint256,uint256)"),
+                        (
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(u64::MAX) + U256::one(),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .execute_error(ExitError::Other(
+                    "the value is outside of u64 bounds".into(),
+                ));
+
+            let requested = H256::from_slice(hotkey.as_ref());
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        selector_u32("getHotkeyConvictions(uint256,bytes32[])"),
+                        (U256::from(TEST_NETUID_U16), vec![requested, requested]),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(stake_info_validation_cost(2))
+                .execute_reverts(|output| output == b"duplicate conviction hotkey");
+
+            let too_many_hotkeys = vec![requested; MAX_CONVICTION_HOTKEYS + 1];
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        selector_u32("getHotkeyConvictions(uint256,bytes32[])"),
+                        (U256::from(TEST_NETUID_U16), too_many_hotkeys),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(0)
+                .execute_reverts(|output| output == b"hotkeys: Value is too large for length");
         });
     }
 

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -61,10 +61,10 @@ const STAKE_INFO_READS_PER_HOTKEY: u64 = 7;
 const STAKE_INFO_INPUT_GAS_PER_HOTKEY: u64 = 64;
 const MAX_STAKE_INFO_HOTKEYS: usize = 64;
 const MAX_CONVICTION_HOTKEYS: usize = 64;
-// Individual state reads the lock row, mode, owner hotkey, and global rates.
-const COLDKEY_LOCK_READS: u64 = 5;
-// Aggregate state reads the owner hotkey, global rates, and up to four buckets.
-const HOTKEY_LOCK_READS: u64 = 7;
+// Individual state reads the lock row, mode, owner hotkey, global rates, and current block.
+const COLDKEY_LOCK_READS: u64 = 6;
+// Aggregate state reads the owner hotkey, global rates, current block, and up to four buckets.
+const HOTKEY_LOCK_READS: u64 = 8;
 
 /// Prefix for the Allowances map in Substrate storage.
 pub struct AllowancesPrefix;
@@ -533,6 +533,8 @@ where
     /// Return one coldkey's lock, rolled forward to the current block.
     ///
     /// Conviction is returned as exact unsigned Q64.64 bits.
+    /// `exists` is false if the rolled lock has crossed the cleanup threshold,
+    /// even when its stale storage row has not yet been removed.
     #[precompile::public("getColdkeyLock(bytes32,uint256)")]
     #[precompile::view]
     fn get_coldkey_lock(
@@ -561,10 +563,11 @@ where
             owner_lock,
             perpetual,
         );
+        let exists = !lock.is_zero();
         let hotkey: [u8; 32] = hotkey.into();
 
         Ok((
-            true,
+            exists,
             hotkey.into(),
             lock.locked_mass.to_u64().into(),
             lock.conviction.to_bits(),
@@ -594,12 +597,10 @@ where
 
         let mut locked = AlphaBalance::ZERO;
         let mut conviction = U64F64::from_bits(0);
-        let mut exists = false;
         let mut add_bucket = |maybe_lock: Option<pallet_subtensor::staking::lock::LockState>,
                               owner_lock: bool,
                               perpetual_lock: bool| {
             if let Some(lock) = maybe_lock {
-                exists = true;
                 let (lock, _) = pallet_subtensor::staking::lock::ConvictionModel::roll_forward_lock(
                     lock,
                     now,
@@ -632,6 +633,7 @@ where
             );
         }
 
+        let exists = locked > AlphaBalance::ZERO || conviction > U64F64::from_bits(0);
         Ok((exists, locked.to_u64().into(), conviction.to_bits()))
     }
 
@@ -1995,6 +1997,125 @@ mod tests {
                     RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(HOTKEY_LOCK_READS),
                 )
                 .execute_returns((false, U256::zero(), 0_u128));
+        });
+    }
+
+    #[test]
+    fn staking_precompile_v2_reports_expired_unpersisted_locks_as_nonexistent() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x1124);
+            let coldkey = mapped_account(caller);
+            let hotkey = AccountId::from([0x65; 32]);
+            let precompiles = precompiles::<StakingPrecompileV2<Runtime>>();
+            let precompile_addr = addr_from_index(StakingPrecompileV2::<Runtime>::INDEX);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            pallet_subtensor::SubnetOwnerHotkey::<Runtime>::insert(netuid, &hotkey);
+            pallet_subtensor::UnlockRate::<Runtime>::set(1);
+            pallet_subtensor::MaturityRate::<Runtime>::set(1);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("lockStake(bytes32,uint256,uint256)"),
+                        (
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(5_000_000_000_u64),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .execute_returns(());
+
+            assert!(pallet_subtensor::Lock::<Runtime>::contains_key((
+                &coldkey, netuid, &hotkey
+            )));
+            assert!(pallet_subtensor::DecayingOwnerLock::<Runtime>::contains_key(netuid));
+
+            frame_system::Pallet::<Runtime>::set_block_number(100);
+            let raw_lock = pallet_subtensor::Lock::<Runtime>::get((&coldkey, netuid, &hotkey))
+                .expect("stale individual lock remains in storage");
+            let (rolled_lock, _) =
+                pallet_subtensor::staking::lock::ConvictionModel::roll_forward_lock(
+                    raw_lock,
+                    100,
+                    pallet_subtensor::UnlockRate::<Runtime>::get(),
+                    pallet_subtensor::MaturityRate::<Runtime>::get(),
+                    true,
+                    false,
+                );
+            assert!(rolled_lock.is_zero());
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getColdkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(coldkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(COLDKEY_LOCK_READS),
+                )
+                .execute_returns((
+                    false,
+                    H256::from_slice(hotkey.as_ref()),
+                    U256::zero(),
+                    0_u128,
+                    100_u64,
+                    false,
+                ));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getHotkeyLock(bytes32,uint256)"),
+                        (
+                            H256::from_slice(hotkey.as_ref()),
+                            U256::from(TEST_NETUID_U16),
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(HOTKEY_LOCK_READS),
+                )
+                .execute_returns((false, U256::zero(), 0_u128));
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getHotkeyConvictions(uint256,bytes32[])"),
+                        (
+                            U256::from(TEST_NETUID_U16),
+                            vec![H256::from_slice(hotkey.as_ref())],
+                        ),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(stake_info_validation_cost(1).saturating_add(
+                    RuntimeHelper::<Runtime>::db_read_gas_cost().saturating_mul(HOTKEY_LOCK_READS),
+                ))
+                .execute_returns(vec![0_u128]);
+
+            // View calls roll state in memory only, so this exercises stale rows.
+            assert!(pallet_subtensor::Lock::<Runtime>::contains_key((
+                &coldkey, netuid, &hotkey
+            )));
+            assert!(pallet_subtensor::DecayingOwnerLock::<Runtime>::contains_key(netuid));
         });
     }
 

--- a/precompiles/src/subnet.rs
+++ b/precompiles/src/subnet.rs
@@ -601,6 +601,38 @@ where
         Ok(pallet_subtensor::MaxBurn::<R>::get(NetUid::from(netuid)).to_u64())
     }
 
+    /// Return whether subnet owner-cut emission is automatically stake-locked.
+    #[precompile::public("getOwnerCutAutoLockEnabled(uint16)")]
+    #[precompile::view]
+    fn get_owner_cut_auto_lock_enabled(
+        handle: &mut impl PrecompileHandle,
+        netuid: u16,
+    ) -> EvmResult<bool> {
+        handle.record_db_reads::<R>(1)?;
+        Ok(pallet_subtensor::OwnerCutAutoLockEnabled::<R>::get(
+            NetUid::from(netuid),
+        ))
+    }
+
+    /// Set whether subnet owner-cut emission is automatically stake-locked.
+    #[precompile::public("setOwnerCutAutoLockEnabled(uint16,bool)")]
+    #[precompile::payable]
+    fn set_owner_cut_auto_lock_enabled(
+        handle: &mut impl PrecompileHandle,
+        netuid: u16,
+        enabled: bool,
+    ) -> EvmResult<()> {
+        let call = pallet_admin_utils::Call::<R>::sudo_set_owner_cut_auto_lock_enabled {
+            netuid: NetUid::from(netuid),
+            enabled,
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(
+            call,
+            RawOrigin::Signed(handle.caller_account_id::<R>()),
+        )
+    }
+
     #[precompile::public("setMaxBurn(uint16,uint64)")]
     #[precompile::payable]
     fn set_max_burn(
@@ -978,6 +1010,58 @@ mod tests {
             assert_eq!(total_after, total_before + 1);
             assert_eq!(pallet_subtensor::SubnetOwner::<Runtime>::get(netuid), caller_account);
             assert!(pallet_subtensor::SubnetIdentitiesV3::<Runtime>::contains_key(netuid));
+        });
+    }
+
+    #[test]
+    fn subnet_precompile_sets_and_gets_owner_cut_auto_lock() {
+        new_test_ext().execute_with(|| {
+            let caller = addr_from_index(0x5003);
+            let netuid = setup_owner_subnet(caller);
+            let precompiles = precompiles::<SubnetPrecompile<Runtime>>();
+            let precompile_addr = addr_from_index(SubnetPrecompile::<Runtime>::INDEX);
+
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getOwnerCutAutoLockEnabled(uint16)"),
+                        (TEST_NETUID_U16,),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    precompile_utils::prelude::RuntimeHelper::<Runtime>::db_read_gas_cost(),
+                )
+                .execute_returns(false);
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("setOwnerCutAutoLockEnabled(uint16,bool)"),
+                        (TEST_NETUID_U16, true),
+                    ),
+                )
+                .execute_returns(());
+            assert!(pallet_subtensor::OwnerCutAutoLockEnabled::<Runtime>::get(
+                netuid
+            ));
+            precompiles
+                .prepare_test(
+                    caller,
+                    precompile_addr,
+                    encode_with_selector(
+                        selector_u32("getOwnerCutAutoLockEnabled(uint16)"),
+                        (TEST_NETUID_U16,),
+                    ),
+                )
+                .with_static_call(true)
+                .expect_cost(
+                    precompile_utils::prelude::RuntimeHelper::<Runtime>::db_read_gas_cost(),
+                )
+                .execute_returns(true);
         });
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 438,
+    spec_version: 439,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/sdk/python/bittensor/evm/abi/stakingV2.json
+++ b/sdk/python/bittensor/evm/abi/stakingV2.json
@@ -584,5 +584,235 @@
     "outputs": [],
     "stateMutability": "",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getColdkeyLock",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "hotkey",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "locked_mass",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint128",
+            "name": "conviction",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "last_update",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "is_perpetual",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IStaking.ColdkeyLockInfo",
+        "name": "lockInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "hotkeys",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "getHotkeyConvictions",
+    "outputs": [
+      {
+        "internalType": "uint128[]",
+        "name": "convictions",
+        "type": "uint128[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getHotkeyLock",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "exists",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "locked_mass",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint128",
+            "name": "conviction",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct IStaking.HotkeyLockInfo",
+        "name": "lockInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLockRates",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "unlockRate",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maturityRate",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRejectLockedAlpha",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "lockStake",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "destinationHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "moveLock",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setPerpetualLock",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setRejectLockedAlpha",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
   }
 ]

--- a/sdk/python/bittensor/evm/abi/subnet.json
+++ b/sdk/python/bittensor/evm/abi/subnet.json
@@ -1122,5 +1122,42 @@
 		"outputs": [],
 		"stateMutability": "payable",
 		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			}
+		],
+		"name": "getOwnerCutAutoLockEnabled",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "uint16",
+				"name": "netuid",
+				"type": "uint16"
+			},
+			{
+				"internalType": "bool",
+				"name": "enabled",
+				"type": "bool"
+			}
+		],
+		"name": "setOwnerCutAutoLockEnabled",
+		"outputs": [],
+		"stateMutability": "payable",
+		"type": "function"
 	}
 ]


### PR DESCRIPTION
## Summary

Adds complete EVM precompile support for the miner conviction and stake-locks feature.

This exposes stake-lock lifecycle operations, lock and conviction queries, recipient policy controls, and subnet owner-cut auto-lock configuration through the existing staking and subnet precompiles.

## Changes

### Staking precompile

Added the following methods:

- `lockStake(bytes32,uint256,uint256)`
- `moveLock(bytes32,uint256)`
- `setPerpetualLock(uint256,bool)`
- `setRejectLockedAlpha(bool)`
- `getColdkeyLock(bytes32,uint256)`
- `getHotkeyLock(bytes32,uint256)`
- `getHotkeyConvictions(uint256,bytes32[])`
- `getLockRates()`
- `getRejectLockedAlpha(bytes32)`

Lock queries:

- Roll state forward to the current block.
- Return conviction as exact unsigned Q64.64 bits.
- Combine perpetual, decaying, general, and owner aggregate buckets correctly.
- Report fully expired stale locks as nonexistent.
- Limit conviction batches to 64 distinct hotkeys.
- Reject duplicate hotkeys and out-of-range numeric inputs.
- Conservatively charge for all database reads, including the current block.

### Subnet precompile

Added:

- `getOwnerCutAutoLockEnabled(uint16)`
- `setOwnerCutAutoLockEnabled(uint16,bool)`

The setter preserves the runtime’s existing root and subnet-owner authorization rules.

### Solidity and SDK support

- Updated the staking and subnet Solidity interfaces.
- Updated the canonical ABI files.
- Synchronized the Python SDK ABI copies.
- Corrected the existing `unt16` typo in the subnet Solidity interface.

## Behavior notes

- There is no separate direct-unlock method. A perpetual lock is unlocked by disabling perpetual mode and allowing the lock to decay according to the runtime parameters.
- `exists` represents the rolled lock state, not merely the presence of a stale storage row.
- Hotkey conviction results preserve the order of the supplied candidate hotkeys.

## Testing

Added coverage for:

- Lock creation and roll-forward.
- Perpetual lock configuration.
- Lock movement while preserving conviction.
- Decaying lock behavior.
- Fully expired locks crossing the cleanup threshold.
- Coldkey and hotkey aggregate queries.
- Batched conviction queries.
- Owner-specific aggregate buckets.
- Recipient locked-alpha policy.
- Owner-cut auto-lock configuration.
- Empty and preconfigured lock states.
- Duplicate, oversized, and out-of-range inputs.
- Database-read gas accounting.

## Validation

- `cargo test -p subtensor-precompiles --lib`
  - 92 passed
- `cargo clippy -p subtensor-precompiles --all-targets -- -D warnings`
  - Passed
- Python EVM unit tests
  - 28 passed
- Solidity interface compilation
  - Passed
- ABI synchronization checks
  - Passed
- `git diff --check`
  - Passed