### PR TITLE
Add ABI/annotation drift check; fix one dropped stakingV2 face

### DIFF
--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -104,6 +104,7 @@ runtime-benchmarks = [
 
 [dev-dependencies]
 pallet-drand = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 pallet-evm-chain-id = { workspace = true, features = ["std"] }
 pallet-preimage = { workspace = true, features = ["std"] }
 pallet-scheduler = { workspace = true, features = ["std"] }

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -209,6 +209,30 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "coldkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netuid",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTotalColdkeyStakeOnSubnet",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "hotkey",
         "type": "bytes32"
       }

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -143,6 +143,18 @@ interface IStaking {
     ) external view returns (uint256);
 
     /**
+     * @dev Returns the total amount of stake under a coldkey on a given subnet.
+     *
+     * @param coldkey The coldkey public key (32 bytes).
+     * @param netuid The subnet id.
+     * @return The amount of RAO staked by the coldkey on that subnet.
+     */
+    function getTotalColdkeyStakeOnSubnet(
+        bytes32 coldkey,
+        uint256 netuid
+    ) external view returns (uint256);
+
+    /**
      * @dev Returns the total amount of stake under a hotkey (delegative or otherwise)
      *
      * This function allows external accounts and contracts to query the total amount of RAO staked under a hotkey

--- a/precompiles/tests/abi_drift.rs
+++ b/precompiles/tests/abi_drift.rs
@@ -1,0 +1,171 @@
+//! Guards the vendored Solidity artifacts against the Rust source of truth.
+//!
+//! `precompiles/src/solidity/*.abi` is what EVM integrators consume as the interface of record. It is
+//! maintained alongside `precompiles/src/*.rs` rather than generated from it, so a face can be added
+//! to the Rust and missed in the ABI. When that happens the omission is silent: the precompile
+//! dispatches correctly on chain, but tooling that enumerates from the vendored ABI cannot see the
+//! face at all.
+//!
+//! This test diffs the two sets in BOTH directions and fails naming the offending signature.
+//!
+//! Run: `cargo test -p subtensor-precompiles --test abi_drift`
+
+#![allow(clippy::expect_used, clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Functions declared in `.abi` artifacts that are deliberately NOT `#[precompile::public]`.
+///
+/// `0x402`/`0x403` (ed25519 / sr25519) consume raw calldata and dispatch no selector — the `.sol`
+/// and `.abi` artifacts describe the calling convention for integrators, but there is no annotated
+/// face behind them. Anything added here needs the same kind of justification.
+const ABI_ONLY_ALLOWLIST: &[&str] = &["verify(bytes32,bytes32,bytes32,bytes32)"];
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every signature inside a `#[precompile::public("...")]` attribute across `precompiles/src/*.rs`.
+///
+/// The attribute is matched across newlines on purpose. `rustfmt` wraps long attributes, so a
+/// line-oriented scan silently misses exactly the faces with the most parameters — today that is
+/// `serveAxonTls` and both long `registerNetwork` variants, three of the most privileged faces in
+/// the tree. This scanner is whitespace- and newline-agnostic by construction.
+fn rust_faces(src: &Path) -> BTreeSet<String> {
+    const OPEN: &str = "#[precompile::public";
+    let mut out = BTreeSet::new();
+
+    let dir = fs::read_dir(src).expect("read precompiles/src");
+    for entry in dir {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let body = fs::read_to_string(&path).expect("read .rs source");
+        let mut rest: &str = &body;
+
+        while let Some(open_at) = rest.find(OPEN) {
+            let Some(after) = rest.get(open_at.saturating_add(OPEN.len())..) else {
+                break;
+            };
+            // The first quoted string after the attribute name is the signature, however it wraps.
+            let Some(q1) = after.find('"') else { break };
+            let Some(tail) = after.get(q1.saturating_add(1)..) else {
+                break;
+            };
+            let Some(q2) = tail.find('"') else { break };
+            let Some(sig) = tail.get(..q2) else { break };
+
+            out.insert(sig.trim().to_string());
+
+            rest = tail.get(q2..).unwrap_or_default();
+        }
+    }
+    out
+}
+
+/// Every `type: "function"` entry across `precompiles/src/solidity/*.abi`, as a canonical signature.
+///
+/// Deliberately module-agnostic: it unions every `.abi` file rather than pairing each to a Rust
+/// module. Rust modules are `snake_case` and the artifacts are `camelCase`, and `staking.rs` alone
+/// declares both `staking` and `stakingV2` — a per-module mapping is a second thing that can be
+/// wrong, and it fails in the direction that manufactures findings.
+fn abi_faces(solidity: &Path) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+
+    let dir = fs::read_dir(solidity).expect("read precompiles/src/solidity");
+    for entry in dir {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("abi") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path).expect("read .abi artifact");
+        let json: serde_json::Value = serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("{}: invalid JSON: {e}", path.display()));
+        let entries = json
+            .as_array()
+            .unwrap_or_else(|| panic!("{}: expected a JSON array", path.display()));
+
+        for entry in entries {
+            if entry.get("type").and_then(|t| t.as_str()) != Some("function") {
+                continue;
+            }
+            let name = entry.get("name").and_then(|n| n.as_str()).unwrap_or_default();
+            let args = entry
+                .get("inputs")
+                .and_then(|i| i.as_array())
+                .map(|inputs| {
+                    inputs
+                        .iter()
+                        .map(|i| i.get("type").and_then(|t| t.as_str()).unwrap_or_default())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+                .unwrap_or_default();
+            out.insert(format!("{name}({args})"));
+        }
+    }
+    out
+}
+
+#[test]
+fn vendored_abi_matches_precompile_public_faces() {
+    let root = crate_root();
+    let rust = rust_faces(&root.join("src"));
+    let abi = abi_faces(&root.join("src").join("solidity"));
+
+    // Guard the scanners themselves — an empty side would make either diff pass vacuously.
+    assert!(
+        rust.len() > 100,
+        "rust face scan returned {}; the scanner is broken, not the tree",
+        rust.len()
+    );
+    assert!(
+        abi.len() > 100,
+        "abi function scan returned {}; the scanner is broken, not the tree",
+        abi.len()
+    );
+
+    let allow: BTreeSet<String> = ABI_ONLY_ALLOWLIST.iter().map(|s| (*s).to_string()).collect();
+
+    let missing_from_abi: Vec<&String> = rust.difference(&abi).collect();
+    let missing_from_rust: Vec<&String> = abi
+        .difference(&rust)
+        .filter(|sig| !allow.contains(*sig))
+        .collect();
+
+    let mut problems = String::new();
+
+    if !missing_from_abi.is_empty() {
+        problems.push_str(&format!(
+            "\n{} face(s) declared #[precompile::public] but absent from every .abi in \
+             precompiles/src/solidity/ — integrators enumerating the vendored ABI cannot see these:\n",
+            missing_from_abi.len()
+        ));
+        for sig in &missing_from_abi {
+            problems.push_str(&format!("    {sig}\n"));
+        }
+    }
+
+    if !missing_from_rust.is_empty() {
+        problems.push_str(&format!(
+            "\n{} function(s) in the vendored .abi with no #[precompile::public] face — either the \
+             face was removed and the artifact not updated, or the entry belongs in \
+             ABI_ONLY_ALLOWLIST with a comment explaining why:\n",
+            missing_from_rust.len()
+        ));
+        for sig in &missing_from_rust {
+            problems.push_str(&format!("    {sig}\n"));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "vendored Solidity artifacts have drifted from the Rust source of truth:\n{problems}\n\
+         rust faces: {}, abi functions: {}",
+        rust.len(),
+        abi.len()
+    );
+}


### PR DESCRIPTION
`getTotalColdkeyStakeOnSubnet(bytes32,uint256)` is declared in `precompiles/src/staking.rs` with `#[precompile::public]` and `#[precompile::view]` inside `impl StakingPrecompileV2`, and dispatches on chain today. It is absent from `precompiles/src/solidity/stakingV2.abi` and `stakingV2.sol`.

Present in the Rust and missing from the vendored artifacts at both **v438** (`c1463f2c`) and **v440** (`e4ffa2e1`) — two releases. `stakingV2.abi` grew from 24 to 33 function entries across v439, so the artifacts are actively maintained and this looks like a drop rather than staleness.

An integrator enumerating callable faces from the vendored ABI — the natural thing to do, since it is the machine-readable artifact — cannot see this face at all.

### Reproduce

Extract every `#[precompile::public("…")]` from `precompiles/src/*.rs`; extract every `type: "function"` signature from `precompiles/src/solidity/*.abi`; diff both directions. At `e4ffa2e1`: **168 rust faces, 168 abi functions**, one present only in the Rust.

The reverse direction returns only `verify(bytes32,bytes32,bytes32,bytes32)` on `ed25519Verify`/`sr25519Verify` — those precompiles consume raw calldata and dispatch no selector, so the artifacts describe a calling convention with no annotated face behind them. Allowlisted in the check with that reasoning inline.

### Two implementation notes

**The Rust scanner is newline-agnostic on purpose.** `rustfmt` wraps long attributes, so a line-oriented scan silently misses exactly the faces with the most parameters — today `serveAxonTls` and both long `registerNetwork` variants. A strict single-line regex finds **165 of 168**.

**The ABI side is module-agnostic**, unioning every `.abi` rather than pairing each to a Rust module. Modules are `snake_case`, artifacts are `camelCase`, and `staking.rs` alone declares both `staking` and `stakingV2` — a per-module mapping is a second thing that can be wrong, and it fails in the direction that manufactures findings. (My first attempt did exactly that and reported 9 false drops.)

### Commits

1. **the check** — fails on `main` today, naming the drifted face
2. **the fix** — adds the entry to both artifacts; the check passes

### Verification

Run against `1.89.0` (matching `rust-toolchain.toml`), with the workspace's `expect-used` / `unwrap-used` / `indexing-slicing` / `arithmetic-side-effects` deny lints replicated:

- `cargo test --test abi_drift` on pristine `main` → **fails**, naming `getTotalColdkeyStakeOnSubnet(bytes32,uint256)`
- same test with the fix applied → **passes**
- `cargo clippy --all-targets -- -D warnings` → **clean**

The test module carries `#![allow(clippy::expect_used, clippy::arithmetic_side_effects, clippy::indexing_slicing)]`, matching the pattern already used in `address_mapping.rs`, `alpha.rs`, `crowdloan.rs`, `leasing.rs` and others. It uses no `.unwrap()`.

No runtime logic is touched — requesting the `no-spec-version-bump` label.

### Related

#2455 (precompile versioning and deprecation lifecycle) describes the general fragility this sits inside. #2998's `coverage-and-testing.md` specifies finding drift in both directions between the Rust signatures and the vendored ABIs — this adds a mechanical check for that specific direction, and the one face it currently finds is the motivation.

### Disclosure

I hit this from the integrator side: I gate precompile calls from a contract and enumerate the callable surface to build that gate. The missing face is why I noticed.
