### PR TITLE
Retry failed release Docker publications

### DIFF
--- a/.github/scripts/publish-localnet-manifest.sh
+++ b/.github/scripts/publish-localnet-manifest.sh
@@ -58,5 +58,7 @@ docker buildx imagetools create \
   --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing" \
   --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor" \
   --annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
+  --annotation "index:org.opencontainers.image.revision=$SHA" \
+  --annotation "index:org.opencontainers.image.version=$TAG" \
   "$amd64_source" \
   "$arm64_source"

--- a/.github/scripts/release-docker-publication.sh
+++ b/.github/scripts/release-docker-publication.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# Check or ensure that a release-tagged Docker workflow completed successfully
+# for an exact source commit. `gh workflow run` only confirms that GitHub
+# accepted a dispatch request; the child workflow can still fail before any job
+# starts. Ensure mode follows the child run to completion and retries transient
+# startup/discovery failures.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  release-docker-publication.sh status WORKFLOW REF EXPECTED_SHA
+  release-docker-publication.sh ensure WORKFLOW REF INPUT_NAME INPUT_VALUE EXPECTED_SHA
+EOF
+  exit 2
+}
+
+[[ $# -ge 1 ]] || usage
+mode="$1"
+shift
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+
+validate_common() {
+  local workflow="$1"
+  local ref="$2"
+  local expected_sha="$3"
+
+  [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+    || { echo "invalid GitHub repository: $GITHUB_REPOSITORY" >&2; exit 2; }
+  [[ "$workflow" =~ ^[A-Za-z0-9_.-]+\.ya?ml$ ]] \
+    || { echo "invalid workflow filename: $workflow" >&2; exit 2; }
+  [[ "$ref" =~ ^[A-Za-z0-9._/-]+$ ]] \
+    || { echo "invalid workflow ref: $ref" >&2; exit 2; }
+  [[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || { echo "expected SHA must be a lowercase 40-byte Git SHA" >&2; exit 2; }
+}
+
+workflow_runs() {
+  local workflow="$1"
+  local ref="$2"
+
+  gh api --method GET \
+    "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs" \
+    -f branch="$ref" \
+    -F per_page=100
+}
+
+successful_run_id() {
+  local workflow="$1"
+  local ref="$2"
+  local expected_sha="$3"
+
+  workflow_runs "$workflow" "$ref" \
+    | jq -er --arg sha "$expected_sha" '
+        [
+          .workflow_runs[]
+          | select(
+              (.event == "workflow_dispatch" or .event == "release") and
+              .head_sha == $sha and
+              .status == "completed" and
+              .conclusion == "success"
+            )
+        ]
+        | if length == 0 then empty else max_by(.id).id end
+      ' 2>/dev/null
+}
+
+latest_matching_run_id() {
+  local workflow="$1"
+  local ref="$2"
+  local expected_sha="$3"
+  local after_id="$4"
+
+  workflow_runs "$workflow" "$ref" \
+    | jq -er --arg sha "$expected_sha" --argjson after_id "$after_id" '
+        [
+          .workflow_runs[]
+          | select(
+              .event == "workflow_dispatch" and
+              .head_sha == $sha and
+              .id > $after_id
+            )
+        ]
+        | if length == 0 then empty else max_by(.id).id end
+      ' 2>/dev/null
+}
+
+case "$mode" in
+  status)
+    [[ $# -eq 3 ]] || usage
+    workflow="$1"
+    ref="$2"
+    expected_sha="$3"
+    validate_common "$workflow" "$ref" "$expected_sha"
+
+    if run_id=$(successful_run_id "$workflow" "$ref" "$expected_sha"); then
+      echo "$workflow already published $ref from $expected_sha in run $run_id"
+      exit 0
+    fi
+    echo "$workflow has no successful $ref publication for $expected_sha" >&2
+    exit 1
+    ;;
+
+  ensure)
+    [[ $# -eq 5 ]] || usage
+    workflow="$1"
+    ref="$2"
+    input_name="$3"
+    input_value="$4"
+    expected_sha="$5"
+    validate_common "$workflow" "$ref" "$expected_sha"
+    [[ "$input_name" =~ ^[A-Za-z0-9_-]+$ ]] \
+      || { echo "invalid workflow input name: $input_name" >&2; exit 2; }
+    [[ "$input_value" =~ ^[A-Za-z0-9._/-]+$ ]] \
+      || { echo "invalid workflow input value: $input_value" >&2; exit 2; }
+    ;;
+
+  *)
+    usage
+    ;;
+esac
+
+if run_id=$(successful_run_id "$workflow" "$ref" "$expected_sha"); then
+  echo "$workflow already published $ref from $expected_sha in run $run_id"
+  exit 0
+fi
+
+max_attempts="${PUBLICATION_MAX_ATTEMPTS:-3}"
+discovery_polls="${PUBLICATION_DISCOVERY_POLLS:-24}"
+completion_polls="${PUBLICATION_COMPLETION_POLLS:-720}"
+poll_interval="${PUBLICATION_POLL_INTERVAL_SECONDS:-15}"
+
+[[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] \
+  || { echo "PUBLICATION_MAX_ATTEMPTS must be positive" >&2; exit 2; }
+[[ "$discovery_polls" =~ ^[1-9][0-9]*$ ]] \
+  || { echo "PUBLICATION_DISCOVERY_POLLS must be positive" >&2; exit 2; }
+[[ "$completion_polls" =~ ^[1-9][0-9]*$ ]] \
+  || { echo "PUBLICATION_COMPLETION_POLLS must be positive" >&2; exit 2; }
+[[ "$poll_interval" =~ ^[0-9]+$ ]] \
+  || { echo "PUBLICATION_POLL_INTERVAL_SECONDS must be non-negative" >&2; exit 2; }
+
+attempt=1
+while (( attempt <= max_attempts )); do
+  before_id=$(workflow_runs "$workflow" "$ref" \
+    | jq -er --arg sha "$expected_sha" '
+        [
+          .workflow_runs[]
+          | select(.event == "workflow_dispatch" and .head_sha == $sha)
+          | .id
+        ]
+        | max // 0
+      ')
+
+  echo "Dispatching $workflow for $ref (attempt $attempt/$max_attempts)"
+  gh workflow run "$workflow" \
+    --repo "$GITHUB_REPOSITORY" \
+    --ref "$ref" \
+    -f "$input_name=$input_value"
+
+  run_id=""
+  poll=1
+  while (( poll <= discovery_polls )); do
+    if run_id=$(latest_matching_run_id \
+        "$workflow" "$ref" "$expected_sha" "$before_id"); then
+      break
+    fi
+    sleep "$poll_interval"
+    poll=$(( poll + 1 ))
+  done
+
+  if [[ -z "$run_id" ]]; then
+    echo "::warning::$workflow dispatch did not produce a discoverable run; retrying"
+    attempt=$(( attempt + 1 ))
+    continue
+  fi
+
+  echo "Following $workflow run $run_id"
+  poll=1
+  conclusion=""
+  while (( poll <= completion_polls )); do
+    run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+    run_event=$(jq -er '.event' <<<"$run_json")
+    run_path=$(jq -er '.path' <<<"$run_json")
+    run_sha=$(jq -er '.head_sha' <<<"$run_json")
+    [[ "$run_event" == "workflow_dispatch" ]] \
+      || { echo "run $run_id has unexpected event: $run_event" >&2; exit 1; }
+    [[ "$run_path" == ".github/workflows/$workflow" ]] \
+      || { echo "run $run_id has unexpected workflow: $run_path" >&2; exit 1; }
+    [[ "$run_sha" == "$expected_sha" ]] \
+      || { echo "run $run_id source $run_sha != $expected_sha" >&2; exit 1; }
+
+    if [[ "$(jq -er '.status' <<<"$run_json")" == "completed" ]]; then
+      conclusion=$(jq -er '.conclusion' <<<"$run_json")
+      break
+    fi
+    sleep "$poll_interval"
+    poll=$(( poll + 1 ))
+  done
+
+  if [[ -z "$conclusion" ]]; then
+    echo "$workflow run $run_id did not complete within the polling window" >&2
+    exit 1
+  fi
+
+  case "$conclusion" in
+    success)
+      echo "$workflow successfully published $ref from $expected_sha in run $run_id"
+      exit 0
+      ;;
+    startup_failure)
+      echo "::warning::$workflow run $run_id failed before jobs started; retrying"
+      attempt=$(( attempt + 1 ))
+      ;;
+    *)
+      echo "$workflow run $run_id concluded with $conclusion; not retrying a build failure" >&2
+      exit 1
+      ;;
+  esac
+done
+
+echo "$workflow did not publish $ref after $max_attempts attempts" >&2
+exit 1

--- a/.github/scripts/release-docker-publication.sh
+++ b/.github/scripts/release-docker-publication.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Check or ensure that a release Docker image exists in GHCR with immutable
-# source identity. A successful Actions run is not terminal state: dispatch
-# inputs can select a different source than the workflow ref. Publication is
-# complete only when the registry tag identifies the expected commit and tag.
+# Reconcile release Docker publication against GHCR. Registry annotations are
+# the terminal state; Actions metadata is used only to avoid dispatching work
+# that is already active. The scheduled release watcher retries any missing
+# terminal state on its next run.
 set -euo pipefail
 
 usage() {
@@ -15,43 +15,44 @@ EOF
   exit 2
 }
 
-[[ $# -ge 1 ]] || usage
+[[ $# -eq 4 ]] || usage
 mode="$1"
-shift
+workflow="$2"
+release_tag="$3"
+expected_sha="$4"
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
 
-validate_common() {
-  local workflow="$1"
-  local release_tag="$2"
-  local expected_sha="$3"
-  local lowercase_repository
+case "$mode" in
+  status) ;;
+  ensure) : "${GH_TOKEN:?GH_TOKEN required in ensure mode}" ;;
+  *) usage ;;
+esac
 
-  [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
-    || { echo "invalid GitHub repository: $GITHUB_REPOSITORY" >&2; exit 2; }
-  [[ "$release_tag" =~ ^v[0-9]+$ ]] \
-    || { echo "invalid release tag: $release_tag" >&2; exit 2; }
-  [[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] \
-    || { echo "expected SHA must be a lowercase 40-byte Git SHA" >&2; exit 2; }
-  lowercase_repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+[[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
+  || { echo "invalid GitHub repository: $GITHUB_REPOSITORY" >&2; exit 2; }
+[[ "$release_tag" =~ ^v[0-9]+$ ]] \
+  || { echo "invalid release tag: $release_tag" >&2; exit 2; }
+[[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] \
+  || { echo "expected SHA must be a lowercase 40-byte Git SHA" >&2; exit 2; }
 
-  case "$workflow" in
-    docker.yml)
-      workflow_input=tag
-      image_repository="$lowercase_repository"
-      verify_latest=true
-      ;;
-    docker-localnet.yml)
-      workflow_input=branch-or-tag
-      image_repository="${lowercase_repository}-localnet"
-      verify_latest=false
-      ;;
-    *)
-      echo "unsupported release Docker workflow: $workflow" >&2
-      exit 2
-      ;;
-  esac
-}
+lowercase_repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+case "$workflow" in
+  docker.yml)
+    workflow_input=tag
+    image_repository="$lowercase_repository"
+    publication_tags=("$release_tag" latest)
+    ;;
+  docker-localnet.yml)
+    workflow_input=branch-or-tag
+    image_repository="${lowercase_repository}-localnet"
+    publication_tags=("$release_tag")
+    ;;
+  *)
+    echo "unsupported release Docker workflow: $workflow" >&2
+    exit 2
+    ;;
+esac
 
 registry_token() {
   curl -fsSL --get \
@@ -60,89 +61,62 @@ registry_token() {
     | jq -er '.token // .access_token'
 }
 
-registry_manifest() {
-  local tag="$1"
-  local token="$2"
-
-  curl -fsSL \
-    -H "Authorization: Bearer $token" \
-    -H 'Accept: application/vnd.oci.image.index.v1+json' \
-    "https://ghcr.io/v2/$image_repository/manifests/$tag"
-}
-
 tag_matches_source() {
   local tag="$1"
   local token="$2"
-  local manifest revision version
+  local response http_code manifest jq_status
 
-  manifest=$(registry_manifest "$tag" "$token") || return 1
-  revision=$(jq -er '.annotations["org.opencontainers.image.revision"]' \
-    <<<"$manifest") || return 1
-  version=$(jq -er '.annotations["org.opencontainers.image.version"]' \
-    <<<"$manifest") || return 1
-  [[ "$revision" == "$expected_sha" && "$version" == "$release_tag" ]]
-}
+  response=$(curl -sS -w $'\n%{http_code}' \
+    -H "Authorization: Bearer $token" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "https://ghcr.io/v2/$image_repository/manifests/$tag") || return 2
+  http_code="${response##*$'\n'}"
+  manifest="${response%$'\n'*}"
+  case "$http_code" in
+    200) ;;
+    404) return 1 ;;
+    *)
+      echo "GHCR returned HTTP $http_code for $image_repository:$tag" >&2
+      return 2
+      ;;
+  esac
 
-publication_exists() {
-  local token
-
-  token=$(registry_token) || return 1
-  tag_matches_source "$release_tag" "$token" || return 1
-  if [[ "$verify_latest" == true ]]; then
-    tag_matches_source latest "$token" || return 1
+  if jq -e \
+    --arg revision "$expected_sha" \
+    --arg version "$release_tag" '
+      .annotations["org.opencontainers.image.revision"] == $revision and
+      .annotations["org.opencontainers.image.version"] == $version
+    ' <<<"$manifest" >/dev/null; then
+    return 0
+  else
+    jq_status=$?
+    [[ "$jq_status" -eq 1 ]] && return 1
+    echo "GHCR returned malformed metadata for $image_repository:$tag" >&2
+    return 2
   fi
 }
 
-workflow_runs() {
-  gh api --method GET \
-    "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs" \
-    -f branch="$workflow_ref" \
-    -F per_page=100
+publication_exists() {
+  local token status tag
+
+  token=$(registry_token) || return 2
+  for tag in "${publication_tags[@]}"; do
+    tag_matches_source "$tag" "$token" || {
+      status=$?
+      return "$status"
+    }
+  done
 }
 
-latest_matching_run_id() {
-  local after_id="$1"
-
-  workflow_runs \
-    | jq -er \
-      --arg title "$run_title" \
-      --argjson after_id "$after_id" '
-        [
-          .workflow_runs[]
-          | select(
-              .event == "workflow_dispatch" and
-              .display_title == $title and
-              .id > $after_id
-            )
-        ]
-        | if length == 0 then empty else max_by(.id).id end
-      ' 2>/dev/null
-}
-
-case "$mode" in
-  status)
-    [[ $# -eq 3 ]] || usage
-    workflow="$1"
-    release_tag="$2"
-    expected_sha="$3"
-    ;;
-  ensure)
-    [[ $# -eq 3 ]] || usage
-    workflow="$1"
-    release_tag="$2"
-    expected_sha="$3"
-    : "${GH_TOKEN:?GH_TOKEN required in ensure mode}"
-    ;;
-  *)
-    usage
-    ;;
-esac
-
-validate_common "$workflow" "$release_tag" "$expected_sha"
-
-if publication_exists; then
+publication_status=0
+publication_exists || publication_status=$?
+if [[ "$publication_status" -eq 0 ]]; then
   echo "$image_repository:$release_tag is published from $expected_sha"
   exit 0
+fi
+if [[ "$publication_status" -ne 1 ]]; then
+  echo "could not determine GHCR publication state" >&2
+  exit 2
 fi
 
 if [[ "$mode" == status ]]; then
@@ -150,118 +124,32 @@ if [[ "$mode" == status ]]; then
   exit 1
 fi
 
-max_attempts="${PUBLICATION_MAX_ATTEMPTS:-3}"
-discovery_polls="${PUBLICATION_DISCOVERY_POLLS:-24}"
-# Leave headroom for the caller's 180-minute job timeout so this helper can
-# report a useful terminal error instead of being killed mid-poll.
-completion_polls="${PUBLICATION_COMPLETION_POLLS:-660}"
-publication_polls="${PUBLICATION_REGISTRY_POLLS:-12}"
-poll_interval="${PUBLICATION_POLL_INTERVAL_SECONDS:-15}"
 workflow_ref="${PUBLICATION_WORKFLOW_REF:-main}"
-run_title="Release image $release_tag from $expected_sha"
-
-[[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] \
-  || { echo "PUBLICATION_MAX_ATTEMPTS must be positive" >&2; exit 2; }
-[[ "$discovery_polls" =~ ^[1-9][0-9]*$ ]] \
-  || { echo "PUBLICATION_DISCOVERY_POLLS must be positive" >&2; exit 2; }
-[[ "$completion_polls" =~ ^[1-9][0-9]*$ ]] \
-  || { echo "PUBLICATION_COMPLETION_POLLS must be positive" >&2; exit 2; }
-[[ "$publication_polls" =~ ^[1-9][0-9]*$ ]] \
-  || { echo "PUBLICATION_REGISTRY_POLLS must be positive" >&2; exit 2; }
-[[ "$poll_interval" =~ ^[0-9]+$ ]] \
-  || { echo "PUBLICATION_POLL_INTERVAL_SECONDS must be non-negative" >&2; exit 2; }
 [[ "$workflow_ref" =~ ^[A-Za-z0-9._/-]+$ ]] \
   || { echo "invalid workflow ref: $workflow_ref" >&2; exit 2; }
+run_title="Release image $release_tag from $expected_sha"
 
-attempt=1
-while (( attempt <= max_attempts )); do
-  before_id=$(workflow_runs \
-    | jq -er \
-      --arg title "$run_title" '
-        [
-          .workflow_runs[]
-          | select(
-              .event == "workflow_dispatch" and
-              .display_title == $title
-            )
-          | .id
-        ]
-        | max // 0
-      ')
+runs_json=$(gh api --method GET \
+  "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs" \
+  -f branch="$workflow_ref" \
+  -f event=workflow_dispatch \
+  -F per_page=100)
+active_run_id=$(jq -r --arg title "$run_title" '
+  [
+    .workflow_runs[]
+    | select(.display_title == $title and .status != "completed")
+  ]
+  | if length == 0 then empty else max_by(.id).id end
+' <<<"$runs_json")
 
-  echo "Dispatching $workflow for $release_tag (attempt $attempt/$max_attempts)"
-  gh workflow run "$workflow" \
-    --repo "$GITHUB_REPOSITORY" \
-    --ref "$workflow_ref" \
-    -f "$workflow_input=$release_tag" \
-    -f "expected-sha=$expected_sha"
+if [[ -n "$active_run_id" ]]; then
+  echo "$workflow run $active_run_id is already publishing $release_tag from $expected_sha"
+  exit 0
+fi
 
-  run_id=""
-  poll=1
-  while (( poll <= discovery_polls )); do
-    if run_id=$(latest_matching_run_id "$before_id"); then
-      break
-    fi
-    sleep "$poll_interval"
-    poll=$(( poll + 1 ))
-  done
-
-  if [[ -z "$run_id" ]]; then
-    echo "::warning::$workflow dispatch did not produce a discoverable run; retrying"
-    attempt=$(( attempt + 1 ))
-    continue
-  fi
-
-  echo "Following $workflow run $run_id"
-  poll=1
-  conclusion=""
-  while (( poll <= completion_polls )); do
-    run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
-    run_event=$(jq -er '.event' <<<"$run_json")
-    run_path=$(jq -er '.path' <<<"$run_json")
-    display_title=$(jq -er '.display_title' <<<"$run_json")
-    [[ "$run_event" == "workflow_dispatch" ]] \
-      || { echo "run $run_id has unexpected event: $run_event" >&2; exit 1; }
-    [[ "$run_path" == ".github/workflows/$workflow" ]] \
-      || { echo "run $run_id has unexpected workflow: $run_path" >&2; exit 1; }
-    [[ "$display_title" == "$run_title" ]] \
-      || { echo "run $run_id has unexpected title: $display_title" >&2; exit 1; }
-
-    if [[ "$(jq -er '.status' <<<"$run_json")" == completed ]]; then
-      conclusion=$(jq -er '.conclusion' <<<"$run_json")
-      break
-    fi
-    sleep "$poll_interval"
-    poll=$(( poll + 1 ))
-  done
-
-  if [[ -z "$conclusion" ]]; then
-    echo "$workflow run $run_id did not complete within the polling window" >&2
-    exit 1
-  fi
-
-  case "$conclusion" in
-    success)
-      for (( poll = 1; poll <= publication_polls; poll++ )); do
-        if publication_exists; then
-          echo "$image_repository:$release_tag is published from $expected_sha in run $run_id"
-          exit 0
-        fi
-        sleep "$poll_interval"
-      done
-      echo "$workflow run $run_id succeeded without publishing the expected image identity" >&2
-      exit 1
-      ;;
-    startup_failure)
-      echo "::warning::$workflow run $run_id failed before jobs started; retrying"
-      attempt=$(( attempt + 1 ))
-      ;;
-    *)
-      echo "$workflow run $run_id concluded with $conclusion; not retrying a build failure" >&2
-      exit 1
-      ;;
-  esac
-done
-
-echo "$workflow did not publish $release_tag after $max_attempts attempts" >&2
-exit 1
+gh workflow run "$workflow" \
+  --repo "$GITHUB_REPOSITORY" \
+  --ref "$workflow_ref" \
+  -f "$workflow_input=$release_tag" \
+  -f "expected-sha=$expected_sha"
+echo "Dispatched $workflow for $release_tag from $expected_sha"

--- a/.github/scripts/release-docker-publication.sh
+++ b/.github/scripts/release-docker-publication.sh
@@ -130,7 +130,9 @@ fi
 
 max_attempts="${PUBLICATION_MAX_ATTEMPTS:-3}"
 discovery_polls="${PUBLICATION_DISCOVERY_POLLS:-24}"
-completion_polls="${PUBLICATION_COMPLETION_POLLS:-720}"
+# Leave headroom for the caller's 180-minute job timeout so this helper can
+# report a useful terminal error instead of being killed mid-poll.
+completion_polls="${PUBLICATION_COMPLETION_POLLS:-660}"
 poll_interval="${PUBLICATION_POLL_INTERVAL_SECONDS:-15}"
 
 [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] \

--- a/.github/scripts/release-docker-publication.sh
+++ b/.github/scripts/release-docker-publication.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 #
-# Check or ensure that a release-tagged Docker workflow completed successfully
-# for an exact source commit. `gh workflow run` only confirms that GitHub
-# accepted a dispatch request; the child workflow can still fail before any job
-# starts. Ensure mode follows the child run to completion and retries transient
-# startup/discovery failures.
+# Check or ensure that a release Docker image exists in GHCR with immutable
+# source identity. A successful Actions run is not terminal state: dispatch
+# inputs can select a different source than the workflow ref. Publication is
+# complete only when the registry tag identifies the expected commit and tag.
 set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  release-docker-publication.sh status WORKFLOW REF EXPECTED_SHA
-  release-docker-publication.sh ensure WORKFLOW REF INPUT_NAME INPUT_VALUE EXPECTED_SHA
+  release-docker-publication.sh status WORKFLOW RELEASE_TAG EXPECTED_SHA
+  release-docker-publication.sh ensure WORKFLOW RELEASE_TAG EXPECTED_SHA
 EOF
   exit 2
 }
@@ -21,66 +20,98 @@ mode="$1"
 shift
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
-: "${GH_TOKEN:?GH_TOKEN required}"
 
 validate_common() {
   local workflow="$1"
-  local ref="$2"
+  local release_tag="$2"
   local expected_sha="$3"
+  local lowercase_repository
 
   [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] \
     || { echo "invalid GitHub repository: $GITHUB_REPOSITORY" >&2; exit 2; }
-  [[ "$workflow" =~ ^[A-Za-z0-9_.-]+\.ya?ml$ ]] \
-    || { echo "invalid workflow filename: $workflow" >&2; exit 2; }
-  [[ "$ref" =~ ^[A-Za-z0-9._/-]+$ ]] \
-    || { echo "invalid workflow ref: $ref" >&2; exit 2; }
+  [[ "$release_tag" =~ ^v[0-9]+$ ]] \
+    || { echo "invalid release tag: $release_tag" >&2; exit 2; }
   [[ "$expected_sha" =~ ^[0-9a-f]{40}$ ]] \
     || { echo "expected SHA must be a lowercase 40-byte Git SHA" >&2; exit 2; }
+  lowercase_repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+
+  case "$workflow" in
+    docker.yml)
+      workflow_input=tag
+      image_repository="$lowercase_repository"
+      verify_latest=true
+      ;;
+    docker-localnet.yml)
+      workflow_input=branch-or-tag
+      image_repository="${lowercase_repository}-localnet"
+      verify_latest=false
+      ;;
+    *)
+      echo "unsupported release Docker workflow: $workflow" >&2
+      exit 2
+      ;;
+  esac
+}
+
+registry_token() {
+  curl -fsSL --get \
+    --data-urlencode "scope=repository:$image_repository:pull" \
+    https://ghcr.io/token \
+    | jq -er '.token // .access_token'
+}
+
+registry_manifest() {
+  local tag="$1"
+  local token="$2"
+
+  curl -fsSL \
+    -H "Authorization: Bearer $token" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "https://ghcr.io/v2/$image_repository/manifests/$tag"
+}
+
+tag_matches_source() {
+  local tag="$1"
+  local token="$2"
+  local manifest revision version
+
+  manifest=$(registry_manifest "$tag" "$token") || return 1
+  revision=$(jq -er '.annotations["org.opencontainers.image.revision"]' \
+    <<<"$manifest") || return 1
+  version=$(jq -er '.annotations["org.opencontainers.image.version"]' \
+    <<<"$manifest") || return 1
+  [[ "$revision" == "$expected_sha" && "$version" == "$release_tag" ]]
+}
+
+publication_exists() {
+  local token
+
+  token=$(registry_token) || return 1
+  tag_matches_source "$release_tag" "$token" || return 1
+  if [[ "$verify_latest" == true ]]; then
+    tag_matches_source latest "$token" || return 1
+  fi
 }
 
 workflow_runs() {
-  local workflow="$1"
-  local ref="$2"
-
   gh api --method GET \
     "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/runs" \
-    -f branch="$ref" \
+    -f branch="$workflow_ref" \
     -F per_page=100
 }
 
-successful_run_id() {
-  local workflow="$1"
-  local ref="$2"
-  local expected_sha="$3"
-
-  workflow_runs "$workflow" "$ref" \
-    | jq -er --arg sha "$expected_sha" '
-        [
-          .workflow_runs[]
-          | select(
-              (.event == "workflow_dispatch" or .event == "release") and
-              .head_sha == $sha and
-              .status == "completed" and
-              .conclusion == "success"
-            )
-        ]
-        | if length == 0 then empty else max_by(.id).id end
-      ' 2>/dev/null
-}
-
 latest_matching_run_id() {
-  local workflow="$1"
-  local ref="$2"
-  local expected_sha="$3"
-  local after_id="$4"
+  local after_id="$1"
 
-  workflow_runs "$workflow" "$ref" \
-    | jq -er --arg sha "$expected_sha" --argjson after_id "$after_id" '
+  workflow_runs \
+    | jq -er \
+      --arg title "$run_title" \
+      --argjson after_id "$after_id" '
         [
           .workflow_runs[]
           | select(
               .event == "workflow_dispatch" and
-              .head_sha == $sha and
+              .display_title == $title and
               .id > $after_id
             )
         ]
@@ -92,40 +123,31 @@ case "$mode" in
   status)
     [[ $# -eq 3 ]] || usage
     workflow="$1"
-    ref="$2"
+    release_tag="$2"
     expected_sha="$3"
-    validate_common "$workflow" "$ref" "$expected_sha"
-
-    if run_id=$(successful_run_id "$workflow" "$ref" "$expected_sha"); then
-      echo "$workflow already published $ref from $expected_sha in run $run_id"
-      exit 0
-    fi
-    echo "$workflow has no successful $ref publication for $expected_sha" >&2
-    exit 1
     ;;
-
   ensure)
-    [[ $# -eq 5 ]] || usage
+    [[ $# -eq 3 ]] || usage
     workflow="$1"
-    ref="$2"
-    input_name="$3"
-    input_value="$4"
-    expected_sha="$5"
-    validate_common "$workflow" "$ref" "$expected_sha"
-    [[ "$input_name" =~ ^[A-Za-z0-9_-]+$ ]] \
-      || { echo "invalid workflow input name: $input_name" >&2; exit 2; }
-    [[ "$input_value" =~ ^[A-Za-z0-9._/-]+$ ]] \
-      || { echo "invalid workflow input value: $input_value" >&2; exit 2; }
+    release_tag="$2"
+    expected_sha="$3"
+    : "${GH_TOKEN:?GH_TOKEN required in ensure mode}"
     ;;
-
   *)
     usage
     ;;
 esac
 
-if run_id=$(successful_run_id "$workflow" "$ref" "$expected_sha"); then
-  echo "$workflow already published $ref from $expected_sha in run $run_id"
+validate_common "$workflow" "$release_tag" "$expected_sha"
+
+if publication_exists; then
+  echo "$image_repository:$release_tag is published from $expected_sha"
   exit 0
+fi
+
+if [[ "$mode" == status ]]; then
+  echo "$image_repository:$release_tag is not published from $expected_sha" >&2
+  exit 1
 fi
 
 max_attempts="${PUBLICATION_MAX_ATTEMPTS:-3}"
@@ -133,7 +155,10 @@ discovery_polls="${PUBLICATION_DISCOVERY_POLLS:-24}"
 # Leave headroom for the caller's 180-minute job timeout so this helper can
 # report a useful terminal error instead of being killed mid-poll.
 completion_polls="${PUBLICATION_COMPLETION_POLLS:-660}"
+publication_polls="${PUBLICATION_REGISTRY_POLLS:-12}"
 poll_interval="${PUBLICATION_POLL_INTERVAL_SECONDS:-15}"
+workflow_ref="${PUBLICATION_WORKFLOW_REF:-main}"
+run_title="Release image $release_tag from $expected_sha"
 
 [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] \
   || { echo "PUBLICATION_MAX_ATTEMPTS must be positive" >&2; exit 2; }
@@ -141,32 +166,40 @@ poll_interval="${PUBLICATION_POLL_INTERVAL_SECONDS:-15}"
   || { echo "PUBLICATION_DISCOVERY_POLLS must be positive" >&2; exit 2; }
 [[ "$completion_polls" =~ ^[1-9][0-9]*$ ]] \
   || { echo "PUBLICATION_COMPLETION_POLLS must be positive" >&2; exit 2; }
+[[ "$publication_polls" =~ ^[1-9][0-9]*$ ]] \
+  || { echo "PUBLICATION_REGISTRY_POLLS must be positive" >&2; exit 2; }
 [[ "$poll_interval" =~ ^[0-9]+$ ]] \
   || { echo "PUBLICATION_POLL_INTERVAL_SECONDS must be non-negative" >&2; exit 2; }
+[[ "$workflow_ref" =~ ^[A-Za-z0-9._/-]+$ ]] \
+  || { echo "invalid workflow ref: $workflow_ref" >&2; exit 2; }
 
 attempt=1
 while (( attempt <= max_attempts )); do
-  before_id=$(workflow_runs "$workflow" "$ref" \
-    | jq -er --arg sha "$expected_sha" '
+  before_id=$(workflow_runs \
+    | jq -er \
+      --arg title "$run_title" '
         [
           .workflow_runs[]
-          | select(.event == "workflow_dispatch" and .head_sha == $sha)
+          | select(
+              .event == "workflow_dispatch" and
+              .display_title == $title
+            )
           | .id
         ]
         | max // 0
       ')
 
-  echo "Dispatching $workflow for $ref (attempt $attempt/$max_attempts)"
+  echo "Dispatching $workflow for $release_tag (attempt $attempt/$max_attempts)"
   gh workflow run "$workflow" \
     --repo "$GITHUB_REPOSITORY" \
-    --ref "$ref" \
-    -f "$input_name=$input_value"
+    --ref "$workflow_ref" \
+    -f "$workflow_input=$release_tag" \
+    -f "expected-sha=$expected_sha"
 
   run_id=""
   poll=1
   while (( poll <= discovery_polls )); do
-    if run_id=$(latest_matching_run_id \
-        "$workflow" "$ref" "$expected_sha" "$before_id"); then
+    if run_id=$(latest_matching_run_id "$before_id"); then
       break
     fi
     sleep "$poll_interval"
@@ -186,15 +219,15 @@ while (( attempt <= max_attempts )); do
     run_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
     run_event=$(jq -er '.event' <<<"$run_json")
     run_path=$(jq -er '.path' <<<"$run_json")
-    run_sha=$(jq -er '.head_sha' <<<"$run_json")
+    display_title=$(jq -er '.display_title' <<<"$run_json")
     [[ "$run_event" == "workflow_dispatch" ]] \
       || { echo "run $run_id has unexpected event: $run_event" >&2; exit 1; }
     [[ "$run_path" == ".github/workflows/$workflow" ]] \
       || { echo "run $run_id has unexpected workflow: $run_path" >&2; exit 1; }
-    [[ "$run_sha" == "$expected_sha" ]] \
-      || { echo "run $run_id source $run_sha != $expected_sha" >&2; exit 1; }
+    [[ "$display_title" == "$run_title" ]] \
+      || { echo "run $run_id has unexpected title: $display_title" >&2; exit 1; }
 
-    if [[ "$(jq -er '.status' <<<"$run_json")" == "completed" ]]; then
+    if [[ "$(jq -er '.status' <<<"$run_json")" == completed ]]; then
       conclusion=$(jq -er '.conclusion' <<<"$run_json")
       break
     fi
@@ -209,8 +242,15 @@ while (( attempt <= max_attempts )); do
 
   case "$conclusion" in
     success)
-      echo "$workflow successfully published $ref from $expected_sha in run $run_id"
-      exit 0
+      for (( poll = 1; poll <= publication_polls; poll++ )); do
+        if publication_exists; then
+          echo "$image_repository:$release_tag is published from $expected_sha in run $run_id"
+          exit 0
+        fi
+        sleep "$poll_interval"
+      done
+      echo "$workflow run $run_id succeeded without publishing the expected image identity" >&2
+      exit 1
       ;;
     startup_failure)
       echo "::warning::$workflow run $run_id failed before jobs started; retrying"
@@ -223,5 +263,5 @@ while (( attempt <= max_attempts )); do
   esac
 done
 
-echo "$workflow did not publish $ref after $max_attempts attempts" >&2
+echo "$workflow did not publish $release_tag after $max_attempts attempts" >&2
 exit 1

--- a/.github/scripts/test-publish-localnet-manifest.sh
+++ b/.github/scripts/test-publish-localnet-manifest.sh
@@ -41,6 +41,8 @@ assert_case() {
     --annotation "index:org.opencontainers.image.description=Subtensor local development network for CI and local testing"
     --annotation "index:org.opencontainers.image.source=https://github.com/RaoFoundation/subtensor"
     --annotation "index:org.opencontainers.image.licenses=Apache-2.0"
+    --annotation "index:org.opencontainers.image.revision=$sha"
+    --annotation "index:org.opencontainers.image.version=pr-2928"
     "$image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
     "$image@sha256:0000000000000000000000000000000000000000000000000000000000000001"
   )

--- a/.github/scripts/test-release-docker-publication.sh
+++ b/.github/scripts/test-release-docker-publication.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+helper="$script_dir/release-docker-publication.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+cat > "$tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$MOCK_GH_LOG"
+
+if [[ "$1" == workflow && "$2" == run ]]; then
+  count=$(<"$MOCK_DISPATCH_COUNT")
+  count=$(( count + 1 ))
+  echo "$count" > "$MOCK_DISPATCH_COUNT"
+  exit 0
+fi
+
+if [[ "$1" != api ]]; then
+  echo "unexpected gh command: $*" >&2
+  exit 2
+fi
+
+endpoint=""
+for arg in "$@"; do
+  case "$arg" in
+    repos/*) endpoint="$arg" ;;
+  esac
+done
+
+case "$endpoint" in
+  */actions/workflows/docker.yml/runs)
+    count=$(<"$MOCK_DISPATCH_COUNT")
+    case "$MOCK_SCENARIO" in
+      existing)
+        cat <<JSON
+{"workflow_runs":[{"id":90,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"}]}
+JSON
+        ;;
+      retry)
+        if (( count == 0 )); then
+          echo '{"workflow_runs":[]}'
+        elif (( count == 1 )); then
+          cat <<JSON
+{"workflow_runs":[{"id":101,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}]}
+JSON
+        else
+          cat <<JSON
+{"workflow_runs":[{"id":102,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"},{"id":101,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}]}
+JSON
+        fi
+        ;;
+      failure)
+        if (( count == 0 )); then
+          echo '{"workflow_runs":[]}'
+        else
+          cat <<JSON
+{"workflow_runs":[{"id":201,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"failure"}]}
+JSON
+        fi
+        ;;
+      mismatch)
+        cat <<JSON
+{"workflow_runs":[{"id":301,"event":"workflow_dispatch","head_sha":"ffffffffffffffffffffffffffffffffffffffff","status":"completed","conclusion":"success"}]}
+JSON
+        ;;
+      *)
+        echo "unknown mock scenario: $MOCK_SCENARIO" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  */actions/runs/101)
+    cat <<JSON
+{"id":101,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}
+JSON
+    ;;
+  */actions/runs/102)
+    cat <<JSON
+{"id":102,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"}
+JSON
+    ;;
+  */actions/runs/201)
+    cat <<JSON
+{"id":201,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"failure"}
+JSON
+    ;;
+  *)
+    echo "unexpected endpoint: $endpoint" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$tmp/bin/gh"
+
+export PATH="$tmp/bin:$PATH"
+export GH_TOKEN=test-token
+export GITHUB_REPOSITORY=RaoFoundation/subtensor
+export EXPECTED_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+export MOCK_DISPATCH_COUNT="$tmp/dispatch-count"
+export MOCK_GH_LOG="$tmp/gh.log"
+export PUBLICATION_MAX_ATTEMPTS=3
+export PUBLICATION_DISCOVERY_POLLS=2
+export PUBLICATION_COMPLETION_POLLS=2
+export PUBLICATION_POLL_INTERVAL_SECONDS=0
+
+reset_fixture() {
+  echo 0 > "$MOCK_DISPATCH_COUNT"
+  : > "$MOCK_GH_LOG"
+}
+
+reset_fixture
+export MOCK_SCENARIO=existing
+"$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null
+"$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA" >/dev/null
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
+
+reset_fixture
+export MOCK_SCENARIO=retry
+retry_log=$("$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA")
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 2 ]]
+grep -q 'run 101 failed before jobs started; retrying' <<<"$retry_log"
+grep -q 'successfully published v438' <<<"$retry_log"
+
+reset_fixture
+export MOCK_SCENARIO=failure
+if "$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected a real child workflow failure to be terminal" >&2
+  exit 1
+fi
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
+
+reset_fixture
+export MOCK_SCENARIO=mismatch
+if "$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected a successful run from the wrong SHA to be rejected" >&2
+  exit 1
+fi
+
+if "$helper" status ../docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected an invalid workflow filename to be rejected" >&2
+  exit 1
+fi
+
+echo "release Docker publication tests passed"

