### PR TITLE
Fix claim root weight accounting

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -67,6 +67,12 @@ pub const MAX_NUM_ROOT_CLAIMS: u64 = 50;
 
 pub const MAX_SUBNET_CLAIMS: usize = 5;
 
+/// Maximum hotkeys that a manual root claim may process for one coldkey.
+///
+/// The resulting worst-case claim weight, including production transaction
+/// extensions, fits within the normal-extrinsic limit.
+pub const MAX_ROOT_CLAIM_HOTKEYS: usize = 256;
+
 pub const MAX_ROOT_CLAIM_THRESHOLD: u64 = 10_000_000;
 
 pub struct SubtensorDustRemoval<T>(PhantomData<T>);

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -6,7 +6,7 @@ use frame_support::pallet_macros::pallet_section;
 #[pallet_section]
 mod dispatches {
     use frame_support::pallet_prelude::DispatchResultWithPostInfo;
-    use frame_support::traits::schedule::v3::Anon as ScheduleAnon;
+    use frame_support::traits::{Get, schedule::v3::Anon as ScheduleAnon};
     use frame_system::pallet_prelude::BlockNumberFor;
     use sp_core::ecdsa::Signature;
     use sp_runtime::{Percent, Saturating, traits::Hash};
@@ -1888,7 +1888,13 @@ mod dispatches {
         /// * `InvalidSubnetNumber`: The subnet set is empty or exceeds the maximum number of claims.
         ///
         #[pallet::call_index(121)]
-        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::claim_root())]
+        // The work scales with the caller's storage-backed, unbounded hotkey list.
+        // Reserve a large admissible weight up front; the call refunds unused weight below.
+        #[pallet::weight(
+            <T as frame_system::Config>::BlockWeights::get()
+                .max_block
+                .saturating_div(2)
+        )]
         pub fn claim_root(
             origin: OriginFor<T>,
             subnets: BTreeSet<NetUid>,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -13,6 +13,7 @@ mod dispatches {
 
     use crate::MAX_CRV3_COMMIT_SIZE_BYTES;
     use crate::MAX_NUM_ROOT_CLAIMS;
+    use crate::MAX_ROOT_CLAIM_HOTKEYS;
     use crate::MAX_ROOT_CLAIM_THRESHOLD;
     use crate::MAX_SUBNET_CLAIMS;
 
@@ -1886,14 +1887,15 @@ mod dispatches {
         ///
         /// # Errors
         /// * `InvalidSubnetNumber`: The subnet set is empty or exceeds the maximum number of claims.
+        /// * `TooManyRootClaimHotkeys`: The coldkey's hotkey fanout exceeds one claim's bound.
         ///
         #[pallet::call_index(121)]
-        // The work scales with the caller's storage-backed, unbounded hotkey list.
-        // Reserve a large admissible weight up front; the call refunds unused weight below.
+        // The benchmark covers one hotkey and one subnet. Manual claims bound both
+        // dimensions below and refund unused weight after execution.
         #[pallet::weight(
-            <T as frame_system::Config>::BlockWeights::get()
-                .max_block
-                .saturating_div(2)
+            <T as crate::pallet::Config>::WeightInfo::claim_root()
+                .saturating_mul(MAX_ROOT_CLAIM_HOTKEYS as u64)
+                .saturating_mul(MAX_SUBNET_CLAIMS as u64)
         )]
         pub fn claim_root(
             origin: OriginFor<T>,
@@ -1907,9 +1909,17 @@ mod dispatches {
                 Error::<T>::InvalidSubnetNumber
             );
 
+            let hotkey_count = StakingHotkeys::<T>::decode_len(&coldkey).unwrap_or_default();
+            ensure!(
+                hotkey_count <= MAX_ROOT_CLAIM_HOTKEYS,
+                Error::<T>::TooManyRootClaimHotkeys
+            );
+
             Self::maybe_add_coldkey_index(&coldkey);
 
-            let weight = Self::do_root_claim(coldkey, Some(subnets))?;
+            let weight = T::DbWeight::get()
+                .reads(1)
+                .saturating_add(Self::do_root_claim(coldkey, Some(subnets))?);
             Ok((Some(weight), Pays::Yes).into())
         }
 

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -346,5 +346,7 @@ mod errors {
         /// with miner collateral on the subnet
         /// ([`crate::MAX_COLDKEY_COLLATERAL_HOTKEYS`]).
         ColdkeyCollateralPositionsFull,
+        /// The coldkey has too many staking hotkeys for a single manual root claim.
+        TooManyRootClaimHotkeys,
     }
 }

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -5,11 +5,11 @@ use crate::RootAlphaDividendsPerSubnet;
 use crate::tests::mock::*;
 use crate::{
     DefaultMinRootClaimAmount, DissolveCleanupQueue, Error, MAX_NUM_ROOT_CLAIMS,
-    MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded, NumRootClaim, NumStakingColdkeys,
-    PendingRootAlphaDivs, RootClaimable, RootClaimableThreshold, RootClaimed, StakingColdkeys,
-    StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetAlphaOut, SubnetMechanism,
-    SubnetMovingPrice, SubnetProtocolFlow, SubnetRootSellTao, SubnetTAO, SubnetTaoFlow,
-    SubnetVolume, SubtokenEnabled, Tempo, TotalStake, pallet,
+    MAX_ROOT_CLAIM_HOTKEYS, MAX_ROOT_CLAIM_THRESHOLD, MAX_SUBNET_CLAIMS, NetworksAdded,
+    NumRootClaim, NumStakingColdkeys, PendingRootAlphaDivs, RootClaimable, RootClaimableThreshold,
+    RootClaimed, StakingColdkeys, StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn,
+    SubnetAlphaOut, SubnetMechanism, SubnetMovingPrice, SubnetProtocolFlow, SubnetRootSellTao,
+    SubnetTAO, SubnetTaoFlow, SubnetVolume, SubtokenEnabled, Tempo, TotalStake, pallet,
 };
 use crate::{RootClaimType, RootClaimTypeEnum};
 use approx::assert_abs_diff_eq;
