### PR TITLE
Add voting power reads to WASM chain extensions

### DIFF
--- a/chain-extensions/src/lib.rs
+++ b/chain-extensions/src/lib.rs
@@ -650,6 +650,73 @@ where
 
                 Ok(RetVal::Converging(Output::Success as u32))
             }
+            FunctionId::GetVotingPowerV1 => {
+                let (netuid, hotkey): (NetUid, T::AccountId) = env
+                    .read_as()
+                    .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+                let voting_power = pallet_subtensor::Pallet::<T>::get_voting_power(netuid, &hotkey);
+
+                env.write_output(&voting_power.encode())
+                    .map_err(|_| DispatchError::Other("Failed to write output"))?;
+
+                Ok(RetVal::Converging(Output::Success as u32))
+            }
+            FunctionId::GetTotalVotingPowerV1 => {
+                let netuid: NetUid = env
+                    .read_as()
+                    .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+                let total_voting_power: u64 = pallet_subtensor::VotingPower::<T>::iter_prefix(netuid)
+                    .map(|(_, power)| power)
+                    .sum();
+
+                env.write_output(&total_voting_power.encode())
+                    .map_err(|_| DispatchError::Other("Failed to write output"))?;
+
+                Ok(RetVal::Converging(Output::Success as u32))
+            }
+            FunctionId::IsVotingPowerTrackingEnabledV1 => {
+                let netuid: NetUid = env
+                    .read_as()
+                    .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+                let enabled = pallet_subtensor::Pallet::<T>::get_voting_power_tracking_enabled(netuid);
+
+                env.write_output(&enabled.encode())
+                    .map_err(|_| DispatchError::Other("Failed to write output"))?;
+
+                Ok(RetVal::Converging(Output::Success as u32))
+            }
+            FunctionId::GetVotingPowerDisableAtBlockV1 => {
+                let netuid: NetUid = env
+                    .read_as()
+                    .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+                let disable_at_block =
+                    pallet_subtensor::Pallet::<T>::get_voting_power_disable_at_block(netuid);
+
+                env.write_output(&disable_at_block.encode())
+                    .map_err(|_| DispatchError::Other("Failed to write output"))?;
+
+                Ok(RetVal::Converging(Output::Success as u32))
+            }
+            FunctionId::GetValidatorPermitV1 => {
+                let (netuid, hotkey): (NetUid, T::AccountId) = env
+                    .read_as()
+                    .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+                let permit = pallet_subtensor::Pallet::<T>::get_uid_for_net_and_hotkey(netuid, &hotkey)
+                    .map(|uid| {
+                        pallet_subtensor::Pallet::<T>::get_validator_permit_for_uid(netuid, uid)
+                    })
+                    .unwrap_or(false);
+
+                env.write_output(&permit.encode())
+                    .map_err(|_| DispatchError::Other("Failed to write output"))?;
+
+                Ok(RetVal::Converging(Output::Success as u32))
+            }
             FunctionId::AddStakeV1 => {
                 let origin = RawOrigin::Signed(env.caller());
                 Self::dispatch_add_stake_v1(env, origin)

--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -1946,6 +1946,213 @@ fn get_stake_availability_uses_rolled_forward_lock() {
     });
 }
 