--- a/.github/scripts/test-release-docker-publication.sh
+++ b/.github/scripts/test-release-docker-publication.sh
@@ -8,6 +8,64 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/bin"
 
+cat > "$tmp/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+for arg in "$@"; do
+  [[ "$arg" == https://* ]] && url="$arg"
+done
+
+if [[ "$url" == https://ghcr.io/token ]]; then
+  echo '{"token":"mock-registry-token"}'
+  exit 0
+fi
+
+[[ "$url" == https://ghcr.io/v2/*/manifests/* ]] || {
+  echo "unexpected curl URL: $url" >&2
+  exit 2
+}
+
+tag="${url##*/}"
+count=$(<"$MOCK_DISPATCH_COUNT")
+published=false
+revision="$EXPECTED_SHA"
+version=v438
+
+case "$MOCK_SCENARIO" in
+  existing)
+    published=true
+    ;;
+  retry)
+    (( count >= 2 )) && published=true
+    ;;
+  failure)
+    ;;
+  wrong-source)
+    published=true
+    revision=ffffffffffffffffffffffffffffffffffffffff
+    ;;
+  tag-only)
+    [[ "$tag" != latest ]] && published=true
+    ;;
+  localnet)
+    [[ "$url" == *"/raofoundation/subtensor-localnet/manifests/v438" ]] \
+      && published=true
+    ;;
+  *)
+    echo "unknown mock scenario: $MOCK_SCENARIO" >&2
+    exit 2
+    ;;
+esac
+
+[[ "$published" == true ]] || exit 22
+cat <<JSON
+{"schemaVersion":2,"annotations":{"org.opencontainers.image.revision":"$revision","org.opencontainers.image.version":"$version"}}
+JSON
+EOF
+chmod +x "$tmp/bin/curl"
+
 cat > "$tmp/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -37,21 +95,16 @@ case "$endpoint" in
   */actions/workflows/docker.yml/runs)
     count=$(<"$MOCK_DISPATCH_COUNT")
     case "$MOCK_SCENARIO" in
