### PR TITLE
Allow clippy::expect_used in claim_root_weight, matching its siblings

### DIFF
--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
 use node_subtensor_runtime::{
     BlockWeights, Runtime, RuntimeCall, TxExtension, check_mortality, check_nonce, sudo_wrapper,


### PR DESCRIPTION
## Description

`cargo clippy --workspace --all-targets ... -- -D warnings` (`check-rust.yml:170`) fails on `main`.

`runtime` inherits `[workspace.lints.clippy]`, where `expect-used = "deny"` (root `Cargo.toml:51`). `runtime/tests/claim_root_weight.rs:37` has a `BlockWeights::get()` chain ending in `.expect("normal extrinsics have a configured maximum")` at line 40, with no crate-level allow. Clippy reports the span at `:37:25`. Both sibling integration tests that use `.expect` carry one:

- `runtime/tests/evm_transaction_fee.rs:1` carries `#![allow(clippy::expect_used, clippy::unwrap_used)]`
- `runtime/tests/precompiles.rs:1-2` carries separate `#![allow]` lines

This adds the matching allow. One line, no behavior change.

How it reached `main`, in case the CI gap is worth a look separately: the file arrived in #2985 (merged 2026-07-27). That PR's head commit `3877023b1` records 79 check runs and none of them is `cargo clippy` or `cargo fmt`, so the job never ran against the code being merged. The next merged PR, #2990 (`release-v440`, head `795ae0269`), shows `cargo clippy (all)` and `cargo clippy (default)` both failing.

## Related Issue(s)

None filed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

None.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to fix formatting and clippy issues
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

No test added: the lint job is the test.

## Additional Notes

Runtime logic is untouched, so no `spec_version` bump. Tell me if the `no-spec-version-bump` label is the convention here and I will add it.
