### PR TITLE
feat: conviction-adjusted emission gate (EmissionConvictionBoost)

### DIFF
--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -861,6 +861,12 @@ mod benchmarks {
     }
 
     #[benchmark]
+    fn sudo_set_emission_conviction_boost() {
+        #[extrinsic_call]
+        _(RawOrigin::Root, U64F64::from_num(1));
+    }
+
+    #[benchmark]
     fn sudo_set_tao_flow_smoothing_factor() {
         #[extrinsic_call]
         _(RawOrigin::Root, u64::MAX);

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2057,6 +2057,25 @@ pub mod pallet {
             Ok(())
         }
 
+        /// Sets the emission conviction boost (lambda): how strongly a subnet's
+        /// conviction-locked ratio amplifies its demand share at the emission
+        /// gate (s_eff = s * (1 + lambda * C)). Zero disables the adjustment.
+        #[pallet::call_index(102)]
+        #[pallet::weight(<T as Config>::WeightInfo::sudo_set_emission_conviction_boost())]
+        pub fn sudo_set_emission_conviction_boost(
+            origin: OriginFor<T>,
+            boost: U64F64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+
+            let eight = U64F64::saturating_from_num(8);
+            ensure!(boost <= eight, Error::<T>::InvalidValue);
+
+            pallet_subtensor::Pallet::<T>::set_emission_conviction_boost(boost);
+            log::debug!("set_emission_conviction_boost( {boost:?} ) ");
+            Ok(())
+        }
+
         /// Sets TAO flow smoothing factor (alpha)
         #[pallet::call_index(83)]
         #[pallet::weight(<T as Config>::WeightInfo::sudo_set_tao_flow_smoothing_factor())]

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -112,6 +112,7 @@ pub trait WeightInfo {
 	fn sudo_set_tao_flow_normalization_exponent() -> Weight;
 	fn sudo_set_emission_bar_quantile() -> Weight;
 	fn sudo_set_emission_gate_exponent() -> Weight;
+	fn sudo_set_emission_conviction_boost() -> Weight;
 	fn sudo_set_tao_flow_smoothing_factor() -> Weight;
 	fn sudo_set_net_tao_flow_enabled() -> Weight;
 	fn sudo_set_max_mechanism_count() -> Weight;
@@ -1335,6 +1336,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `SubtensorModule::EmissionGateExponent` (r:0 w:1)
 	/// Proof: `SubtensorModule::EmissionGateExponent` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn sudo_set_emission_gate_exponent() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 1_000_000 picoseconds.
+		Weight::from_parts(2_000_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `SubtensorModule::EmissionConvictionBoost` (r:0 w:1)
+	/// Proof: `SubtensorModule::EmissionConvictionBoost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn sudo_set_emission_conviction_boost() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -2708,6 +2719,16 @@ impl WeightInfo for () {
 	/// Storage: `SubtensorModule::EmissionGateExponent` (r:0 w:1)
 	/// Proof: `SubtensorModule::EmissionGateExponent` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	fn sudo_set_emission_gate_exponent() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 1_000_000 picoseconds.
+		Weight::from_parts(2_000_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `SubtensorModule::EmissionConvictionBoost` (r:0 w:1)
+	/// Proof: `SubtensorModule::EmissionConvictionBoost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	fn sudo_set_emission_conviction_boost() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -435,6 +435,28 @@ impl<T: Config> Pallet<T> {
             EmissionGateBar::<T>::put(theta);
             log::debug!("Emission gate bar updated: theta = {theta:?} (q = {q:?})");
         }
+
+        // Refresh conviction ratios on the same cadence as the bar, so the
+        // per-block gate application below never iterates lock storage. While
+        // the boost is disabled (the default) this is a no-op, keeping the
+        // default path zero-cost. A subnet slot reused after deregistration
+        // can read a stale ratio for at most one bar interval before this
+        // refresh overwrites it.
+        let one = U64F64::saturating_from_num(1);
+        if EmissionConvictionBoost::<T>::get() > zero {
+            for netuid in shares.keys() {
+                let alpha_out =
+                    U64F64::saturating_from_num(u64::from(SubnetAlphaOut::<T>::get(*netuid)));
+                let ratio = if alpha_out > zero {
+                    Self::get_total_conviction(*netuid)
+                        .safe_div(alpha_out)
+                        .min(one)
+                } else {
+                    zero
+                };
+                EmissionConvictionRatio::<T>::insert(*netuid, ratio);
+            }
+        }
     }
 
     /// Applies the Hill emission gate in place and renormalizes.
@@ -457,14 +479,30 @@ impl<T: Config> Pallet<T> {
             return;
         }
         let h = EmissionGateExponent::<T>::get();
+        let lambda = EmissionConvictionBoost::<T>::get();
 
         let ungated = shares.clone();
 
-        for share in shares.values_mut() {
+        for (netuid, share) in shares.iter_mut() {
             if *share <= zero {
                 continue;
             }
-            let ratio = theta.safe_div(*share);
+            // Conviction-adjusted share, used for gate evaluation only. C is
+            // the subnet's time-weighted conviction as a fraction of its alpha
+            // out, capped at 1, so a fully locked subnet counts at most
+            // (1 + lambda) times its raw demand share at the gate. Conviction
+            // matures over months and is irreversible while active, so this
+            // input is as manipulation-resistant as the moving prices the gate
+            // already consumes. C is read from the cache refreshed on the bar
+            // cadence — this hot path never iterates lock storage — and
+            // lambda = 0 (the default) reproduces the unadjusted gate.
+            let gate_share = if lambda > zero {
+                let conviction_ratio = EmissionConvictionRatio::<T>::get(*netuid).min(one);
+                share.saturating_mul(one.saturating_add(lambda.saturating_mul(conviction_ratio)))
+            } else {
+                *share
+            };
+            let ratio = theta.safe_div(gate_share);
             // For s << theta, safe_pow saturates and the gate goes to ~0;
             // for s >> theta, the ratio underflows ln and safe_pow returns 0,
             // so the gate goes to 1. Both limits are the intended behavior.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1869,6 +1869,30 @@ pub mod pallet {
     pub type EmissionGateExponent<T: Config> =
         StorageValue<_, U64F64, ValueQuery, DefaultEmissionGateExponent<T>>;
 
+    #[pallet::type_value]
+    /// Default emission conviction boost (lambda). Zero disables the
+    /// conviction adjustment and reproduces the unadjusted v4.4.0 gate.
+    pub fn DefaultEmissionConvictionBoost<T: Config>() -> U64F64 {
+        U64F64::saturating_from_num(0)
+    }
+    #[pallet::storage]
+    /// ITEM --> Emission Conviction Boost (lambda). Scales how much a subnet's
+    /// conviction-locked ratio C (total time-weighted conviction / alpha out,
+    /// capped at 1) amplifies its demand share when evaluated against the
+    /// emission gate: s_eff = s * (1 + lambda * C). Only the gate argument is
+    /// adjusted; the base emission weight and the bar computation continue to
+    /// use the raw share s, so zero-demand subnets gain nothing from locking.
+    pub type EmissionConvictionBoost<T: Config> =
+        StorageValue<_, U64F64, ValueQuery, DefaultEmissionConvictionBoost<T>>;
+
+    #[pallet::storage]
+    /// MAP ( netuid ) --> conviction-locked ratio C consumed by the emission
+    /// gate. Refreshed on the same block cadence as the gate bar (and only
+    /// while EmissionConvictionBoost > 0), so the per-block gate hot path
+    /// never iterates lock storage. A missing entry reads as zero (no boost).
+    pub type EmissionConvictionRatio<T: Config> =
+        StorageMap<_, Identity, NetUid, U64F64, ValueQuery>;
+
     #[pallet::storage]
     /// ITEM --> Emission gate bar (theta): the q-mass demand-share threshold the
     /// Hill gate is centered on. Recomputed on a fixed block cadence from the

--- a/pallets/subtensor/src/tests/subnet_emissions.rs
+++ b/pallets/subtensor/src/tests/subnet_emissions.rs
@@ -266,6 +266,65 @@ fn emission_gate_concentrates_1_to_2_price_split() {
     });
 }
 
+/// Conviction boost: of two identical below-bar subnets, the one whose alpha
+/// is conviction-locked clears more of the gate under lambda = 1, matches its
+/// unlocked twin exactly under the default lambda = 0, and never disturbs the
+/// price-driven base weight of the demand head.
+#[test]
+fn emission_gate_conviction_boost_lifts_locked_subnet() {
+    new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(90);
+        let owner_coldkey = U256::from(91);
+        let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n3 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        System::set_block_number(0);
+        // n3 is the demand head; n1 and n2 sit equally below the bar.
+        SubnetMovingPrice::<Test>::insert(n1, i96f32(0.1));
+        SubnetMovingPrice::<Test>::insert(n2, i96f32(0.1));
+        SubnetMovingPrice::<Test>::insert(n3, i96f32(1.0));
+        for n in [n1, n2, n3] {
+            MinerBurned::<Test>::insert(n, U96F32::saturating_from_num(0.0));
+        }
+
+        // n1 carries a matured owner lock worth its entire alpha out (C = 1);
+        // n2 has the same alpha out and no lock (C = 0).
+        let alpha_out = 1_000_000u64;
+        SubnetAlphaOut::<Test>::insert(n1, AlphaBalance::from(alpha_out));
+        SubnetAlphaOut::<Test>::insert(n2, AlphaBalance::from(alpha_out));
+        OwnerLock::<Test>::insert(
+            n1,
+            crate::staking::lock::LockState {
+                locked_mass: alpha_out.into(),
+                conviction: U64F64::saturating_from_num(alpha_out),
+                last_update: 0,
+            },
+        );
+
+        // Default lambda = 0: the lock changes nothing.
+        let base = SubtensorModule::get_shares(&[n1, n2, n3]);
+        let b1 = base.get(&n1).copied().unwrap().to_num::<f64>();
+        let b2 = base.get(&n2).copied().unwrap().to_num::<f64>();
+        assert_abs_diff_eq!(b1, b2, epsilon = 1e-12);
+
+        // lambda = 1: the locked subnet clears more of the gate than its twin.
+        EmissionConvictionBoost::<Test>::put(u64f64(1.0));
+        let boosted = SubtensorModule::get_shares(&[n1, n2, n3]);
+        let s1 = boosted.get(&n1).copied().unwrap().to_num::<f64>();
+        let s2 = boosted.get(&n2).copied().unwrap().to_num::<f64>();
+        let s3 = boosted.get(&n3).copied().unwrap().to_num::<f64>();
+        assert!(
+            s1 > s2,
+            "locked subnet must out-earn its unlocked twin: {s1} vs {s2}"
+        );
+        // The boost only widens the gate; the base weight stays price-driven,
+        // so the demand head keeps its dominance.
+        assert!(s3 > s1);
+        assert_abs_diff_eq!(s1 + s2 + s3, 1.0_f64, epsilon = 1e-9);
+    });
+}
+
 /// Stale theta ≫ equal shares with max h can underflow every gated product to
 /// zero; the gate must restore the ungated distribution instead of stranding
 /// the block's emission.

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -1000,6 +1000,11 @@ impl<T: Config> Pallet<T> {
         EmissionGateExponent::<T>::set(exponent);
     }
 