-      existing)
-        cat <<JSON
-{"workflow_runs":[{"id":90,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"}]}
-JSON
-        ;;
       retry)
         if (( count == 0 )); then
           echo '{"workflow_runs":[]}'
         elif (( count == 1 )); then
           cat <<JSON
-{"workflow_runs":[{"id":101,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}]}
+{"workflow_runs":[{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"startup_failure"}]}
 JSON
         else
           cat <<JSON
-{"workflow_runs":[{"id":102,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"},{"id":101,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}]}
+{"workflow_runs":[{"id":102,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"success"},{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"startup_failure"}]}
 JSON
         fi
         ;;
@@ -60,34 +113,43 @@ JSON
           echo '{"workflow_runs":[]}'
         else
           cat <<JSON
-{"workflow_runs":[{"id":201,"event":"workflow_dispatch","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"failure"}]}
+{"workflow_runs":[{"id":201,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"failure"}]}
 JSON
         fi
         ;;
-      mismatch)
-        cat <<JSON
-{"workflow_runs":[{"id":301,"event":"workflow_dispatch","head_sha":"ffffffffffffffffffffffffffffffffffffffff","status":"completed","conclusion":"success"}]}
+      wrong-source)
+        if (( count == 0 )); then
+          echo '{"workflow_runs":[]}'
+        else
+          cat <<JSON
+{"workflow_runs":[{"id":301,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"success"}]}
 JSON
+        fi
         ;;
       *)
-        echo "unknown mock scenario: $MOCK_SCENARIO" >&2
+        echo "unexpected workflow run query for scenario: $MOCK_SCENARIO" >&2
         exit 2
         ;;
     esac
     ;;
   */actions/runs/101)
     cat <<JSON
-{"id":101,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"startup_failure"}
+{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"startup_failure"}
 JSON
     ;;
   */actions/runs/102)
     cat <<JSON
-{"id":102,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"success"}
+{"id":102,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"success"}
 JSON
     ;;
   */actions/runs/201)
     cat <<JSON
-{"id":201,"event":"workflow_dispatch","path":".github/workflows/docker.yml","head_sha":"$EXPECTED_SHA","status":"completed","conclusion":"failure"}
+{"id":201,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"failure"}
+JSON
+    ;;
+  */actions/runs/301)
+    cat <<JSON
+{"id":301,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"success"}
 JSON
     ;;
   *)
