### PR TITLE
Raise emission gate bar quantile from 0.61 to 0.8073

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1850,9 +1850,9 @@ pub mod pallet {
     /// Default emission bar quantile (q). The bar theta is the demand share at
     /// which the sorted cumulative share distribution crosses q.
     pub fn DefaultEmissionBarQuantile<T: Config>() -> U64F64 {
-        // 0.61: on the July 2026 distribution this lands the bar at the
-        // uniform share (1/active_subnets), around rank 32.
-        U64F64::saturating_from_num(0.61)
+        // 0.8073: on the July 2026 distribution this lands the bar around
+        // rank 64 (theta ~0.441%, 24 of 62 enabled subnets gated).
+        U64F64::saturating_from_num(0.8073)
     }
     #[pallet::storage]
     /// ITEM --> Emission Bar Quantile (q)

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -396,18 +396,18 @@ fn test_coinbase_tao_issuance_different_prices() {
         // Run the coinbase with the emission amount.
         SubtensorModule::run_coinbase(emission_credit);
 
-        // Linear shares are 1/3 and 2/3. The emission gate bar (q = 0.61) lands
-        // on the larger share (theta = 2/3), so gate(2/3) = 1/2 and
-        // gate(1/3) = 1/(1 + 2^3) = 1/9. Gated weights 1/27 and 1/3 normalize
-        // to a 1/10 : 9/10 split.
+        // Linear shares are 1/3 and 2/3. Cumulative 2/3 < q = 0.8073, so the
+        // emission gate bar lands on the smaller share (theta = 1/3):
+        // gate(1/3) = 1/2 and gate(2/3) = 1/(1 + (1/2)^3) = 8/9. Gated weights
+        // 1/6 and 16/27 normalize to a 9/41 : 32/41 split.
         assert_abs_diff_eq!(
             SubnetTAO::<Test>::get(netuid1),
-            TaoBalance::from(initial_tao + emission / 10),
+            TaoBalance::from(initial_tao + emission * 9 / 41),
             epsilon = 10.into(),
         );
         assert_abs_diff_eq!(
             SubnetTAO::<Test>::get(netuid2),
-            TaoBalance::from(initial_tao + 9 * emission / 10),
+            TaoBalance::from(initial_tao + emission * 32 / 41),
             epsilon = 10.into(),
         );
 
@@ -674,19 +674,19 @@ fn test_coinbase_alpha_issuance_different() {
         set_full_injection_root_stake();
         // Run coinbase
         SubtensorModule::run_coinbase(emission_credit);
-        // Linear shares are 1/3 and 2/3; the emission gate (q = 0.61, h = 3)
-        // turns them into a 1/10 : 9/10 split (see
+        // Linear shares are 1/3 and 2/3; the emission gate (q = 0.8073, h = 3)
+        // turns them into a 9/41 : 32/41 split (see
         // test_coinbase_tao_issuance_different_prices for the gate math).
-        // tao_in = 100_000, alpha_in = 100_000/price = 100_000 + initial
+        // tao_in = 219_512, alpha_in = 219_512/price = 219_512 + initial
         assert_abs_diff_eq!(
             SubnetAlphaIn::<Test>::get(netuid1),
-            AlphaBalance::from(initial + emission / 10),
+            AlphaBalance::from(initial + emission * 9 / 41),
             epsilon = 10.into(),
         );
-        // tao_in = 900_000, alpha_in = 900_000/price = 450_000 + initial
+        // tao_in = 780_487, alpha_in = 780_487/price = 390_243 + initial
         assert_abs_diff_eq!(
             SubnetAlphaIn::<Test>::get(netuid2),
-            AlphaBalance::from(initial + (emission * 9 / 10) / 2),
+            AlphaBalance::from(initial + (emission * 32 / 41) / 2),
             epsilon = 10.into(),
         );
     });

--- a/pallets/subtensor/src/tests/subnet_emissions.rs
+++ b/pallets/subtensor/src/tests/subnet_emissions.rs
@@ -235,7 +235,7 @@ fn emission_gate_one_subnet_full_share() {
     });
 }
 
