### PR TITLE
Cap chain buys and allocate spillover liquidity-first

### DIFF
--- a/docs/concepts/emissions.mdx
+++ b/docs/concepts/emissions.mdx
@@ -63,7 +63,22 @@ capped at `root_proportion × alpha_emission`, where
 As a subnet ages its alpha issuance grows, the cap falls, and the TAO that
 can no longer be injected as liquidity is instead swapped for alpha on the
 subnet's own pool — buying pressure that transitions mature subnets from
-liquidity injection to chain buybacks. Alpha bought this way accumulates as
+liquidity injection to chain buybacks. A subnet's chain buy is capped at the
+spot-TAO value of the alpha actually allocated to miners:
+
+```
+allocated_miner_alpha_i =
+  alpha_out_i × (1 − owner_cut_i) × 50% × (1 − miner_burned_i)
+
+chain_buy_i = min(excess_tao_i, allocated_miner_alpha_i × spot_price_i)
+```
+
+`miner_burned` is the proportion recorded by the subnet's last settled tempo
+for miner incentive directed to owner/immune burn or recycle UIDs. Those
+withheld emissions do not support chain-buy capacity; at 100% miner burn, the
+cap is zero. If owner cut is disabled, the miner half is calculated from the
+full `alpha_out`. TAO above the cap is not reassigned or issued; the unused
+coinbase credit is recycled. Alpha bought by the chain-buy path accumulates as
 protocol-owned alpha.
 
 <RootProportionExplainer />

--- a/docs/concepts/emissions.mdx
+++ b/docs/concepts/emissions.mdx
@@ -77,9 +77,14 @@ chain_buy_i = min(excess_tao_i, allocated_miner_alpha_i × spot_price_i)
 for miner incentive directed to owner/immune burn or recycle UIDs. Those
 withheld emissions do not support chain-buy capacity; at 100% miner burn, the
 cap is zero. If owner cut is disabled, the miner half is calculated from the