@@ -102,11 +164,13 @@ export PATH="$tmp/bin:$PATH"
 export GH_TOKEN=test-token
 export GITHUB_REPOSITORY=RaoFoundation/subtensor
 export EXPECTED_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+export RUN_TITLE="Release image v438 from $EXPECTED_SHA"
 export MOCK_DISPATCH_COUNT="$tmp/dispatch-count"
 export MOCK_GH_LOG="$tmp/gh.log"
 export PUBLICATION_MAX_ATTEMPTS=3
 export PUBLICATION_DISCOVERY_POLLS=2
 export PUBLICATION_COMPLETION_POLLS=2
+export PUBLICATION_REGISTRY_POLLS=2
 export PUBLICATION_POLL_INTERVAL_SECONDS=0
 
 reset_fixture() {
@@ -117,33 +181,53 @@ reset_fixture() {
 reset_fixture
 export MOCK_SCENARIO=existing
 "$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null
-"$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA" >/dev/null
+"$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
 
 reset_fixture
 export MOCK_SCENARIO=retry
-retry_log=$("$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA")
+retry_log=$("$helper" ensure docker.yml v438 "$EXPECTED_SHA")
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 2 ]]
 grep -q 'run 101 failed before jobs started; retrying' <<<"$retry_log"
-grep -q 'successfully published v438' <<<"$retry_log"
+grep -q 'subtensor:v438 is published' <<<"$retry_log"
+grep -Fq -- "--ref main -f tag=v438 -f expected-sha=$EXPECTED_SHA" "$MOCK_GH_LOG"
 
 reset_fixture
 export MOCK_SCENARIO=failure