-/// Two-subnet 1:2 prices through the default gate (q = 0.61, h = 3) → 1/10 : 9/10.
+/// Two-subnet 1:2 prices through the default gate (q = 0.8073, h = 3) → 9/41 : 32/41.
 #[test]
 fn emission_gate_concentrates_1_to_2_price_split() {
     new_test_ext(1).execute_with(|| {
@@ -254,14 +254,16 @@ fn emission_gate_concentrates_1_to_2_price_split() {
         let s1 = shares.get(&n1).copied().unwrap().to_num::<f64>();
         let s2 = shares.get(&n2).copied().unwrap().to_num::<f64>();
 
-        // Linear 1/3 : 2/3; q-mass bar lands on 2/3; gated weights normalize to 1/10 : 9/10.
+        // Linear 1/3 : 2/3; cumulative 2/3 < q = 0.8073, so the q-mass bar lands
+        // on the smaller share (theta = 1/3). gate(1/3) = 1/2, gate(2/3) = 8/9;
+        // gated weights 1/6 and 16/27 normalize to 9/41 : 32/41.
         assert_abs_diff_eq!(
             EmissionGateBar::<Test>::get().to_num::<f64>(),
-            2.0 / 3.0,
+            1.0 / 3.0,
             epsilon = 1e-9
         );
-        assert_abs_diff_eq!(s1, 0.1_f64, epsilon = 1e-6);
-        assert_abs_diff_eq!(s2, 0.9_f64, epsilon = 1e-6);
+        assert_abs_diff_eq!(s1, 9.0 / 41.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(s2, 32.0 / 41.0, epsilon = 1e-6);
         assert_abs_diff_eq!(s1 + s2, 1.0_f64, epsilon = 1e-9);
     });
 }
@@ -308,7 +310,7 @@ fn emission_gate_bar_update_cadence() {
         let n3 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
         System::set_block_number(0);
-        // Shares 0.7, 0.2, 0.1. q = 0.61 crosses on the first → theta = 0.7.
+        // Shares 0.7, 0.2, 0.1. q = 0.8073 crosses on the second → theta = 0.2.
         SubnetMovingPrice::<Test>::insert(n1, i96f32(7.0));
         SubnetMovingPrice::<Test>::insert(n2, i96f32(2.0));
         SubnetMovingPrice::<Test>::insert(n3, i96f32(1.0));
@@ -318,9 +320,9 @@ fn emission_gate_bar_update_cadence() {
 
         let _ = SubtensorModule::get_shares(&[n1, n2, n3]);
         let bar_head = EmissionGateBar::<Test>::get().to_num::<f64>();
-        assert_abs_diff_eq!(bar_head, 0.7_f64, epsilon = 1e-9);
+        assert_abs_diff_eq!(bar_head, 0.2_f64, epsilon = 1e-9);
 
-        // Flatten to equal thirds. Mid-interval: bar sticky at 0.6.
+        // Flatten to equal thirds. Mid-interval: bar sticky at 0.2.
         SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
         SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
         SubnetMovingPrice::<Test>::insert(n3, i96f32(1.0));
@@ -332,8 +334,8 @@ fn emission_gate_bar_update_cadence() {
             epsilon = 1e-9
         );
 
-        // At the cadence boundary: q = 0.61 over equal thirds crosses on the
-        // second share → theta = 1/3.
+        // At the cadence boundary: q = 0.8073 over equal thirds crosses on the
+        // third share → theta = 1/3.
         System::set_block_number(SubtensorModule::EMISSION_BAR_UPDATE_INTERVAL);
         let _ = SubtensorModule::get_shares(&[n1, n2, n3]);
         assert_abs_diff_eq!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 440,
+    spec_version: 441,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Raise the emission gate bar quantile from 0.61 to 0.8073

### What this changes

A single default: `EmissionBarQuantile` (q) goes from 0.61 to 0.8073.
Nothing else about the gate changes. The q-mass bar, the Hill gate, the
exponent h = 3, and the 360-block recompute cadence all stay as shipped.

### Why

v440 shipped with q = 0.61, which puts the emission bar around rank 30 on
the current Finney distribution. We modeled the gate against live chain
data and got numbers that match the release page's own chart closely
(theta 0.789% vs the published 0.78%, below-bar emission 39.0% to 11.9% vs
the published 38.4% to 12.5%), so we're confident we're measuring the same
thing. At the shipped setting, 41 of 62 actively paying subnets sit below
the bar, and about 665 tao/day moves upward. That's roughly 18.5% of all
daily emission, most of it landing on a handful of subnets.

Raising q to 0.8073 puts the bar around rank 64 on the same distribution:

|                         | q = 0.61 (shipped)   | q = 0.8073 (this PR) |
|-------------------------|----------------------|----------------------|
| Bar (theta)             | 0.789%               | 0.441%               |
| Enabled subnets gated   | 41 of 62             | 24 of 62             |
| Emission moved upward   | ~665 tao/day (18.5%) | ~265 tao/day (7.3%)  |

Rank 64 is not an arbitrary midpoint: the network originally ran with a
64-subnet capacity before the limit was expanded. Setting the bar there
keeps the gate's pressure on the expansion slots, the "junior pool" of
newer entrants competing to demonstrate demand and graduate above the bar,
rather than cutting into subnets within the network's original footprint.

The upgrade's stated goal still holds. Emission concentrates on subnets
with demonstrated demand and idle slots lose their passive carry. This
change just cuts the size of the transfer by about 2.5x.

### Scope and caveats

- q is a demand-mass quantile, not a rank. Rank 64 is where the bar lands
  on the July 2026 snapshot and will drift as the distribution changes.
- This adjusts the distribution, not the gate dynamics. Subnets below the
  bar face the same mechanics as before. There are just fewer of them.
- `EmissionBarQuantile` remains sudo-settable, so the default can be tuned
  further in either direction without another runtime upgrade.

Made with [Cursor](https://cursor.com)