+    /// Sets the emission conviction boost (lambda)
+    pub fn set_emission_conviction_boost(boost: U64F64) {
+        EmissionConvictionBoost::<T>::set(boost);
+    }
+
     /// Sets TAO flow smoothing factor (alpha)
     pub fn set_tao_flow_smoothing_factor(smoothing_factor: u64) {
         FlowEmaSmoothingFactor::<T>::set(smoothing_factor);


### PR DESCRIPTION
# feat: Conviction-adjusted emission gate (`EmissionConvictionBoost`)

## The blind spot this fixes

The v4.4.0 gate asks one question of every subnet: *how much demand do you have right now?* That is the right question for catching parked slots — but it is answered with a single signal (moving-price share), and one signal cannot tell apart two very different subnets:

- a **parked slot**: no demand, no commitment, collecting passive yield — the gate's intended target;
- a **committed subnet under water**: real technology, capital voluntarily frozen into it, price temporarily crushed — for example by a multi-million legacy alpha overhang inherited with the slot from a previous owner.

Both show a low price share. The gate executes both. The chain, however, already computes a second signal that separates them perfectly: **conviction** (BIT-0011). Conviction is capital that was bought and irreversibly locked — you cannot fake it, you cannot flash it, and nobody locks capital into a slot they are squatting.

Demand has a *flow* (price, what the gate reads today) and a *stock* (locked capital). This PR lets the gate read both.

## The mechanism — one line, gate argument only

```text
C     = min(total_conviction / alpha_out, 1)     # conviction-locked ratio
s_eff = s · (1 + λ · C)                          # evaluated against the bar
w     = s · gate(s_eff)                          # base weight: still raw s
```

Equivalently: a subnet's **personal bar** becomes `θ / (1 + λ·C)`. The network bar θ itself is untouched — it is still computed from raw shares, so locking cannot move the bar for anyone else. A subnet that locks earns a lower cliff *for itself only*, paid for with its own frozen capital.

- `EmissionConvictionBoost` (λ): new hyperparameter, **default 0 = feature fully off**. At the default this PR changes no behavior and never touches lock storage. Root enables it via `sudo_set_emission_conviction_boost` (call_index 102, bounded [0, 8], rate-limited like the other gate parameters).
- **Hot-path safety:** conviction ratios are recomputed on the same block cadence as the bar (`EMISSION_BAR_UPDATE_INTERVAL`) and cached in `EmissionConvictionRatio`; the per-block gate application reads only the cache. Lock storage is iterated once per bar interval, and only while λ > 0 — dust-lock inflation cannot grow per-block weight.
- Reuses `get_total_conviction()` — the exact aggregation the subnet-king threshold already trusts. No new trust assumptions, no migration.

## Why this cannot be farmed by squatters

The chain itself supplies the counterexample. There is a live subnet literally named **"Parked" (SN73)** with 27.5% of its alpha conviction-locked (owner auto-lock). Under λ=1 its emission share moves from 0.016% to 0.030% — noise. Because the boost multiplies the demand share, `~0 × anything = ~0`. The only subnets that benefit materially are those that already show real demand *and* have real capital frozen behind it:

| Subnet (mainnet, block ~8,722,800) | Rank | C locked | Share today | λ=1 | λ=3 |
|---|---|---|---|---|---|
| SN124 Swarm | 32 | 31.5% | 0.627% | 0.847% | 1.027% |
| SN79 MVTRX | 43 | 39.8% | 0.324% | 0.550% | 0.771% |
| SN61 RedTeam | 65 | 25.7% | 0.099% | 0.167% | 0.308% |
| SN73 "Parked" (squatter control case) | 104 | 27.5% | 0.016% | 0.030% | 0.074% |

Network-level effect is deliberately modest and budget-neutral:

| | λ=0 (today) | λ=1 | λ=3 |
|---|---|---|---|
| Below-bar emission share (96 subnets) | 11.94% | 13.46% | 16.07% |
| Top-8 emission share | 54.67% | 52.94% | 50.35% |

The 32-rank cliff stays on the map. What changes is that a subnet can *earn* a lower personal cliff by freezing capital — the effective set of meaningful earners widens, but every seat in the widened set is paid for.

## Second-order effect: a structural alpha demand sink

Under this mechanism, locking alpha is no longer only a governance action — it directly defends a subnet's emissions. That gives every below-bar community a rational reason to buy and freeze supply rather than exit. The gate's goal is demand-driven emissions; this addition *manufactures demand for alpha itself* in exactly the subnets fighting to prove theirs.

## Suggested governance path

Ship dark (λ=0, this PR) → observe → enable conservatively (λ=1: a fully-locked subnet counts double at the gate, at most) → revisit with distribution data. Every step reversible, rate-limited, root-only.

## Known limitation (disclosed, with follow-ups)

`OwnerCutAutoLockEnabled` defaults to on, so owner emissions accrue conviction at no marginal cost. Natural follow-ups if reviewers want them: discount owner-hotkey conviction by a factor ω inside `C`, or land PR #2695 (auto-lock default off). Kept out of this PR to stay minimal. Note the cap `C ≤ 1` and the multiplicative form already bound the damage: the control case above *is* an owner-auto-lock subnet, and it gains nothing.

## Release note

Adds one extrinsic and two storage items → expects the usual `spec_version` bump on the release train.

## Testing

- `emission_gate_conviction_boost_lifts_locked_subnet`: two identical below-bar subnets, one fully conviction-locked — identical shares at λ=0 (default-off proof); locked twin out-earns its unlocked twin at λ=1; the demand head keeps dominance (base weight untouched); distribution still sums to 1.
- All pre-existing gate tests pass unchanged.