-if "$helper" ensure docker.yml v438 tag v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
   echo "expected a real child workflow failure to be terminal" >&2
   exit 1
 fi
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
 
+# Regression: a successful run whose effective input built another commit must
+# not satisfy publication, even if its workflow ref and head_sha look correct.
 reset_fixture
-export MOCK_SCENARIO=mismatch
+export MOCK_SCENARIO=wrong-source
+if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected wrong image source metadata to be rejected" >&2
+  exit 1
+fi
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
+
+reset_fixture
+export MOCK_SCENARIO=tag-only
 if "$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
-  echo "expected a successful run from the wrong SHA to be rejected" >&2
+  echo "expected a missing node latest tag to require publication" >&2
   exit 1
 fi
 
-if "$helper" status ../docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
-  echo "expected an invalid workflow filename to be rejected" >&2
+reset_fixture
+export MOCK_SCENARIO=localnet
+"$helper" status docker-localnet.yml v438 "$EXPECTED_SHA" >/dev/null
+
+if "$helper" status other.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected an unsupported workflow to be rejected" >&2
+  exit 1
+fi
+
+if "$helper" status docker.yml main "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected a non-release tag to be rejected" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-release-docker-publication.sh
+++ b/.github/scripts/test-release-docker-publication.sh
@@ -28,41 +28,43 @@ fi
 }
 
 tag="${url##*/}"