@@ -1672,25 +1672,47 @@ fn test_claim_root_subnet_limits() {
 #[test]
 fn test_claim_root_declared_weight_covers_stored_hotkey_fanout() {
     new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
         let coldkey = U256::from(1003);
-        let netuid = NetUid::from(1);
-        let hotkeys = [U256::from(1004), U256::from(1005)];
+        let subnets = (0..MAX_SUBNET_CLAIMS)
+            .map(|index| {
+                let netuid =
+                    add_dynamic_network(&U256::from(index.saturating_add(2_000)), &owner_coldkey);
+                remove_owner_registration_stake(netuid);
+                RootClaimableThreshold::<Test>::insert(netuid, I96F32::from(0));
+                netuid
+            })
+            .collect::<BTreeSet<_>>();
+        let hotkeys = (0..MAX_ROOT_CLAIM_HOTKEYS)
+            .map(|index| U256::from(index.saturating_add(10_000)))
+            .collect::<Vec<_>>();
 
-        StakingHotkeys::<Test>::insert(coldkey, hotkeys.to_vec());
-        for hotkey in hotkeys {
-            RootClaimable::<Test>::insert(hotkey, BTreeMap::from([(netuid, I96F32::from(0))]));
+        for hotkey in &hotkeys {
+            mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+                hotkey,
+                &coldkey,
+                NetUid::ROOT,
+                1_000_000u64.into(),
+            );
+            RootClaimable::<Test>::insert(
+                hotkey,
+                subnets
+                    .iter()
+                    .map(|netuid| (*netuid, I96F32::from(1)))
+                    .collect::<BTreeMap<_, _>>(),
+            );
         }
-        DissolveCleanupQueue::<Test>::put(vec![netuid]);
+        RootClaimType::<Test>::insert(coldkey, RootClaimTypeEnum::Keep);
 
-        let subnets = BTreeSet::from([netuid]);
         let call = RuntimeCall::SubtensorModule(crate::Call::claim_root {
             subnets: subnets.clone(),
         });
         let declared_weight = call.get_dispatch_info().call_weight;
-        let actual_weight = SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), subnets)
-            .expect("claim succeeds")
-            .actual_weight
-            .expect("claim reports actual weight");
+        let actual_weight =
+            SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), subnets.clone())
+                .expect("claim succeeds")
+                .actual_weight
+                .expect("claim reports actual weight");
 
         assert!(
             actual_weight.all_lte(declared_weight),
@@ -1704,6 +1726,37 @@ fn test_claim_root_declared_weight_covers_stored_hotkey_fanout() {
         assert!(
             declared_weight.all_lte(max_extrinsic),
             "declared weight {declared_weight:?} exceeds max extrinsic {max_extrinsic:?}"
+        );
+
+        for hotkey in hotkeys {
+            for netuid in &subnets {
+                assert_eq!(
+                    u64::from(SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                        &hotkey, &coldkey, *netuid,
+                    )),
+                    1_000_000,
+                    "claim must exercise the active-subnet keep path"
+                );
+            }
+        }
+    });
+}
+
+#[test]
+fn test_claim_root_rejects_hotkey_fanout_above_bound() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1003);
+        let hotkeys = (0..=MAX_ROOT_CLAIM_HOTKEYS)
+            .map(|index| U256::from(index.saturating_add(10_000)))
+            .collect::<Vec<_>>();
+        StakingHotkeys::<Test>::insert(coldkey, hotkeys);
+
+        assert_err!(
+            SubtensorModule::claim_root(
+                RuntimeOrigin::signed(coldkey),
+                BTreeSet::from([NetUid::from(1)])
+            ),
+            Error::<Test>::TooManyRootClaimHotkeys
         );
     });
 }

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -7,13 +7,13 @@ use crate::{
     DefaultMinRootClaimAmount, DissolveCleanupQueue, Error, MAX_NUM_ROOT_CLAIMS,
     MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded, NumRootClaim, NumStakingColdkeys,
     PendingRootAlphaDivs, RootClaimable, RootClaimableThreshold, RootClaimed, StakingColdkeys,
-    StakingColdkeysByIndex, SubnetAlphaIn, SubnetAlphaOut, SubnetMechanism, SubnetMovingPrice,
-    SubnetProtocolFlow, SubnetRootSellTao, SubnetTAO, SubnetTaoFlow, SubnetVolume, SubtokenEnabled,
-    Tempo, TotalStake, pallet,
+    StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetAlphaOut, SubnetMechanism,
+    SubnetMovingPrice, SubnetProtocolFlow, SubnetRootSellTao, SubnetTAO, SubnetTaoFlow,
+    SubnetVolume, SubtokenEnabled, Tempo, TotalStake, pallet,
 };
 use crate::{RootClaimType, RootClaimTypeEnum};
 use approx::assert_abs_diff_eq;