+#[test]
+fn get_voting_power_returns_encoded_value() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9001);
+        let owner_coldkey = U256::from(9002);
+        let hotkey = U256::from(9003);
+        let caller = U256::from(9004);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let expected_voting_power: u64 = 1_000_000_000_000;
+        pallet_subtensor::VotingPower::<mock::Test>::insert(netuid, hotkey, expected_voting_power);
+
+        let mut env = MockEnv::new(
+            FunctionId::GetVotingPowerV1,
+            caller,
+            (netuid, hotkey).encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let output_power: u64 = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert_eq!(output_power, expected_voting_power);
+    });
+}
+
+#[test]
+fn get_voting_power_returns_zero_when_not_set() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9101);
+        let owner_coldkey = U256::from(9102);
+        let hotkey = U256::from(9103);
+        let caller = U256::from(9104);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let mut env = MockEnv::new(
+            FunctionId::GetVotingPowerV1,
+            caller,
+            (netuid, hotkey).encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let output_power: u64 = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert_eq!(output_power, 0);
+    });
+}
+
+#[test]
+fn get_total_voting_power_returns_sum() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9201);
+        let owner_coldkey = U256::from(9202);
+        let hotkey1 = U256::from(9203);
+        let hotkey2 = U256::from(9204);
+        let hotkey3 = U256::from(9205);
+        let caller = U256::from(9206);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let power1: u64 = 1_000_000_000_000;
+        let power2: u64 = 2_000_000_000_000;
+        let power3: u64 = 3_000_000_000_000;
+        pallet_subtensor::VotingPower::<mock::Test>::insert(netuid, hotkey1, power1);
+        pallet_subtensor::VotingPower::<mock::Test>::insert(netuid, hotkey2, power2);
+        pallet_subtensor::VotingPower::<mock::Test>::insert(netuid, hotkey3, power3);
+
+        let mut env = MockEnv::new(FunctionId::GetTotalVotingPowerV1, caller, netuid.encode());
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let total_power: u64 = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert_eq!(total_power, power1 + power2 + power3);
+    });
+}
+
+#[test]
+fn is_voting_power_tracking_enabled_returns_status() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9301);
+        let owner_coldkey = U256::from(9302);
+        let caller = U256::from(9303);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let mut env = MockEnv::new(
+            FunctionId::IsVotingPowerTrackingEnabledV1,
+            caller,
+            netuid.encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let enabled: bool = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert!(!enabled);
+
+        pallet_subtensor::VotingPowerTrackingEnabled::<mock::Test>::insert(netuid, true);
+
+        let mut env = MockEnv::new(
+            FunctionId::IsVotingPowerTrackingEnabledV1,
+            caller,
+            netuid.encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+
+        let enabled: bool = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert!(enabled);
+    });
+}
+
+#[test]
+fn get_voting_power_disable_at_block_returns_value() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9401);
+        let owner_coldkey = U256::from(9402);
+        let caller = U256::from(9403);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let expected_block: u64 = 123_456;
+        pallet_subtensor::VotingPowerDisableAtBlock::<mock::Test>::insert(netuid, expected_block);
+
+        let mut env = MockEnv::new(
+            FunctionId::GetVotingPowerDisableAtBlockV1,
+            caller,
+            netuid.encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let disable_at_block: u64 = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert_eq!(disable_at_block, expected_block);
+    });
+}
+
+#[test]
+fn get_validator_permit_reflects_permit_state() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9501);
+        let owner_coldkey = U256::from(9502);
+        let hotkey = U256::from(9503);
+        let coldkey = U256::from(9504);
+        let caller = U256::from(9505);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        mock::register_ok_neuron(netuid, hotkey, coldkey, 0);
+
+        let uid = pallet_subtensor::Pallet::<mock::Test>::get_uid_for_net_and_hotkey(netuid, &hotkey)
+            .expect("neuron just registered");
+        let mut permits = pallet_subtensor::ValidatorPermit::<mock::Test>::get(netuid);
+        permits.resize(uid as usize + 1, false);
+        permits[uid as usize] = true;
+        pallet_subtensor::ValidatorPermit::<mock::Test>::insert(netuid, permits);
+
+        let mut env = MockEnv::new(
+            FunctionId::GetValidatorPermitV1,
+            caller,
+            (netuid, hotkey).encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let permit: bool = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert!(permit);
+    });
+}
+
+#[test]
+fn get_validator_permit_false_for_unregistered_hotkey() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(9601);
+        let owner_coldkey = U256::from(9602);
+        let hotkey = U256::from(9603);
+        let caller = U256::from(9604);
+
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        let mut env = MockEnv::new(
+            FunctionId::GetValidatorPermitV1,
+            caller,
+            (netuid, hotkey).encode(),
+        );
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert!(env.charged_weight().is_none());
+
+        let permit: bool = Decode::decode(&mut &env.output()[..]).unwrap();
+        assert!(!permit);
+    });
+}
+
 /// `Caller*` dispatch uses `env.origin()` via `convert_origin`; with [`MockEnv`] both match
 /// `Signed(caller)`, so outcomes align with non-`Caller` arms. Weight expectations match the shared
 /// `dispatch_*_v1` helpers used by each pair.

--- a/chain-extensions/src/types.rs
+++ b/chain-extensions/src/types.rs
@@ -44,6 +44,11 @@ pub enum FunctionId {
     GetSubnetRegistrationStateV1 = 34,
     GetColdkeyLockV1 = 35,
     GetStakeAvailabilityV1 = 36,
+    GetVotingPowerV1 = 37,
+    GetTotalVotingPowerV1 = 38,
+    IsVotingPowerTrackingEnabledV1 = 39,
+    GetVotingPowerDisableAtBlockV1 = 40,
+    GetValidatorPermitV1 = 41,
 }
 
 #[freeze_struct("5dc33d60abed5c08")]