-full `alpha_out`. TAO above the cap is not reassigned or issued; the unused
-coinbase credit is recycled. Alpha bought by the chain-buy path accumulates as
-protocol-owned alpha.
+full `alpha_out`. TAO above the cap remains issued and is redistributed across
+all emitting subnets in proportion to their emission weights. The redistributed
+TAO is held in each subnet's protocol TAO reservoir, where it cannot create an
+uncapped chain buy or an unpaired spot-price change. The balancer may activate
+reservoir TAO in a later block when pool weights permit. If every emitting
+subnet reaches its chain-buy cap, the entire remainder is still issued and
+allocated in those same emission-weight proportions. Alpha bought by the
+chain-buy path accumulates as protocol-owned alpha.
 
 <RootProportionExplainer />
 

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -219,6 +219,9 @@ impl<T: Config> Pallet<T> {
         let mut alpha_in: BTreeMap<NetUid, U96F32> = BTreeMap::new();
         let mut alpha_out: BTreeMap<NetUid, U96F32> = BTreeMap::new();
         let mut excess_tao: BTreeMap<NetUid, U96F32> = BTreeMap::new();
+        let owner_cut_percent = Self::get_float_subnet_owner_cut();
+        let one = asfloat!(1);
+        let miner_share = asfloat!(0.5);
 
         // Only calculate for subnets that we are emitting to.
         for (&netuid_i, &tao_emission_i) in subnet_emissions.iter() {
@@ -251,7 +254,23 @@ impl<T: Config> Pallet<T> {
                 tao_in_i = alpha_in_i.saturating_mul(price_i);
             }
 
-            let excess_amount: U96F32 = tao_emission_i.saturating_sub(tao_in_i);
+            // Chain buys may consume at most the TAO value of miner alpha actually
+            // allocated by the last settled tempo. Start from the miner half of
+            // alpha_out after owner cut, then exclude the proportion withheld from
+            // miners by burn/recycle UIDs. If owner cut is disabled, miners receive
+            // half of the full alpha_out before the burn adjustment.
+            let participant_alpha_i = if Self::get_owner_cut_enabled(netuid_i) {
+                alpha_emission_i.saturating_sub(alpha_emission_i.saturating_mul(owner_cut_percent))
+            } else {
+                alpha_emission_i
+            };
+            let miner_burned_i = MinerBurned::<T>::get(netuid_i).min(one);
+            let allocated_miner_alpha_i = participant_alpha_i
+                .saturating_mul(miner_share)
+                .saturating_mul(one.saturating_sub(miner_burned_i));
+            let chain_buy_cap_i = allocated_miner_alpha_i.saturating_mul(price_i);
+            let excess_amount: U96F32 =
+                tao_emission_i.saturating_sub(tao_in_i).min(chain_buy_cap_i);
             excess_tao.insert(netuid_i, excess_amount);
 
             // Insert values into maps

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -69,6 +69,7 @@ impl<T: Config> Pallet<T> {
 
     pub fn inject_and_maybe_swap(
         subnets_to_emit_to: &[NetUid],
+        subnet_emissions: &BTreeMap<NetUid, U96F32>,
         tao_in: &BTreeMap<NetUid, U96F32>,
         alpha_in: &BTreeMap<NetUid, U96F32>,
         excess_tao: &BTreeMap<NetUid, U96F32>,
@@ -198,10 +199,76 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // Remaining imbalance should be zero at this point. If not, log error and burn.
-        let remaining_balance = remaining_credit.peek();
-        if !remaining_balance.is_zero() {
-            // log::error!("Unspent imbalance remains: remaining_balance = {remaining_balance:?}");
+        // Chain-buy caps can leave part of the block emission unspent. Allocate
+        // that TAO across all emitting subnets in proportion to their emission
+        // weights. It is materialized into each subnet's protocol TAO reservoir
+        // rather than sent through another chain buy, which preserves the cap and
+        // avoids an unpaired liquidity injection changing the spot price.
+        Self::allocate_remaining_tao(subnets_to_emit_to, subnet_emissions, remaining_credit);
+    }
+
+    fn allocate_remaining_tao(
+        subnets_to_emit_to: &[NetUid],
+        subnet_emissions: &BTreeMap<NetUid, U96F32>,
+        credit: CreditOf<T>,
+    ) {
+        let mut remaining_credit = credit;
+        if remaining_credit.peek().is_zero() {
+            return;
+        }
+
+        let zero = asfloat!(0);
+        let recipients: Vec<(NetUid, T::AccountId, U96F32)> = subnets_to_emit_to
+            .iter()
+            .filter_map(|netuid| {
+                let weight = *subnet_emissions.get(netuid).unwrap_or(&zero);
+                if weight == zero {
+                    return None;
+                }
+                Self::get_subnet_account_id(*netuid).map(|account| (*netuid, account, weight))
+            })
+            .collect();
+        let total_weight = recipients
+            .iter()
+            .fold(zero, |total, (_, _, weight)| total.saturating_add(*weight));
+
+        if total_weight == zero {
+            log::debug!("No weighted emitting subnet is available for remaining TAO");
+            Self::recycle_credit(remaining_credit);
+            return;
+        }
+
+        let distributable = asfloat!(remaining_credit.peek());
+        let last_index = recipients.len().saturating_sub(1);
+        for (index, (netuid, account, weight)) in recipients.into_iter().enumerate() {
+            let amount: TaoBalance = if index == last_index {
+                remaining_credit.peek()
+            } else {
+                tou64!(distributable.saturating_mul(weight.safe_div(total_weight))).into()
+            };
+            if amount.is_zero() {
+                continue;
+            }
+
+            match Self::spend_tao(&account, remaining_credit, amount) {
+                Ok(remainder) => {
+                    remaining_credit = remainder;
+                    T::SwapInterface::reserve_protocol_tao(netuid, amount);
+                }
+                Err(remainder) => {
+                    remaining_credit = remainder;
+                    log::error!(
+                        "Failed to allocate remaining TAO: netuid = {netuid:?}, amount = {amount:?}"
+                    );
+                }
+            }
+        }
+
+        if !remaining_credit.peek().is_zero() {
+            log::error!(
+                "Unable to allocate all remaining TAO: remaining = {:?}",
+                remaining_credit.peek()
+            );
             Self::recycle_credit(remaining_credit);
         }
     }
@@ -299,6 +366,7 @@ impl<T: Config> Pallet<T> {
         // --- 2. Inject TAO and ALPHA to pool and swap with excess TAO.
         Self::inject_and_maybe_swap(
             subnets_to_emit_to,
+            subnet_emissions,
             &tao_in,
             &alpha_in,
             &excess_amount,

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -742,7 +742,6 @@ fn test_coinbase_alpha_issuance_with_cap_trigger_and_block_emission() {
         let netuid1 = NetUid::from(1);
         let netuid2 = NetUid::from(2);
         let emission: u64 = 1_000_000;
-        let emission_credit = SubtensorModule::mint_tao(emission.into());
         add_network(netuid1, 1, 0);
         add_network(netuid2, 1, 0);
 
@@ -777,35 +776,46 @@ fn test_coinbase_alpha_issuance_with_cap_trigger_and_block_emission() {
         SubnetAlphaOut::<Test>::insert(netuid2, AlphaBalance::from(21_000_000_000_000_000_u64)); // Set issuance above 21M
 
         // Run coinbase
+        let issuance_before = TotalIssuance::<Test>::get();
+        let emission_credit = SubtensorModule::mint_tao(emission.into());
         SubtensorModule::run_coinbase(emission_credit);
 
-        // New behavior: chain-bought alpha is cached instead of recycled.
-        // The cached amount remains part of outstanding alpha supply.
-        assert!(
-            !SubnetProtocolAlpha::<Test>::get(netuid1).is_zero()
-                || !SubnetProtocolAlpha::<Test>::get(netuid2).is_zero()
+        // At the alpha supply cap there is no miner or validator alpha emission,
+        // so the chain-buy cap is zero and all of the TAO credit is recycled.
+        assert_eq!(
+            SubnetProtocolAlpha::<Test>::get(netuid1),
+            AlphaBalance::ZERO
         );
+        assert_eq!(
+            SubnetProtocolAlpha::<Test>::get(netuid2),
+            AlphaBalance::ZERO
+        );
+        assert_eq!(TotalIssuance::<Test>::get(), issuance_before);
 
         // Get the prices after the run_coinbase
         let price_1_after = <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid1);
         let price_2_after = <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid2);
 
-        // AlphaIn gets decreased beacuse of a buy
-        assert!(u64::from(SubnetAlphaIn::<Test>::get(netuid1)) < initial_alpha);
+        // No chain buy means pool reserves and prices remain unchanged.
         assert_eq!(
-            u64::from(SubnetAlphaOut::<Test>::get(netuid2)),
-            21_000_000_000_000_000_u64
-                .saturating_add(u64::from(SubnetProtocolAlpha::<Test>::get(netuid2)))
+            u64::from(SubnetAlphaIn::<Test>::get(netuid1)),
+            initial_alpha
         );
-        assert!(u64::from(SubnetAlphaIn::<Test>::get(netuid2)) < initial_alpha);
+        assert_eq!(
+            u64::from(SubnetAlphaOut::<Test>::get(netuid1)),
+            21_000_000_000_000_000_u64
+        );
+        assert_eq!(
+            u64::from(SubnetAlphaIn::<Test>::get(netuid2)),
+            initial_alpha
+        );
         assert_eq!(
             u64::from(SubnetAlphaOut::<Test>::get(netuid2)),
             21_000_000_000_000_000_u64
-                .saturating_add(u64::from(SubnetProtocolAlpha::<Test>::get(netuid2)))
         );
 
-        assert!(price_1_after > price_1_before);
-        assert!(price_2_after > price_2_before);
+        assert_eq!(price_1_after, price_1_before);
+        assert_eq!(price_2_after, price_2_before);
     });
 }
 
@@ -2039,6 +2049,7 @@ fn test_incentive_to_subnet_owner_is_burned() {
         assert_eq!(subnet_owner_stake_after, 0.into());
         let other_stake_after = SubtensorModule::get_stake_for_hotkey_on_subnet(&other_hk, netuid);
         assert!(other_stake_after > 0.into());
+        assert_eq!(MinerBurned::<Test>::get(netuid), U96F32::from_num(0.5));
     });
 }
 
@@ -2094,6 +2105,7 @@ fn test_incentive_to_subnet_owners_hotkey_is_burned() {
         assert_eq!(subnet_owner_stake_after, 0.into());
         let other_stake_after = SubtensorModule::get_stake_for_hotkey_on_subnet(&other_hk, netuid);
         assert_eq!(other_stake_after, 0.into());
+        assert_eq!(MinerBurned::<Test>::get(netuid), U96F32::from_num(1));
     });
 }
 
