### PR TITLE
fix: restore release quality gates

### DIFF
--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -8,6 +8,10 @@ use std::collections::BTreeSet;
 use subtensor_runtime_common::{NetUid, TaoBalance};
 
 #[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test asserts the runtime configures a normal extrinsic limit"
+)]
 fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
     let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
         subnets: BTreeSet::from([NetUid::from(1)]),
@@ -34,12 +38,10 @@ fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
 
     let mut dispatch_info = call.get_dispatch_info();
     dispatch_info.extension_weight = extensions.weight(&call);
-    let Some(max_extrinsic) = BlockWeights::get()
+    let max_extrinsic = BlockWeights::get()
         .get(DispatchClass::Normal)
         .max_extrinsic
-    else {
-        panic!("normal extrinsics have a configured maximum");
-    };
+        .expect("normal extrinsics have a configured maximum");
 
     assert!(
         dispatch_info.total_weight().all_lte(max_extrinsic),

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "bittensor"
-version = "11.0.1.dev0"
+version = "11.0.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bittensor-core" },
@@ -165,7 +165,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.1"
+version = "0.1.2"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]


### PR DESCRIPTION
## Summary

- refresh sdk/python/uv.lock for the 11.0.2.dev0 and 0.1.2 package version bumps
- restore the direct expectation in claim_root_weight with a narrowly scoped lint allowance
- fix the remaining SDK lock and Rust formatting quality gates on #2994

## Verification

- uv lock --check
- cargo fmt --all -- --check
- SKIP_WASM_BUILD=1 cargo clippy -p node-subtensor-runtime --test claim_root_weight --no-deps -- -D warnings
- SKIP_WASM_BUILD=1 cargo test -p node-subtensor-runtime --test claim_root_weight

## Scope

Stacked on and targeting release-v441 (#2994). #2995 handles the separate Python publication workflow finding.