-count=$(<"$MOCK_DISPATCH_COUNT")
 published=false
 revision="$EXPECTED_SHA"
-version=v438
 
 case "$MOCK_SCENARIO" in
-  existing)
-    published=true
-    ;;
-  retry)
-    (( count >= 2 )) && published=true
-    ;;
-  failure)
-    ;;
+  existing) published=true ;;
   wrong-source)
     published=true
     revision=ffffffffffffffffffffffffffffffffffffffff
     ;;
-  tag-only)
-    [[ "$tag" != latest ]] && published=true
-    ;;
+  tag-only) [[ "$tag" != latest ]] && published=true ;;
   localnet)
     [[ "$url" == *"/raofoundation/subtensor-localnet/manifests/v438" ]] \
       && published=true
     ;;
+  active|missing|failed|malformed) ;;
+  unavailable) exit 7 ;;
   *)
     echo "unknown mock scenario: $MOCK_SCENARIO" >&2
     exit 2
     ;;
 esac
 
-[[ "$published" == true ]] || exit 22
-cat <<JSON
-{"schemaVersion":2,"annotations":{"org.opencontainers.image.revision":"$revision","org.opencontainers.image.version":"$version"}}
+if [[ "$MOCK_SCENARIO" == malformed ]]; then
+  echo '{'
+  echo 200
+  exit 0
+fi
+
+if [[ "$published" == true ]]; then
+  cat <<JSON
+{"schemaVersion":2,"annotations":{"org.opencontainers.image.revision":"$revision","org.opencontainers.image.version":"v438"}}
 JSON
+  echo 200
+else
+  echo
+  echo 404
+fi
 EOF
 chmod +x "$tmp/bin/curl"
 
@@ -74,86 +76,31 @@ printf '%s\n' "$*" >> "$MOCK_GH_LOG"
 
 if [[ "$1" == workflow && "$2" == run ]]; then
   count=$(<"$MOCK_DISPATCH_COUNT")
-  count=$(( count + 1 ))
-  echo "$count" > "$MOCK_DISPATCH_COUNT"
+  echo $(( count + 1 )) > "$MOCK_DISPATCH_COUNT"
   exit 0
 fi
 
-if [[ "$1" != api ]]; then
+[[ "$1" == api ]] || {
   echo "unexpected gh command: $*" >&2
   exit 2
-fi
+}
 
-endpoint=""
-for arg in "$@"; do
-  case "$arg" in
-    repos/*) endpoint="$arg" ;;
-  esac
-done
-
-case "$endpoint" in
-  */actions/workflows/docker.yml/runs)
-    count=$(<"$MOCK_DISPATCH_COUNT")
-    case "$MOCK_SCENARIO" in
-      retry)
-        if (( count == 0 )); then
-          echo '{"workflow_runs":[]}'
-        elif (( count == 1 )); then
-          cat <<JSON
-{"workflow_runs":[{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"startup_failure"}]}
+case "$MOCK_SCENARIO" in
+  active)
+    cat <<JSON
+{"workflow_runs":[{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"in_progress","conclusion":null}]}
 JSON
-        else
-          cat <<JSON
-{"workflow_runs":[{"id":102,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"success"},{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"startup_failure"}]}
-JSON
-        fi
-        ;;
-      failure)
-        if (( count == 0 )); then
-          echo '{"workflow_runs":[]}'
-        else
-          cat <<JSON
+    ;;
+  failed)
+    cat <<JSON
 {"workflow_runs":[{"id":201,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"failure"}]}
 JSON