-use frame_support::dispatch::RawOrigin;
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo, RawOrigin};
 use frame_support::pallet_prelude::Weight;
 use frame_support::traits::{Currency, Get};
 use frame_support::{assert_err, assert_noop, assert_ok};
@@ -1665,6 +1665,45 @@ fn test_claim_root_subnet_limits() {
                 BTreeSet::from_iter((0u16..=10u16).into_iter().map(NetUid::from))
             ),
             Error::<Test>::InvalidSubnetNumber
+        );
+    });
+}
+
+#[test]
+fn test_claim_root_declared_weight_covers_stored_hotkey_fanout() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1003);
+        let netuid = NetUid::from(1);
+        let hotkeys = [U256::from(1004), U256::from(1005)];
+
+        StakingHotkeys::<Test>::insert(coldkey, hotkeys.to_vec());
+        for hotkey in hotkeys {
+            RootClaimable::<Test>::insert(hotkey, BTreeMap::from([(netuid, I96F32::from(0))]));
+        }
+        DissolveCleanupQueue::<Test>::put(vec![netuid]);
+
+        let subnets = BTreeSet::from([netuid]);
+        let call = RuntimeCall::SubtensorModule(crate::Call::claim_root {
+            subnets: subnets.clone(),
+        });
+        let declared_weight = call.get_dispatch_info().call_weight;
+        let actual_weight = SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), subnets)
+            .expect("claim succeeds")
+            .actual_weight
+            .expect("claim reports actual weight");
+
+        assert!(
+            actual_weight.all_lte(declared_weight),
+            "actual weight {actual_weight:?} exceeds declared weight {declared_weight:?}"
+        );
+
+        let max_extrinsic = BlockWeights::get()
+            .get(DispatchClass::Normal)
+            .max_extrinsic
+            .expect("normal extrinsics have a configured maximum");
+        assert!(
+            declared_weight.all_lte(max_extrinsic),
+            "declared weight {declared_weight:?} exceeds max extrinsic {max_extrinsic:?}"
         );
     });
 }

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -1,0 +1,47 @@
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
+use node_subtensor_runtime::{
+    BlockWeights, Runtime, RuntimeCall, TxExtension, check_mortality, check_nonce, sudo_wrapper,
+    transaction_payment_wrapper::ChargeTransactionPaymentWrapper,
+};
+use sp_runtime::{generic::Era, traits::TransactionExtension};
+use std::collections::BTreeSet;
+use subtensor_runtime_common::{NetUid, TaoBalance};
+
+#[test]
+fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
+    let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
+        subnets: BTreeSet::from([NetUid::from(1)]),
+    });
+    let extensions: TxExtension = (
+        (
+            frame_system::CheckNonZeroSender::<Runtime>::new(),
+            frame_system::CheckSpecVersion::<Runtime>::new(),
+            frame_system::CheckTxVersion::<Runtime>::new(),
+            frame_system::CheckGenesis::<Runtime>::new(),
+            check_mortality::CheckMortality::<Runtime>::from(Era::Immortal),
+            check_nonce::CheckNonce::<Runtime>::from(0),
+            frame_system::CheckWeight::<Runtime>::new(),
+        ),
+        (
+            ChargeTransactionPaymentWrapper::<Runtime>::new(TaoBalance::new(0)),
+            sudo_wrapper::SudoTransactionExtension::<Runtime>::new(),
+            pallet_shield::CheckShieldedTxValidity::<Runtime>::new(),
+            pallet_subtensor::SubtensorTransactionExtension::<Runtime>::new(),
+            pallet_drand::drand_priority::DrandPriority::<Runtime>::new(),
+        ),
+        frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(true),
+    );
+
+    let mut dispatch_info = call.get_dispatch_info();
+    dispatch_info.extension_weight = extensions.weight(&call);
+    let max_extrinsic = BlockWeights::get()
+        .get(DispatchClass::Normal)
+        .max_extrinsic
+        .expect("normal extrinsics have a configured maximum");
+
+    assert!(
+        dispatch_info.total_weight().all_lte(max_extrinsic),
+        "claim_root total weight {:?} exceeds normal max extrinsic {max_extrinsic:?}",
+        dispatch_info.total_weight()
+    );
+}


### PR DESCRIPTION
## Summary
- cap manual `claim_root` processing at 256 staking hotkeys and reject larger fanout before decoding the full vector
- derive the declared reservation from the canonical one-hotkey/one-subnet benchmark multiplied by the bounded hotkey and subnet dimensions, while retaining the actual-weight refund
- cover the full 256-hotkey × 5-subnet active Keep path and total production transaction-extension admission

## Context
The generated benchmark covers one hotkey and one subnet, while production `claim_root` calls iterate every hotkey in `StakingHotkeys` and can process up to five subnet claims. A fixed reservation did not establish an execution bound, and FRAME clamps post-dispatch weight to the pre-dispatch declaration.

## Verification
- `cargo fmt --all -- --check`
- max-bound active claim regression passed
- production extension admission test passed
- full pallet suite: 1327 passed, 9 ignored