### PR TITLE
Allocate TAO emissions across the top 64 subnets

### DIFF
--- a/docs/concepts/emissions.mdx
+++ b/docs/concepts/emissions.mdx
@@ -89,6 +89,13 @@ proportionally to enabled ones — and with `tao_in` zeroed, `alpha_in`
 (`tao_in / price`) is zero too, so pool injection stops entirely while
 `alpha_out` keeps accruing for participants.
 
+After the emission gate and emission-enabled filter are applied, positive
+subnet scores are ranked from highest to lowest. Ranks 1–32 receive 75% of
+the block's TAO emission in aggregate, ranks 33–64 receive 25%, and ranks
+65+ receive zero. Within each tier, the existing score proportions are
+preserved. Equal scores are ordered by ascending netuid. If 32 or fewer
+subnets have a positive score, they receive the full block emission.
+
 The EMA uses an age-dependent smoothing factor:
 
 ```
@@ -98,8 +105,9 @@ ema_alpha = base_alpha × blocks_since_start / (blocks_since_start + halving_blo
 with `halving_blocks` defaulting to 201,600 (~4 weeks). New subnets start
 near zero — their moving price adapts extremely slowly, which blunts launch
 pumps, coordinated buys, and flash attacks on emission shares. The spot
-price feeding the EMA is capped at 1.0. There is no zero-emission floor: a
-subnet with a low EMA price still receives a small non-zero share.
+price feeding the EMA is capped at 1.0. The scoring formula has no non-zero
+floor: a subnet with a low EMA price can receive a small non-zero score, but
+only the top 64 positive scores receive TAO emission.
 
 <SubnetEmissionShareChart />
 

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -57,23 +57,98 @@ impl<T: Config> Pallet<T> {
             shares_with_emission_enabled.push((netuid, share, emission_enabled));
         }
 
-        shares_with_emission_enabled
+        let mut enabled_shares = shares_with_emission_enabled
             .into_iter()
             .map(|(netuid, share, emission_enabled)| {
-                let share = if has_disabled_subnets {
-                    if emission_enabled && enabled_share_sum > zero {
-                        share.safe_div(enabled_share_sum)
+                (
+                    netuid,
+                    if has_disabled_subnets {
+                        if emission_enabled && enabled_share_sum > zero {
+                            share.safe_div(enabled_share_sum)
+                        } else {
+                            zero
+                        }
                     } else {
-                        zero
-                    }
-                } else {
-                    share
-                };
+                        share
+                    },
+                )
+            })
+            .collect::<BTreeMap<NetUid, U64F64>>();
+
+        Self::apply_ranked_emission_tiers(&mut enabled_shares);
+
+        enabled_shares
+            .into_iter()
+            .map(|(netuid, share)| {
                 let emission = U64F64::saturating_from_num(block_emission).saturating_mul(share);
                 (netuid, U96F32::saturating_from_num(emission))
             })
             .collect::<BTreeMap<NetUid, U96F32>>()
     }
+
+    /// Number of positive-score subnets in each TAO emission tier.
+    pub const EMISSION_TIER_SIZE: usize = 32;
+
+    /// Applies hard rank tiers to the final, emission-enabled subnet scores.
+    ///
+    /// Ranks 1-32 receive 75% of block TAO emission in aggregate, ranks 33-64
+    /// receive 25%, and ranks 65+ receive zero. Existing score proportions are
+    /// preserved within each tier. If there is no second tier, the first tier
+    /// receives 100% so block emission is not stranded.
+    ///
+    /// Only positive scores are ranked. Equal scores are ordered by ascending
+    /// netuid to make the boundary deterministic.
+    pub(crate) fn apply_ranked_emission_tiers(shares: &mut BTreeMap<NetUid, U64F64>) {
+        let zero = U64F64::saturating_from_num(0);
+        let one = U64F64::saturating_from_num(1);
+        let primary_tier_allocation =
+            U64F64::saturating_from_num(3).safe_div(U64F64::saturating_from_num(4));
+        let secondary_tier_allocation = one.saturating_sub(primary_tier_allocation);
+
+        let mut ranked = shares
+            .iter()
+            .filter(|(_, share)| **share > zero)
+            .map(|(netuid, share)| (*netuid, *share))
+            .collect::<Vec<(NetUid, U64F64)>>();
+        ranked.sort_unstable_by(|(netuid_a, share_a), (netuid_b, share_b)| {
+            share_b.cmp(share_a).then_with(|| netuid_a.cmp(netuid_b))
+        });
+
+        let secondary_start = ranked.len().min(Self::EMISSION_TIER_SIZE);
+        let secondary_end = ranked.len().min(Self::EMISSION_TIER_SIZE.saturating_mul(2));
+        let primary_total = ranked[..secondary_start]
+            .iter()
+            .map(|(_, share)| *share)
+            .fold(zero, |total, share| total.saturating_add(share));
+        let secondary_total = ranked[secondary_start..secondary_end]
+            .iter()
+            .map(|(_, share)| *share)
+            .fold(zero, |total, share| total.saturating_add(share));
+        let has_secondary_tier = secondary_total > zero;
+
+        for share in shares.values_mut() {
+            *share = zero;
+        }
+
+        for (rank, (netuid, score)) in ranked.into_iter().enumerate() {
+            let tiered_share = if rank < secondary_start {
+                let allocation = if has_secondary_tier {
+                    primary_tier_allocation
+                } else {
+                    one
+                };
+                score.safe_div(primary_total).saturating_mul(allocation)
+            } else if rank < secondary_end {
+                score
+                    .safe_div(secondary_total)
+                    .saturating_mul(secondary_tier_allocation)
+            } else {
+                zero
+            };
+            shares.insert(netuid, tiered_share);
+        }
+    }
+
     pub fn record_tao_inflow(netuid: NetUid, tao: TaoBalance) {
         SubnetTaoFlow::<T>::mutate(netuid, |flow| {
             *flow = flow.saturating_add(u64::from(tao) as i64);

--- a/pallets/subtensor/src/tests/subnet_emissions.rs
+++ b/pallets/subtensor/src/tests/subnet_emissions.rs
@@ -20,6 +20,84 @@ fn i96f32(x: f64) -> I96F32 {
 }
 
 #[test]
+fn ranked_emission_tiers_split_equal_scores_75_25_and_cut_off_after_64() {
+    let equal_score = u64f64(1.0 / 65.0);
+    let mut shares = (1u16..=65)
+        .map(|netuid| (NetUid::from(netuid), equal_score))
+        .collect::<BTreeMap<NetUid, U64F64>>();
+
+    SubtensorModule::apply_ranked_emission_tiers(&mut shares);
+
+    let primary_total = (1u16..=32)
+        .map(|netuid| shares[&NetUid::from(netuid)])
+        .fold(u64f64(0.0), |total, share| total.saturating_add(share));
+    let secondary_total = (33u16..=64)
+        .map(|netuid| shares[&NetUid::from(netuid)])
+        .fold(u64f64(0.0), |total, share| total.saturating_add(share));
+
+    assert_abs_diff_eq!(primary_total.to_num::<f64>(), 0.75, epsilon = 1e-9);
+    assert_abs_diff_eq!(secondary_total.to_num::<f64>(), 0.25, epsilon = 1e-9);
+    assert_eq!(shares[&NetUid::from(65)], u64f64(0.0));
+    assert!(
+        shares[&NetUid::from(64)] > u64f64(0.0),
+        "ascending netuid must break an equal-score boundary tie"
+    );
+}
+
+#[test]
+fn ranked_emission_tiers_preserve_score_proportions_within_each_tier() {
+    let mut shares = (1u16..=96)
+        .map(|netuid| {
+            (
+                NetUid::from(netuid),
+                u64f64(f64::from(97u16.saturating_sub(netuid))),
+            )
+        })
+        .collect::<BTreeMap<NetUid, U64F64>>();
+
+    SubtensorModule::apply_ranked_emission_tiers(&mut shares);
+
+    let primary_total = (1u16..=32)
+        .map(|netuid| shares[&NetUid::from(netuid)])
+        .fold(u64f64(0.0), |total, share| total.saturating_add(share));
+    let secondary_total = (33u16..=64)
+        .map(|netuid| shares[&NetUid::from(netuid)])
+        .fold(u64f64(0.0), |total, share| total.saturating_add(share));
+
+    assert_abs_diff_eq!(primary_total.to_num::<f64>(), 0.75, epsilon = 1e-9);
+    assert_abs_diff_eq!(secondary_total.to_num::<f64>(), 0.25, epsilon = 1e-9);
+    assert_abs_diff_eq!(
+        (shares[&NetUid::from(1)] / shares[&NetUid::from(2)]).to_num::<f64>(),
+        96.0 / 95.0,
+        epsilon = 1e-9
+    );
+    assert_abs_diff_eq!(
+        (shares[&NetUid::from(33)] / shares[&NetUid::from(34)]).to_num::<f64>(),
+        64.0 / 63.0,
+        epsilon = 1e-9
+    );
+    for netuid in 65u16..=96 {
+        assert_eq!(shares[&NetUid::from(netuid)], u64f64(0.0));
+    }
+}
+
+#[test]
+fn ranked_emission_tiers_give_full_allocation_to_single_populated_tier() {
+    let mut shares = (1u16..=32)
+        .map(|netuid| (NetUid::from(netuid), u64f64(f64::from(netuid))))
+        .collect::<BTreeMap<NetUid, U64F64>>();
+
+    SubtensorModule::apply_ranked_emission_tiers(&mut shares);
+
+    let total = shares
+        .values()
+        .copied()
+        .fold(u64f64(0.0), |total, share| total.saturating_add(share));
+    assert_abs_diff_eq!(total.to_num::<f64>(), 1.0, epsilon = 1e-9);
+    assert!(shares.values().all(|share| *share > u64f64(0.0)));
+}
+
+#[test]
 fn inplace_pow_normalize_all_zero_inputs_no_panic_and_unchanged() {
     let mut m: BTreeMap<NetUid, U64F64> = BTreeMap::new();
     m.insert(NetUid::from(1), u64f64(0.0));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 440,
+    spec_version: 441,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

- Allocate 75% of block TAO emissions to subnet ranks 1-32.
- Allocate 25% to ranks 33-64.
- Allocate no TAO emissions to ranks 65 and below.
- Preserve score proportionality within each tier.
- Resolve equal-score boundary ties by ascending netuid.
- Give the eligible set 100% of emissions when 32 or fewer subnets have positive scores.
- Document the behavior and add focused boundary and proportionality tests.

## Rationale

The current top-32 cutoff concentrates all TAO emissions among today's highest-ranked subnets. This strongly rewards proven performers, but it also creates an incumbent advantage: a credible subnet immediately below rank 32 receives no TAO emission even when it may be close to product-market fit or capable of becoming a future top performer.

This proposal introduces a deliberate exploration and exploitation balance. The top 32 retain a dominant 75% share, so most capital remains concentrated on subnets that have demonstrated demand and performance. The next 32 collectively receive 25%, giving the competitive middle enough support to improve infrastructure, attract participants, and prove whether they can challenge current leaders.

This is not an equal subsidy. Rewards remain proportional to performance within each tier, only the top 64 positive scores qualify, and a subnet must improve its ranking to enter the larger 75% pool. The intended benefit is greater network option value: preserve strong support for current winners while increasing exposure to potential breakout subnets and keeping the top tier contestable.

## User and developer impact

Subnet operators ranked 33-64 gain a bounded TAO emission path. Top-32 subnets continue to receive most emissions, while ranks 65 and below remain ineligible. The ranking is deterministic, including equal-score ties, and no block emission is stranded when the second tier is empty.

## Validation

- 3 focused ranked-tier tests passed.
- All 14 subnet-emission tests passed.
- All 78 coinbase tests passed.
- All 1,423 `pallet-subtensor` all-feature tests passed, with 9 ignored.
- All remaining Rust workspace tests and doctests passed after isolating the known failures below.
- Separate `eco-tests`: 56 passed.
- Documentation preview tests: 56 passed.
- Python SDK pytest: 980 passed and 1 skipped in the sandbox; the localhost bridge tests passed when rerun with socket permission.
- Rust formatting and `git diff --check` passed.

## Known unrelated repository failures

The complete repository suite is not currently green. Four runtime proxy-filter tests and the Python SDK codegen coverage check fail because the existing call inventory omits `sudo_set_emission_bar_quantile` and `sudo_set_emission_gate_exponent`. Ruff formatting also reports two unrelated Python SDK files. None of these failures touch the three files changed by this PR.