-        fi
-        ;;
-      wrong-source)
-        if (( count == 0 )); then
-          echo '{"workflow_runs":[]}'
-        else
-          cat <<JSON
-{"workflow_runs":[{"id":301,"event":"workflow_dispatch","display_title":"$RUN_TITLE","status":"completed","conclusion":"success"}]}
-JSON
-        fi
-        ;;
-      *)
-        echo "unexpected workflow run query for scenario: $MOCK_SCENARIO" >&2
-        exit 2
-        ;;
-    esac
     ;;
-  */actions/runs/101)
-    cat <<JSON
-{"id":101,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"startup_failure"}
-JSON
-    ;;
-  */actions/runs/102)
-    cat <<JSON
-{"id":102,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"success"}
-JSON
-    ;;
-  */actions/runs/201)
-    cat <<JSON
-{"id":201,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"failure"}
-JSON
-    ;;
-  */actions/runs/301)
-    cat <<JSON
-{"id":301,"event":"workflow_dispatch","display_title":"$RUN_TITLE","path":".github/workflows/docker.yml","status":"completed","conclusion":"success"}
-JSON
+  missing|wrong-source)
+    echo '{"workflow_runs":[]}'
     ;;
   *)
-    echo "unexpected endpoint: $endpoint" >&2
+    echo "unexpected Actions query for scenario: $MOCK_SCENARIO" >&2
     exit 2
     ;;
 esac
@@ -167,11 +114,6 @@ export EXPECTED_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 export RUN_TITLE="Release image v438 from $EXPECTED_SHA"
 export MOCK_DISPATCH_COUNT="$tmp/dispatch-count"
 export MOCK_GH_LOG="$tmp/gh.log"
