### PR TITLE
fix: default Docker images to bundled testnet spec

### DIFF
--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -104,4 +104,23 @@ jobs:
           set -euo pipefail
           actual=$(docker image inspect subtensor-ci:amd64 --format '{{.Architecture}}')
           test "$actual" = amd64
+          expected_cmd='["--base-path","/data","--chain","/home/subtensor/chainspecs/raw_spec_testfinney.json"]'
+          grep -Fqx "CMD $expected_cmd" Dockerfile
+          grep -Fqx "CMD $expected_cmd" Dockerfile.prebuilt
+          actual_cmd=$(docker image inspect subtensor-ci:amd64 --format '{{json .Config.Cmd}}')
+          test "$actual_cmd" = "$expected_cmd"
           docker run --rm --platform linux/amd64 subtensor-ci:amd64 --help > /dev/null
+
+          generated_spec=$(mktemp)
+          docker run --rm --platform linux/amd64 \
+            --entrypoint node-subtensor \
+            subtensor-ci:amd64 \
+            build-spec --raw \
+            --chain /home/subtensor/chainspecs/raw_spec_testfinney.json \
+            > "$generated_spec"
+          jq -e \
+            '.id == "bittensor" and .protocolId == "bittensor-testnet"' \
+            "$generated_spec" > /dev/null
+          cmp \
+            <(jq -cS '.genesis' "$generated_spec") \
+            <(jq -cS '.genesis' chainspecs/raw_spec_testfinney.json)

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ EXPOSE 30333 9933 9944
 # in the script
 USER root
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["--base-path", "/data"]
+CMD ["--base-path","/data","--chain","/home/subtensor/chainspecs/raw_spec_testfinney.json"]
 
 ###############################################################################
 # ---------- 4. Local build stage --------------------------------------------

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -32,4 +32,4 @@ EXPOSE 30333 9933 9944
 
 USER root
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["--base-path", "/data"]
+CMD ["--base-path","/data","--chain","/home/subtensor/chainspecs/raw_spec_testfinney.json"]

--- a/docs/guides/running-a-node.mdx
+++ b/docs/guides/running-a-node.mdx
@@ -76,7 +76,9 @@ of pulling, uncomment the `build:` block in the compose file — it builds the
 
 The container starts as root only to fix ownership of the data directory,
 then drops to the unprivileged `subtensor` user (UID 10001) via `gosu` — see
-`scripts/docker_entrypoint.sh`.
+`scripts/docker_entrypoint.sh`. The production image's default command selects
+its bundled `chainspecs/raw_spec_testfinney.json`. If you override the container
+command, pass `--chain` explicitly.
 
 ## Run from source
 


### PR DESCRIPTION
## Summary

- default both production Docker images to the bundled raw testnet spec
- keep the entrypoint and explicit container commands unchanged
- verify the release image command and emitted testnet genesis in Docker CI

## Why

Without `--chain`, the node resolves the empty chain selector to the procedural
`test_finney` configuration. Its generated genesis can diverge from the live
testnet. Selecting the packaged raw spec in the image default makes new
default-command containers use the frozen live-testnet genesis.

## Compatibility

This changes only the Docker image's default `CMD`. Callers that override the
container command must continue to pass `--chain` explicitly. The change does
not delete, initialize, or migrate database directories; existing volumes
created against a different genesis are left untouched.

## Testing

- validated both Dockerfiles contain the expected default command
- validated the workflow YAML
- loaded the bundled spec with the production binary and matched its genesis to
  `chainspecs/raw_spec_testfinney.json`
- added CI checks for the built image command, entrypoint smoke test, testnet
  identity, and exact genesis equality