@@ -188,11 +193,16 @@ mod function_id_tests {
         assert_eq!(FunctionId::GetSubnetRegistrationStateV1 as u16, 34);
         assert_eq!(FunctionId::GetColdkeyLockV1 as u16, 35);
         assert_eq!(FunctionId::GetStakeAvailabilityV1 as u16, 36);
+        assert_eq!(FunctionId::GetVotingPowerV1 as u16, 37);
+        assert_eq!(FunctionId::GetTotalVotingPowerV1 as u16, 38);
+        assert_eq!(FunctionId::IsVotingPowerTrackingEnabledV1 as u16, 39);
+        assert_eq!(FunctionId::GetVotingPowerDisableAtBlockV1 as u16, 40);
+        assert_eq!(FunctionId::GetValidatorPermitV1 as u16, 41);
     }
 
     #[test]
     fn caller_ids_roundtrip_try_from_primitive() {
-        for id in 16u16..=36u16 {
+        for id in 16u16..=41u16 {
             let v = FunctionId::try_from_primitive(id)
                 .unwrap_or_else(|_| panic!("try_from_primitive failed for {id}"));
             assert_eq!(v as u16, id);

--- a/docs/internals/wasm-contracts.mdx
+++ b/docs/internals/wasm-contracts.mdx
@@ -68,6 +68,11 @@ Subtensor provides a custom chain extension that allows smart contracts to inter
 | 34 | `get_subnet_registration_state` | Query whether a subnet exists and which registration generation currently owns the netuid | `(NetUid)` | `SubnetRegistrationState { netuid, exists, registered_subnet_counter }` |
 | 35 | `get_coldkey_lock` | Query the current rolled-forward lock state for a coldkey on a subnet | `(AccountId, NetUid)` | `Option<ColdkeyLock { locked_mass: AlphaBalance, conviction_bits: u128, last_update: u64 }>` |
 | 36 | `get_stake_availability` | Query total, locked, and currently available alpha for a coldkey on a subnet | `(AccountId, NetUid)` | `StakeAvailability { netuid: NetUid, total: AlphaBalance, locked: AlphaBalance, available: AlphaBalance }` |
+| 37 | `get_voting_power` | Get voting power (EMA-smoothed stake) for a hotkey in a subnet | `(NetUid, AccountId)` | `u64` |
+| 38 | `get_total_voting_power` | Get total voting power across all hotkeys in a subnet | `(NetUid)` | `u64` |
+| 39 | `is_voting_power_tracking_enabled` | Check whether voting-power tracking is enabled for a subnet | `(NetUid)` | `bool` |
+| 40 | `get_voting_power_disable_at_block` | Get the block at which voting-power tracking will be disabled (0 = none) | `(NetUid)` | `u64` |
+| 41 | `get_validator_permit` | Check whether a hotkey holds a validator permit on a subnet | `(NetUid, AccountId)` | `bool` |
 
 <Callout type="note">
 Functions **1–14** dispatch with the **contract's own address** as the signed origin. Their caller-origin mirrors (functions **20–33**) dispatch with the **original transaction signer's** origin instead; parameters and return values are identical to the corresponding base function.

--- a/ink-contract/lib.rs
+++ b/ink-contract/lib.rs
@@ -43,6 +43,11 @@ pub enum FunctionId {
     GetSubnetRegistrationStateV1 = 34,
     GetColdkeyLockV1 = 35,
     GetStakeAvailabilityV1 = 36,
+    GetVotingPowerV1 = 37,
+    GetTotalVotingPowerV1 = 38,
+    IsVotingPowerTrackingEnabledV1 = 39,
+    GetVotingPowerDisableAtBlockV1 = 40,
+    GetValidatorPermitV1 = 41,
 }
 
 #[ink::chain_extension(extension = 0x1000)]
@@ -287,6 +292,27 @@ pub trait RuntimeReadWrite {
         coldkey: <CustomEnvironment as ink::env::Environment>::AccountId,
         netuid: u16,
     ) -> StakeAvailability;
+
+    #[ink(function = 37)]
+    fn get_voting_power(
+        netuid: u16,
+        hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+    ) -> u64;
+
+    #[ink(function = 38)]
+    fn get_total_voting_power(netuid: u16) -> u64;
+
+    #[ink(function = 39)]
+    fn is_voting_power_tracking_enabled(netuid: u16) -> bool;
+
+    #[ink(function = 40)]
+    fn get_voting_power_disable_at_block(netuid: u16) -> u64;
+
+    #[ink(function = 41)]
+    fn get_validator_permit(
+        netuid: u16,
+        hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+    ) -> bool;
 }
 
 #[ink::scale_derive(Encode, Decode, TypeInfo)]


### PR DESCRIPTION
Mirrors the EVM VotingPowerPrecompile (0x80D) for ink!/WASM contracts, so contract logic can read validator voting power without leaving pallet-contracts. Revives #2376 (closed when its base feature branch was superseded), rebased onto main with function IDs renumbered to the current table.

New chain extension functions:
- 37 get_voting_power(netuid, hotkey) -> u64
- 38 get_total_voting_power(netuid) -> u64
- 39 is_voting_power_tracking_enabled(netuid) -> bool
- 40 get_voting_power_disable_at_block(netuid) -> u64
- 41 get_validator_permit(netuid, hotkey) -> bool (false for unregistered hotkeys)

All are pure reads: read_as -> pallet getter -> write_output, no weight-charged dispatch. Includes 7 unit tests (61 total passing in subtensor-chain-extensions), doc table rows in docs/internals/wasm-contracts.mdx, and the ink-contract example trait extended.

Context: discussed in Discord — building subnet contract logic (validator-gated repo registry) that needs stake-weight and permit reads from WASM.