-export PUBLICATION_MAX_ATTEMPTS=3
-export PUBLICATION_DISCOVERY_POLLS=2
-export PUBLICATION_COMPLETION_POLLS=2
-export PUBLICATION_REGISTRY_POLLS=2
-export PUBLICATION_POLL_INTERVAL_SECONDS=0
 
 reset_fixture() {
   echo 0 > "$MOCK_DISPATCH_COUNT"
@@ -185,29 +127,33 @@ export MOCK_SCENARIO=existing
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
 
 reset_fixture
-export MOCK_SCENARIO=retry
-retry_log=$("$helper" ensure docker.yml v438 "$EXPECTED_SHA")
-[[ "$(<"$MOCK_DISPATCH_COUNT")" == 2 ]]
-grep -q 'run 101 failed before jobs started; retrying' <<<"$retry_log"
-grep -q 'subtensor:v438 is published' <<<"$retry_log"
+export MOCK_SCENARIO=active
+active_log=$("$helper" ensure docker.yml v438 "$EXPECTED_SHA")
+grep -q 'run 101 is already publishing' <<<"$active_log"
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
+
+reset_fixture
+export MOCK_SCENARIO=missing
+"$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
 grep -Fq -- "--ref main -f tag=v438 -f expected-sha=$EXPECTED_SHA" "$MOCK_GH_LOG"
 
+# A completed failure is not active. Scheduled reconciliation dispatches a new
+# attempt while keeping the failed child visible as its own terminal run.
 reset_fixture
-export MOCK_SCENARIO=failure
-if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
-  echo "expected a real child workflow failure to be terminal" >&2
-  exit 1
-fi
+export MOCK_SCENARIO=failed
+"$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
 
-# Regression: a successful run whose effective input built another commit must
-# not satisfy publication, even if its workflow ref and head_sha look correct.
+# Regression: successful Actions metadata cannot satisfy publication when the
+# registry identifies a different source commit.
 reset_fixture
 export MOCK_SCENARIO=wrong-source
-if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+if "$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
   echo "expected wrong image source metadata to be rejected" >&2
   exit 1
 fi
+"$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null
 [[ "$(<"$MOCK_DISPATCH_COUNT")" == 1 ]]
 
 reset_fixture
@@ -216,6 +162,22 @@ if "$helper" status docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
   echo "expected a missing node latest tag to require publication" >&2
   exit 1
 fi
+
+reset_fixture
+export MOCK_SCENARIO=unavailable
+if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected an unavailable registry to block dispatch" >&2
+  exit 1
+fi
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
+
+reset_fixture
+export MOCK_SCENARIO=malformed
+if "$helper" ensure docker.yml v438 "$EXPECTED_SHA" >/dev/null 2>&1; then
+  echo "expected malformed registry metadata to block dispatch" >&2
+  exit 1
+fi
+[[ "$(<"$MOCK_DISPATCH_COUNT")" == 0 ]]
 
 reset_fixture
 export MOCK_SCENARIO=localnet

--- a/.github/workflows/check-localnet-publication.yml
+++ b/.github/workflows/check-localnet-publication.yml
@@ -9,6 +9,9 @@ on:
       - ".github/scripts/test-resolve-localnet-image.sh"
       - ".github/scripts/publish-localnet-manifest.sh"
       - ".github/scripts/test-publish-localnet-manifest.sh"
+      - ".github/scripts/release-docker-publication.sh"
+      - ".github/scripts/test-release-docker-publication.sh"
+      - ".github/workflows/watch-mainnet-release.yml"
 
 concurrency:
   group: check-localnet-publication-${{ github.ref }}
@@ -28,3 +31,6 @@ jobs:
 
       - name: Test immutable manifest publication
         run: ./.github/scripts/test-publish-localnet-manifest.sh
+
+      - name: Test release publication retries
+        run: ./.github/scripts/test-release-docker-publication.sh

--- a/.github/workflows/check-localnet-publication.yml
+++ b/.github/workflows/check-localnet-publication.yml
@@ -3,6 +3,7 @@ name: Localnet Publication Contract
 on:
   pull_request:
     paths:
+      - ".github/workflows/docker.yml"
       - ".github/workflows/docker-localnet.yml"
       - ".github/workflows/check-localnet-publication.yml"
       - ".github/scripts/resolve-localnet-image.sh"

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,4 +1,5 @@
 name: Publish Localnet Docker Image
+run-name: Release image ${{ inputs.branch-or-tag || github.ref_name }} from ${{ inputs.expected-sha || github.sha }}
 
 # Localnet images are the chain-in-a-box used by SDK/btcli e2e harnesses.
 # The release train force-moves the devnet/testnet mirror branch only after
@@ -22,9 +23,16 @@ on:
         description: "PR number to build (e.g. 2283). Creates tag pr-{number} and does not move :latest."
         required: false
         default: ""
+      expected-sha:
+        description: "Require the selected source ref to resolve to this commit"
+        required: false
+        default: ""
 
 concurrency:
-  group: docker-localnet-${{ github.ref }}
+  # Release recovery dispatches the current workflow definition from main.
+  # Isolate it from ordinary main publication so a later push cannot cancel
+  # an in-flight immutable release build.
+  group: docker-localnet-${{ inputs.expected-sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -105,7 +113,17 @@ jobs:
 
       - name: Record source commit
         id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          EXPECTED_SHA: ${{ inputs.expected-sha }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          if [[ -n "$EXPECTED_SHA" ]]; then
+            [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] \
+              || { echo "expected-sha must be a full lowercase commit SHA"; exit 1; }
+            [[ "$sha" == "$EXPECTED_SHA" ]] \
+              || { echo "selected source $sha does not match expected $EXPECTED_SHA"; exit 1; }
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   # Build node binaries for both runtimes on both architectures.
   artifacts:

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -33,7 +33,7 @@ concurrency:
   # Isolate it from ordinary main publication so a later push cannot cancel
   # an in-flight immutable release build.
   group: docker-localnet-${{ inputs.expected-sha || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ inputs.expected-sha == '' }}
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
 name: Publish Docker Image
+run-name: Release image ${{ inputs.tag || github.ref_name }} from ${{ inputs.expected-sha || github.sha }}
 
 # Node images publish whenever main or a network mirror moves, on runtime
 # releases, and on demand. Main advances the development-facing :main tag.
@@ -18,9 +19,16 @@ on:
         description: "Ref to build and Docker tag to publish (defaults to the dispatching ref)"
         required: false
         default: ""
+      expected-sha:
+        description: "Require the selected source ref to resolve to this commit"
+        required: false
+        default: ""
 
 concurrency:
-  group: docker-${{ github.ref }}
+  # Release recovery dispatches the current workflow definition from main.
+  # Isolate it from ordinary main publication so a later push cannot cancel
+  # an in-flight immutable release build.
+  group: docker-${{ inputs.expected-sha || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -41,7 +49,17 @@ jobs:
 
       - name: Resolve immutable source revision
         id: ref
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          EXPECTED_SHA: ${{ inputs.expected-sha }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          if [[ -n "$EXPECTED_SHA" ]]; then
+            [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] \
+              || { echo "expected-sha must be a full lowercase commit SHA"; exit 1; }
+            [[ "$sha" == "$EXPECTED_SHA" ]] \
+              || { echo "selected source $sha does not match expected $EXPECTED_SHA"; exit 1; }
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
   binary:
     name: production binary (${{ matrix.platform.arch }})
@@ -181,3 +199,6 @@ jobs:
           tags: |
             ${{ env.image }}:${{ env.tag }}
             ${{ env.latest_tag == 'true' && format('{0}:latest', env.image) || '' }}
+          annotations: |
+            index:org.opencontainers.image.revision=${{ needs.setup.outputs.sha }}
+            index:org.opencontainers.image.version=${{ env.tag }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ concurrency:
   # Isolate it from ordinary main publication so a later push cannot cancel
   # an in-flight immutable release build.
   group: docker-${{ inputs.expected-sha || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ inputs.expected-sha == '' }}
 
 permissions:
   contents: read

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -350,10 +350,9 @@ jobs:
       needs.check.result == 'success' &&
       needs.check.outputs.docker_needed == 'true' &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
-    # This job only checks out the helper and polls GitHub; keep build runners
-    # available for the child image workflows that do the CPU-heavy work.
+    # This job only queries GitHub/GHCR; keep build runners available for the
+    # child image workflows that do the CPU-heavy work.
     runs-on: ubuntu-latest
-    timeout-minutes: 180
     permissions:
       actions: write
       contents: read
@@ -369,8 +368,8 @@ jobs:
       - uses: actions/checkout@v4
 
       # Dispatch the current workflow definition with an immutable release tag
-      # and expected source SHA, then verify the resulting registry identity.
-      # A startup failure is retried; a real build failure remains terminal.
+      # and expected source SHA. Scheduled watcher runs reconcile GHCR until
+      # the terminal registry identity exists, without duplicating active work.
       - name: Ensure release image is published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -350,7 +350,9 @@ jobs:
       needs.check.result == 'success' &&
       needs.check.outputs.docker_needed == 'true' &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
-    runs-on: [self-hosted, fireactions-turbo-8]
+    # This job only checks out the helper and polls GitHub; keep build runners
+    # available for the child image workflows that do the CPU-heavy work.
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
       actions: write

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -363,16 +363,14 @@ jobs:
         include:
           - name: node
             workflow: docker.yml
-            input_name: tag
           - name: localnet
             workflow: docker-localnet.yml
-            input_name: branch-or-tag
     steps:
       - uses: actions/checkout@v4
 
-      # Dispatch at the immutable release tag, then follow the child run to a
-      # terminal conclusion. A startup failure is retried; a real build failure
-      # remains terminal and visible on this watcher run.
+      # Dispatch the current workflow definition with an immutable release tag
+      # and expected source SHA, then verify the resulting registry identity.
+      # A startup failure is retried; a real build failure remains terminal.
       - name: Ensure release image is published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -380,8 +378,6 @@ jobs:
           tag="v${{ needs.check.outputs.spec_version }}"
           .github/scripts/release-docker-publication.sh ensure \
             "${{ matrix.workflow }}" \
-            "$tag" \
-            "${{ matrix.input_name }}" \
             "$tag" \
             "${{ needs.check.outputs.sha }}"
 

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -9,7 +9,7 @@ name: Watch Mainnet Release
 # failed or partial upload:
 #   1. GitHub release v<spec_version>, with the srtool wasm + digest and
 #      multisig call data from the release train attached as assets
-#   2. Docker images via explicit dispatch of docker.yml and
+#   2. Docker images via observed, retryable dispatches of docker.yml and
 #      docker-localnet.yml (a release created with the default GITHUB_TOKEN
 #      does not emit `release: published`, so their `on: release` triggers
 #      never fire for releases cut by this workflow)
@@ -45,6 +45,7 @@ jobs:
       actions: read # list/download the release-train artifact
     outputs:
       release_needed: ${{ steps.compare.outputs.release_needed }}
+      docker_needed: ${{ steps.compare.outputs.docker_needed }}
       python_needed: ${{ steps.compare.outputs.python_needed }}
       spec_version: ${{ steps.compare.outputs.spec_version }}
       release_tag: ${{ steps.compare.outputs.release_tag }}
@@ -91,6 +92,7 @@ jobs:
           if [ "$chain_spec" -gt "$local_spec" ]; then
             echo "Main does not contain the on-chain runtime yet; refusing to publish."
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "docker_needed=false" >> "$GITHUB_OUTPUT"
             echo "python_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -113,6 +115,7 @@ jobs:
             echo "Historical release $release_tag is complete; Python was handled manually."
             echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "docker_needed=false" >> "$GITHUB_OUTPUT"
             echo "python_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -211,7 +214,18 @@ jobs:
             fi
           fi
 
+          docker_needed=true
+          if .github/scripts/release-docker-publication.sh \
+              status docker.yml "$release_tag" "$release_sha" &&
+            .github/scripts/release-docker-publication.sh \
+              status docker-localnet.yml "$release_tag" "$release_sha"; then
+            docker_needed=false
+          else
+            echo "One or more release Docker images still need publication."
+          fi
+
           echo "release_needed=$release_needed" >> "$GITHUB_OUTPUT"
+          echo "docker_needed=$docker_needed" >> "$GITHUB_OUTPUT"
           echo "python_needed=$python_needed" >> "$GITHUB_OUTPUT"
 
   release:
@@ -329,24 +343,45 @@ jobs:
             --latest
 
   publish-docker:
-    name: Dispatch Docker image publishing
+    name: Publish ${{ matrix.name }} Docker image
     needs: [check, release]
-    if: needs.check.outputs.release_needed == 'true'
+    if: >-
+      always() &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.docker_needed == 'true' &&
+      (needs.release.result == 'success' || needs.release.result == 'skipped')
     runs-on: [self-hosted, fireactions-turbo-8]
+    timeout-minutes: 180
     permissions:
       actions: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: node
+            workflow: docker.yml
+            input_name: tag
+          - name: localnet
+            workflow: docker-localnet.yml
+            input_name: branch-or-tag
     steps:
-      # Dispatch at the release tag so both workflows check out and tag the
-      # exact released sha, even if main has moved on.
-      - name: Dispatch docker workflows at the release tag
+      - uses: actions/checkout@v4
+
+      # Dispatch at the immutable release tag, then follow the child run to a
+      # terminal conclusion. A startup failure is retried; a real build failure
+      # remains terminal and visible on this watcher run.
+      - name: Ensure release image is published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="v${{ needs.check.outputs.spec_version }}"
-          gh workflow run docker.yml \
-            --repo "$GITHUB_REPOSITORY" --ref "$tag" -f tag="$tag"
-          gh workflow run docker-localnet.yml \
-            --repo "$GITHUB_REPOSITORY" --ref "$tag" -f branch-or-tag="$tag"
+          .github/scripts/release-docker-publication.sh ensure \
+            "${{ matrix.workflow }}" \
+            "$tag" \
+            "${{ matrix.input_name }}" \
+            "$tag" \
+            "${{ needs.check.outputs.sha }}"
 
   # Full platform matrix (manylinux x86_64/aarch64, macOS arm64/x86_64,
   # sdist) at the released commit; the SDK's committed .dev0 is stamped stable.


### PR DESCRIPTION
## Summary
- publish immutable OCI revision/version metadata for release node and localnet images
- validate the selected build source against the expected release commit
- reconcile missing GHCR state on each scheduled watcher run without duplicating active work
- require both the versioned node tag and :latest to identify the expected release
- isolate immutable release builds from ordinary branch-publication concurrency

## Tests
- .github/scripts/test-release-docker-publication.sh
- .github/scripts/test-resolve-localnet-image.sh
- .github/scripts/test-publish-localnet-manifest.sh
- bash -n on the edited scripts
- ShellCheck on the edited scripts
- Actionlint on the edited workflows
- read-only GHCR predicate check against v439
- git diff --check