@@ -3676,6 +3688,128 @@ fn test_coinbase_subnet_terms_with_alpha_in_lte_alpha_emission() {
             excess_tao[&netuid0].to_num::<f64>(),
             tao_emission.to_num::<f64>() - tao_in[&netuid0].to_num::<f64>(),
             epsilon = 0.01
+        );
+    });
+}
+
+#[test]
+fn test_coinbase_chain_buy_is_capped_at_allocated_miner_alpha_value() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(1_000_000_000_000_000_u64),
+            AlphaBalance::from(1_000_000_000_000_000_u64),
+        );
+        Swap::maybe_initialize_palswap(netuid, None);
+
+        // Force root_proportion to zero so the full subnet TAO allocation is
+        // eligible for the chain-buy path.
+        SubnetTAO::<Test>::insert(NetUid::ROOT, TaoBalance::ZERO);
+        SubnetOwnerCut::<Test>::set(u16::MAX / 10);
+        SubtensorModule::set_owner_cut_enabled_flag(netuid, true);
+        MinerBurned::<Test>::insert(netuid, U96F32::from_num(0));
+
+        let alpha_emission = U96F32::saturating_from_num(
+            SubtensorModule::get_block_emission_for_issuance(
+                SubtensorModule::get_alpha_issuance(netuid).into(),
+            )
+            .unwrap_or(0),
+        );
+        let price = U96F32::saturating_from_num(Swap::current_alpha_price(netuid));
+        let owner_cut =
+            alpha_emission.saturating_mul(SubtensorModule::get_float_subnet_owner_cut());
+        let participant_alpha = alpha_emission.saturating_sub(owner_cut);
+        let miner_alpha = participant_alpha.saturating_mul(U96F32::from_num(0.5));
+        let chain_buy_cap = miner_alpha.saturating_mul(price);
+        let tao_emission = chain_buy_cap.saturating_mul(U96F32::from_num(2));
+
+        let subnet_emissions = BTreeMap::from([(netuid, tao_emission)]);
+        let (tao_in, _, _, excess_tao) = SubtensorModule::get_subnet_terms(&subnet_emissions);
+
+        assert_eq!(tao_in[&netuid], U96F32::from_num(0));
+        assert_eq!(excess_tao[&netuid], chain_buy_cap);
+
+        // A chain buy already below the participant-emission value is unchanged.
+        let below_cap = chain_buy_cap.saturating_div(U96F32::from_num(2));
+        let subnet_emissions = BTreeMap::from([(netuid, below_cap)]);
+        let (_, _, _, excess_tao) = SubtensorModule::get_subnet_terms(&subnet_emissions);
+        assert_eq!(excess_tao[&netuid], below_cap);
+
+        // Miner emission withheld by burn/recycle UIDs reduces chain-buy
+        // capacity by the same proportion.
+        MinerBurned::<Test>::insert(netuid, U96F32::from_num(0.25));
+        let partially_burned_cap = chain_buy_cap.saturating_mul(U96F32::from_num(0.75));
+        let subnet_emissions = BTreeMap::from([(
+            netuid,
+            partially_burned_cap.saturating_mul(U96F32::from_num(2)),
+        )]);
+        let (_, _, _, excess_tao) = SubtensorModule::get_subnet_terms(&subnet_emissions);
+        assert_eq!(excess_tao[&netuid], partially_burned_cap);
+
+        // A subnet withholding all miner emission gets no chain-buy capacity.
+        MinerBurned::<Test>::insert(netuid, U96F32::from_num(1));
+        let subnet_emissions = BTreeMap::from([(netuid, chain_buy_cap)]);
+        let (_, _, _, excess_tao) = SubtensorModule::get_subnet_terms(&subnet_emissions);
+        assert_eq!(excess_tao[&netuid], U96F32::from_num(0));
+
+        // With owner cut disabled, the miner half is calculated from the full
+        // alpha_out amount before applying the burn adjustment.
+        SubtensorModule::set_owner_cut_enabled_flag(netuid, false);
+        MinerBurned::<Test>::insert(netuid, U96F32::from_num(0));
+        let full_miner_cap = alpha_emission
+            .saturating_mul(U96F32::from_num(0.5))
+            .saturating_mul(price);
+        let subnet_emissions =
+            BTreeMap::from([(netuid, full_miner_cap.saturating_mul(U96F32::from_num(2)))]);
+        let (_, _, _, excess_tao) = SubtensorModule::get_subnet_terms(&subnet_emissions);
+        assert_eq!(excess_tao[&netuid], full_miner_cap);
+    });
+}
+
+#[test]
+fn test_coinbase_recycles_tao_above_chain_buy_cap() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(1_000_000_000_000_000_u64),
+            AlphaBalance::from(1_000_000_000_000_000_u64),
+        );
+        Swap::maybe_initialize_palswap(netuid, None);
+
+        SubnetTAO::<Test>::insert(NetUid::ROOT, TaoBalance::ZERO);
+        SubnetOwnerCut::<Test>::set(u16::MAX / 10);
+        SubtensorModule::set_owner_cut_enabled_flag(netuid, true);
+        MinerBurned::<Test>::insert(netuid, U96F32::from_num(0.25));
+
+        let alpha_emission = U96F32::saturating_from_num(
+            SubtensorModule::get_block_emission_for_issuance(
+                SubtensorModule::get_alpha_issuance(netuid).into(),
+            )
+            .unwrap_or(0),
+        );
+        let price = U96F32::saturating_from_num(Swap::current_alpha_price(netuid));
+        let miner_alpha = alpha_emission
+            .saturating_sub(
+                alpha_emission.saturating_mul(SubtensorModule::get_float_subnet_owner_cut()),
+            )
+            .saturating_mul(U96F32::from_num(0.5))
+            .saturating_mul(U96F32::from_num(0.75));
+        let chain_buy_cap = miner_alpha.saturating_mul(price);
+        let tao_emission = chain_buy_cap.saturating_mul(U96F32::from_num(2));
+        let tao_emission_balance = TaoBalance::from(tao_emission.saturating_to_num::<u64>());
+        let expected_chain_buy = TaoBalance::from(chain_buy_cap.saturating_to_num::<u64>());
+        let issuance_before = TotalIssuance::<Test>::get();
+
+        let credit = SubtensorModule::mint_tao(tao_emission_balance);
+        let subnet_emissions = BTreeMap::from([(netuid, tao_emission)]);
+        SubtensorModule::emit_to_subnets(&[netuid], &subnet_emissions, credit, false);
+
+        assert_eq!(SubnetExcessTao::<Test>::get(netuid), expected_chain_buy);
+        assert_eq!(
+            TotalIssuance::<Test>::get(),
+            issuance_before.saturating_add(expected_chain_buy)
         );
     });
 }

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -282,17 +282,17 @@ fn test_sudo_set_subnet_emission_enabled_multiple_subnets_multiple_toggles() {
             assert_abs_diff_eq!(
                 SubnetTaoInEmission::<Test>::get(netuid1),
                 TaoBalance::from(expected1),
-                epsilon = 2.into(),
+                epsilon = 10.into(),
             );
             assert_abs_diff_eq!(
                 SubnetTaoInEmission::<Test>::get(netuid2),
                 TaoBalance::from(expected2),
-                epsilon = 2.into(),
+                epsilon = 10.into(),
             );
             assert_abs_diff_eq!(
                 SubnetTaoInEmission::<Test>::get(netuid3),
                 TaoBalance::from(expected3),
-                epsilon = 2.into(),
+                epsilon = 10.into(),
             );
 
             assert_eq!(
@@ -781,7 +781,8 @@ fn test_coinbase_alpha_issuance_with_cap_trigger_and_block_emission() {
         SubtensorModule::run_coinbase(emission_credit);
 
         // At the alpha supply cap there is no miner or validator alpha emission,
-        // so the chain-buy cap is zero and all of the TAO credit is recycled.
+        // so the chain-buy cap is zero and all TAO is allocated to subnet
+        // reservoirs by emission weight.
         assert_eq!(
             SubnetProtocolAlpha::<Test>::get(netuid1),
             AlphaBalance::ZERO
@@ -790,7 +791,16 @@ fn test_coinbase_alpha_issuance_with_cap_trigger_and_block_emission() {
             SubnetProtocolAlpha::<Test>::get(netuid2),
             AlphaBalance::ZERO
         );
-        assert_eq!(TotalIssuance::<Test>::get(), issuance_before);
+        assert_eq!(
+            TotalIssuance::<Test>::get(),
+            issuance_before.saturating_add(TaoBalance::from(emission))
+        );
+        assert_eq!(
+            pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid1).saturating_add(
+                pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid2)
+            ),
+            TaoBalance::from(emission)
+        );
 
         // Get the prices after the run_coinbase
         let price_1_after = <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid1);
@@ -3768,7 +3778,7 @@ fn test_coinbase_chain_buy_is_capped_at_allocated_miner_alpha_value() {
 }
 
 #[test]
-fn test_coinbase_recycles_tao_above_chain_buy_cap() {
+fn test_coinbase_allocates_tao_above_chain_buy_cap() {
     new_test_ext(1).execute_with(|| {
         let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
         mock::setup_reserves(
@@ -3800,6 +3810,7 @@ fn test_coinbase_recycles_tao_above_chain_buy_cap() {
         let tao_emission = chain_buy_cap.saturating_mul(U96F32::from_num(2));
         let tao_emission_balance = TaoBalance::from(tao_emission.saturating_to_num::<u64>());
         let expected_chain_buy = TaoBalance::from(chain_buy_cap.saturating_to_num::<u64>());
+        let expected_reservoir = tao_emission_balance.saturating_sub(expected_chain_buy);
         let issuance_before = TotalIssuance::<Test>::get();
 
         let credit = SubtensorModule::mint_tao(tao_emission_balance);
@@ -3809,8 +3820,73 @@ fn test_coinbase_recycles_tao_above_chain_buy_cap() {
         assert_eq!(SubnetExcessTao::<Test>::get(netuid), expected_chain_buy);
         assert_eq!(
             TotalIssuance::<Test>::get(),
-            issuance_before.saturating_add(expected_chain_buy)
+            issuance_before.saturating_add(tao_emission_balance)
         );
+        assert_eq!(
+            pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid),
+            expected_reservoir
+        );
+    });
+}
+
+#[test]
+fn test_coinbase_allocates_capped_tao_across_subnets_by_emission_weight() {
+    new_test_ext(1).execute_with(|| {
+        let netuid1 = add_dynamic_network(&U256::from(1), &U256::from(2));
+        let netuid2 = add_dynamic_network(&U256::from(3), &U256::from(4));
+        let initial_tao = TaoBalance::from(1_000_000_000_000_000_u64);
+        let initial_alpha = AlphaBalance::from(1_000_000_000_000_000_u64);
+
+        for netuid in [netuid1, netuid2] {
+            mock::setup_reserves(netuid, initial_tao, initial_alpha);
+            Swap::maybe_initialize_palswap(netuid, None);
+            SubtensorModule::set_owner_cut_enabled_flag(netuid, false);
+            MinerBurned::<Test>::insert(netuid, U96F32::from_num(1));
+        }
+        SubnetTAO::<Test>::insert(NetUid::ROOT, TaoBalance::ZERO);
+
+        let emission1 = TaoBalance::from(100_u64);
+        let emission2 = TaoBalance::from(300_u64);
+        let total_emission = emission1.saturating_add(emission2);
+        let subnet_emissions = BTreeMap::from([
+            (netuid1, U96F32::saturating_from_num(emission1)),
+            (netuid2, U96F32::saturating_from_num(emission2)),
+        ]);
+        let subnet_account1 = SubtensorModule::get_subnet_account_id(netuid1).unwrap();
+        let subnet_account2 = SubtensorModule::get_subnet_account_id(netuid2).unwrap();
+        let balance1_before = Balances::free_balance(&subnet_account1);
+        let balance2_before = Balances::free_balance(&subnet_account2);
+        let issuance_before = TotalIssuance::<Test>::get();
+
+        let credit = SubtensorModule::mint_tao(total_emission);
+        SubtensorModule::emit_to_subnets(&[netuid1, netuid2], &subnet_emissions, credit, false);
+
+        // Both subnets have zero chain-buy capacity, so the entire emission is
+        // allocated to their TAO reservoirs in the original 1:3 emission ratio.
+        assert_eq!(SubnetExcessTao::<Test>::get(netuid1), TaoBalance::ZERO);
+        assert_eq!(SubnetExcessTao::<Test>::get(netuid2), TaoBalance::ZERO);
+        assert_eq!(
+            pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid1),
+            emission1
+        );
+        assert_eq!(
+            pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid2),
+            emission2
+        );
+        assert_eq!(
+            Balances::free_balance(&subnet_account1),
+            balance1_before.saturating_add(emission1)
+        );
+        assert_eq!(
+            Balances::free_balance(&subnet_account2),
+            balance2_before.saturating_add(emission2)
+        );
+        assert_eq!(
+            TotalIssuance::<Test>::get(),
+            issuance_before.saturating_add(total_emission)
+        );
+        assert_eq!(SubnetTAO::<Test>::get(netuid1), initial_tao);
+        assert_eq!(SubnetTAO::<Test>::get(netuid2), initial_tao);
     });
 }
 
@@ -3832,10 +3908,19 @@ fn test_coinbase_inject_and_maybe_swap_does_not_skew_reserves() {
         let alpha_in = BTreeMap::from([(netuid0, U96F32::saturating_from_num(456))]);
         // We have excess TAO, so we will be swapping with it.
         let excess_tao = BTreeMap::from([(netuid0, U96F32::saturating_from_num(789100))]);
+        let subnet_emissions =
+            BTreeMap::from([(netuid0, U96F32::saturating_from_num(123 + 789100))]);
 
         // Run the inject and maybe swap
         let credit = SubtensorModule::mint_tao((123 + 789100).into());
-        SubtensorModule::inject_and_maybe_swap(&[netuid0], &tao_in, &alpha_in, &excess_tao, credit);
+        SubtensorModule::inject_and_maybe_swap(
+            &[netuid0],
+            &subnet_emissions,
+            &tao_in,
+            &alpha_in,
+            &excess_tao,
+            credit,
+        );
 
         let tao_in_after = SubnetTAO::<Test>::get(netuid0);
         let alpha_in_after = SubnetAlphaIn::<Test>::get(netuid0);
@@ -3871,9 +3956,17 @@ fn test_coinbase_failed_tao_materialization_does_not_activate_current_tao() {
         let tao_in = BTreeMap::from([(netuid, U96F32::saturating_from_num(current_tao))]);
         let alpha_in = BTreeMap::from([(netuid, U96F32::saturating_from_num(current_alpha))]);
         let excess_tao = BTreeMap::new();
+        let subnet_emissions = BTreeMap::from([(netuid, U96F32::saturating_from_num(current_tao))]);
         let credit = SubtensorModule::mint_tao(TaoBalance::ZERO);
 
-        SubtensorModule::inject_and_maybe_swap(&[netuid], &tao_in, &alpha_in, &excess_tao, credit);
+        SubtensorModule::inject_and_maybe_swap(
+            &[netuid],
+            &subnet_emissions,
+            &tao_in,
+            &alpha_in,
+            &excess_tao,
+            credit,
+        );
 
         assert_eq!(
             SubnetTAO::<Test>::get(netuid),
@@ -3920,7 +4013,7 @@ fn test_alpha_reservoir_counts_toward_subnet_issuance_across_blocks() {
 }
 
 #[test]
-fn test_coinbase_inject_and_maybe_swap_reverts_excess_tao_deposit_on_swap_failure() {
+fn test_coinbase_inject_and_maybe_swap_reserves_excess_tao_on_swap_failure() {
     new_test_ext(1).execute_with(|| {
         let zero = U96F32::saturating_from_num(0);
         let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
@@ -3957,15 +4050,36 @@ fn test_coinbase_inject_and_maybe_swap_reverts_excess_tao_deposit_on_swap_failur
         let tao_in = BTreeMap::from([(netuid, zero)]);
         let alpha_in = BTreeMap::from([(netuid, zero)]);
         let excess_tao = BTreeMap::from([(netuid, U96F32::saturating_from_num(tao_to_swap))]);
+        let subnet_emissions = BTreeMap::from([(netuid, U96F32::saturating_from_num(tao_to_swap))]);
         let credit = SubtensorModule::mint_tao(tao_to_swap);
 
-        SubtensorModule::inject_and_maybe_swap(&[netuid], &tao_in, &alpha_in, &excess_tao, credit);
+        SubtensorModule::inject_and_maybe_swap(
+            &[netuid],
+            &subnet_emissions,
+            &tao_in,
+            &alpha_in,
+            &excess_tao,
+            credit,
+        );
 
-        assert_eq!(Balances::free_balance(subnet_account), chain_before);
+        assert_eq!(
+            Balances::free_balance(subnet_account),
+            chain_before.saturating_add(tao_to_swap)
+        );
         assert_eq!(SubnetTAO::<Test>::get(netuid), subnet_tao_before);
         assert_eq!(SubnetExcessTao::<Test>::get(netuid), TaoBalance::ZERO);
-        assert_eq!(TotalIssuance::<Test>::get(), total_issuance_before);
-        assert_eq!(Balances::total_issuance(), balances_issuance_before);
+        assert_eq!(
+            pallet_subtensor_swap::BalancerTaoReservoir::<Test>::get(netuid),
+            tao_to_swap
+        );
+        assert_eq!(
+            TotalIssuance::<Test>::get(),
+            total_issuance_before.saturating_add(tao_to_swap)
+        );
+        assert_eq!(
+            Balances::total_issuance(),
+            balances_issuance_before.saturating_add(tao_to_swap)
+        );
     });
 }
 

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -510,6 +510,12 @@ impl<T: Config> SwapHandler for Pallet<T> {
         BalancerTaoReservoir::<T>::get(netuid)
     }
 
+    fn reserve_protocol_tao(netuid: NetUid, amount: TaoBalance) {
+        BalancerTaoReservoir::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(amount);
+        });
+    }
+
     fn clear_protocol_liquidity_reservoirs(netuid: NetUid) {
         BalancerTaoReservoir::<T>::remove(netuid);
         BalancerAlphaReservoir::<T>::remove(netuid);

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -186,6 +186,27 @@ mod dispatchables {
     }
 
     #[test]
+    fn test_reserve_protocol_tao_accumulates_without_activating_reserves() {
+        new_test_ext().execute_with(|| {
+            let netuid = NetUid::from(1);
+            let initial_tao = TaoBalance::from(1_000_u64);
+            let initial_alpha = AlphaBalance::from(2_000_u64);
+            TaoReserve::set_mock_reserve(netuid, initial_tao);
+            AlphaReserve::set_mock_reserve(netuid, initial_alpha);
+
+            Swap::reserve_protocol_tao(netuid, TaoBalance::from(100_u64));
+            Swap::reserve_protocol_tao(netuid, TaoBalance::from(50_u64));
+
+            assert_eq!(
+                Swap::protocol_tao_reservoir(netuid),
+                TaoBalance::from(150_u64)
+            );
+            assert_eq!(TaoReserve::reserve(netuid), initial_tao);
+            assert_eq!(AlphaReserve::reserve(netuid), initial_alpha);
+        });
+    }
+
+    #[test]
     fn test_adjust_protocol_liquidity_materializes_alpha_when_reservoiring_alpha() {
         new_test_ext().execute_with(|| {
             let netuid = NetUid::from(1);

--- a/primitives/swap-interface/src/lib.rs
+++ b/primitives/swap-interface/src/lib.rs
@@ -49,6 +49,9 @@ pub trait SwapHandler {
     ) -> (TaoBalance, AlphaBalance);
     fn protocol_alpha_reservoir(netuid: NetUid) -> AlphaBalance;
     fn protocol_tao_reservoir(netuid: NetUid) -> TaoBalance;
+    /// Record protocol TAO that the caller has already materialized into the
+    /// subnet account, without making it immediately price-active.
+    fn reserve_protocol_tao(netuid: NetUid, amount: TaoBalance);
     fn clear_protocol_liquidity_reservoirs(netuid: NetUid);
     fn clear_protocol_liquidity(netuid: NetUid, weight_meter: &mut WeightMeter) -> bool;
     fn init_swap(netuid: NetUid, maybe_price: Option<U64F64>);


### PR DESCRIPTION
## Why this change

A subnet's chain buy should fund the productive miner layer, not create unlimited mechanical demand. This PR caps each subnet's chain buy at the spot-TAO value of its unburned miner emissions, while preserving exact block issuance and reallocating rejected TAO to other emitting subnets that can still use it.

This keeps immediate protocol demand tied to miner work and gives lower-ranked networks a deterministic path to liquidity and miner buyback support without removing the largest subnets' emission-weight priority.

## Allocation behavior

For each subnet, the planner starts from its original emission-weight allocation:

1. Fill TAO/alpha liquidity up to the subnet's injection capacity.
2. Route remaining local TAO to a chain buy.
3. Cap that chain buy at the TAO value of unburned miner emissions.

Unburned miner emissions are the miner half of alpha emissions after owner cut, reduced by the proportion withheld by `MinerBurned` in the last settled tempo:

`chain_buy_cap = post_owner_cut_alpha × 50% × (1 - MinerBurned) × spot_price`

If owner cut is disabled, the miner half is calculated from the full alpha emission. Owner and validator emissions do not increase the cap, and burn/recycle UID withholding reduces it.

TAO rejected by local chain-buy caps is pooled and distributed to positive-emission subnets in descending original emission-weight order, with ascending netuid as the deterministic tie-breaker. For each recipient, spillover first fills remaining TAO/alpha liquidity-injection capacity and then fills the chain buy up to its unburned-miner-emission cap. The allocator advances only after both capacities are full or spillover is exhausted.

Only after every eligible liquidity and chain-buy capacity is full can a terminal remainder enter emission-weighted protocol TAO reservoirs. TAO is never recycled or left unissued. Integer fixed-point remainder is reconciled through the same liquidity-first priority before reservoir allocation.

## Materialized emission reporting

The runtime records each subnet's final current-block TAO allocation: materialized liquidity, successful chain buys after spillover, and any current-block terminal reservoir allocation. Dynamic subnet info and metagraph responses now populate their existing emission fields from that final allocation, and stale values are cleared each block. TAO activated later from a prior reservoir is not counted again.

## Illustrative mainnet snapshot

At mainnet block 8,725,138 on July 29, 2026, the top 32 subnets received 97.85% of the original TAO allocation. With liquidity-first spillover, they still receive 84.20% of block issuance and retain full buyback coverage for their unburned miner emissions. Their combined allocation falls by 13.96%.

That change redirects 0.06749 TAO per block to ranks 33 through 66. About 0.02688 TAO first fills their remaining liquidity capacity, then 0.04061 TAO funds chain buybacks. This fully covers the TAO value of unburned miner emissions for all 34 subnets. The remaining spillover fills rank 67’s liquidity and partially funds its buyback.

This is the practical tradeoff: the largest subnets keep most issuance and full miner coverage, while a limited reallocation gives lower-ranked networks enough liquidity and buyback support to fund the miners they depend on.

This is a one-block example, not a guarantee of the cutoff under future prices, emission weights, burn rates, or liquidity requirements.

The final simulation conserved exactly 500,000,000 rao, assigned 31,129,431 rao of spillover to liquidity and 69,850,054 rao to buybacks (including 48 rao of integer reconciliation), and assigned 0 rao to terminal reservoirs. Full liquidity and unburned-miner buyback coverage extends through rank 66; rank 67 receives 600,015 rao of liquidity spillover and 205,154 rao of buyback spillover, leaving 139,085 rao of buyback headroom. Ranks 68 through 70 receive no spillover.

## Verification

- Focused spillover tests: 5 passed, 0 failed
- Focused coinbase tests: 88 passed, 0 failed
- Full standard `pallet-subtensor`: 1,344 passed, 0 failed, 9 ignored
- Full all-features `pallet-subtensor`: 1,432 passed, 0 failed, 9 ignored; doctests: 0 failed, 7 ignored
- Full `pallet-subtensor-swap`: 52 passed, 0 failed, 3 ignored; doctests: 0 failed
- `cargo fmt --all -- --check` passed on a byte-identical source snapshot
- `git diff --check` passed on the live working tree
- Final mainnet simulation validations passed for issuance conservation, priority ordering, liquidity-first allocation, chain-buy caps, terminal remainder handling, and zero-emission ineligibility

## Remaining requirement before review or merge

The benchmark fixture now includes clearing 128 prior `SubnetTaoEmission` entries so a production benchmark measures the added storage work. The all-features `bench_block_step` smoke test passed, but it is not a production measurement.

**Before this PR is ready for review or merge, run the measured production runtime `block_step` benchmark and regenerate the production weight from that measurement.** `weights.rs` is intentionally not updated by this commit; an existing benchmark smoke test is not a substitute for the measured weight update.
