### PR TITLE
Benchmark `register_network` against a full subnet map

### DIFF
--- a/pallets/subtensor/src/benchmarks/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks/benchmarks.rs
@@ -301,8 +301,40 @@ mod pallet_benchmarks {
         let amount: u64 = 100_000_000_000_000u64.saturating_mul(2);
         add_balance_to_coldkey_account::<T>(&coldkey, amount.into());
 
+        frame_system::Pallet::<T>::set_block_number(1u32.into());
+        fill_subnets_below_limit::<T>(&account("FillOwner", 0, seed));
+
         #[extrinsic_call]
         _(RawOrigin::Signed(coldkey.clone()), hotkey.clone());
+    }
+
+    /// The other outcome of `do_register_network`: at `SubnetLimit` the call prunes a subnet and
+    /// queues rather than creating one. Not an extrinsic; it exists so the two dispatches that can
+    /// reach this branch can charge the worst of the two.
+    #[benchmark]
+    fn register_network_pruning() {
+        let seed: u32 = 1;
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("TestHotkey", 0, seed);
+
+        Subtensor::<T>::set_network_rate_limit(1);
+        let amount: u64 = 100_000_000_000_000u64.saturating_mul(2);
+        add_balance_to_coldkey_account::<T>(&coldkey, amount.into());
+
+        frame_system::Pallet::<T>::set_block_number(1u32.into());
+        fill_subnets_to_limit::<T>(&account("FillOwner", 0, seed));
+
+        #[block]
+        {
+            let _ = Subtensor::<T>::do_register_network(
+                RawOrigin::Signed(coldkey.clone()).into(),
+                &hotkey,
+                1,
+                None,
+            );
+        }
+
+        assert!(!NetworkRegistrationQueue::<T>::get().is_empty());
     }
 
     #[benchmark]
@@ -1455,6 +1487,9 @@ mod pallet_benchmarks {
         Subtensor::<T>::set_network_rate_limit(1);
         let amount: u64 = 9_999_999_999_999;
         add_balance_to_coldkey_account::<T>(&coldkey, amount.into());
+
+        frame_system::Pallet::<T>::set_block_number(1u32.into());
+        fill_subnets_below_limit::<T>(&account("FillOwner", 0, 1));
 
         #[extrinsic_call]
         _(

--- a/pallets/subtensor/src/benchmarks/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks/benchmarks.rs
@@ -308,9 +308,15 @@ mod pallet_benchmarks {
         _(RawOrigin::Signed(coldkey.clone()), hotkey.clone());
     }
 
-    /// The other outcome of `do_register_network`: at `SubnetLimit` the call prunes a subnet and
-    /// queues rather than creating one. Not an extrinsic; it exists so the two dispatches that can
-    /// reach this branch can charge the worst of the two.
+    /// The queueing outcome of `do_register_network`: at `SubnetLimit` the call prunes a subnet and
+    /// queues rather than creating one. Not an extrinsic; it exists so the dispatches that can reach
+    /// this branch have a worst case to charge.
+    ///
+    /// This also covers the third outcome, `wait_to_cleanup`. That path reaches the same queueing
+    /// block without running `get_network_to_prune` or `do_dissolve_network`, so at equal queue
+    /// depth it is strictly cheaper than this one. Queue depth itself is measured at neither: both
+    /// queues are decoded unconditionally on every call and neither is a `BoundedVec`, so there is
+    /// no maximum to benchmark against.
     #[benchmark]
     fn register_network_pruning() {
         let seed: u32 = 1;
@@ -326,12 +332,12 @@ mod pallet_benchmarks {
 
         #[block]
         {
-            let _ = Subtensor::<T>::do_register_network(
+            assert_ok!(Subtensor::<T>::do_register_network(
                 RawOrigin::Signed(coldkey.clone()).into(),
                 &hotkey,
                 1,
-                None,
-            );
+                Some(max_subnet_identity()),
+            ));
         }
 
         assert!(!NetworkRegistrationQueue::<T>::get().is_empty());
@@ -1481,7 +1487,7 @@ mod pallet_benchmarks {
     fn register_network_with_identity() {
         let coldkey: T::AccountId = whitelisted_caller();
         let hotkey: T::AccountId = account("Alice", 0, 1);
-        let identity: Option<SubnetIdentityOfV3> = None;
+        let identity: Option<SubnetIdentityOfV3> = Some(max_subnet_identity());
 
         Subtensor::<T>::set_network_registration_allowed(1.into(), true);
         Subtensor::<T>::set_network_rate_limit(1);

--- a/pallets/subtensor/src/benchmarks/helpers.rs
+++ b/pallets/subtensor/src/benchmarks/helpers.rs
@@ -15,25 +15,71 @@ pub(super) fn set_reserves<T: Config>(
     SubnetAlphaIn::<T>::insert(netuid, alpha_in);
 }
 
+/// The largest identity `is_valid_subnet_identity` accepts: 6,656 bytes across the eight fields.
+///
+/// Both registration outcomes carry the identity. Creation writes it to `SubnetIdentitiesV3`;
+/// queueing encodes it into the `NetworkRegistrationQueue` entry and again into the event. `None`
+/// measures neither.
+pub(super) fn max_subnet_identity() -> SubnetIdentityOfV3 {
+    SubnetIdentityOfV3 {
+        subnet_name: vec![b'n'; 256],
+        github_repo: vec![b'g'; 1024],
+        subnet_contact: vec![b'c'; 1024],
+        subnet_url: vec![b'u'; 1024],
+        discord: vec![b'd'; 256],
+        description: vec![b'e'; 1024],
+        logo_url: vec![b'l'; 1024],
+        additional: vec![b'a'; 1024],
+    }
+}
+
 /// Fill the chain with prunable subnets so a registration benchmark runs against a realistic
 /// `NetworksAdded` map rather than an empty one.
 ///
 /// `do_register_network` counts every entry in `NetworksAdded` on every call, and once that count
 /// reaches `SubnetLimit` it also walks `get_network_to_prune`. Registering into an empty chain
-/// measures neither. The two outcomes are mutually exclusive and neither dominates the other:
-/// below the limit the call creates a subnet (many writes), at the limit it prunes and queues
-/// instead (far more reads). Callers pick which one they are measuring via `subnets`.
+/// measures neither. Callers pick which outcome they are measuring via `subnets`: below the limit
+/// the call creates a subnet (many writes), at the limit it prunes and queues instead (far more
+/// reads). Neither dominates the other.
 ///
 /// Immunity is set to one block and `NetworkRegisteredAt` to zero so no candidate is skipped.
 /// Requires a current block above zero.
+///
+/// Every subnet is made dynamic with a funded pool, and both prices are staggered per subnet.
+///
+/// Two independent scans walk `NetworksAdded`, and a fixture of stable, empty-pool subnets makes
+/// both of them exit early on every entry:
+///
+/// - `get_network_to_prune` calls `get_moving_alpha_price`, which returns on `SubnetMechanism == 0`
+///   without reading `SubnetMovingPrice`.
+/// - `get_median_subnet_alpha_price` calls swap `current_price`, which returns on a non-dynamic
+///   mechanism, and on a dynamic one still returns before reading the TAO reserve or the balancer
+///   unless the alpha reserve is nonzero.
+///
+/// So the scans would walk 128 entries while pricing none, which is the same class of mistake as
+/// benchmarking against an empty chain. Staggering matters as well as seeding: the median builds a
+/// `BTreeMap` keyed on price, and identical reserves collapse it to a single entry.
 pub(super) fn fill_subnets<T: Config>(owner: &T::AccountId, subnets: u16) {
     NetworkImmunityPeriod::<T>::set(1);
 
     for netuid in 1..=subnets {
+        let offset = u64::from(netuid);
         let netuid = NetUid::from(netuid);
+
         Subtensor::<T>::init_new_network(netuid, 1);
         NetworkRegisteredAt::<T>::insert(netuid, 0);
         SubnetOwner::<T>::insert(netuid, owner.clone());
+        SubnetMechanism::<T>::insert(netuid, 1);
+        set_reserves::<T>(
+            netuid,
+            TaoBalance::from(150_000_000_000_u64.saturating_add(offset.saturating_mul(1_000_000))),
+            AlphaBalance::from(100_000_000_000_u64),
+        );
+        SubnetMovingPrice::<T>::insert(
+            netuid,
+            I96F32::saturating_from_num(1_000_u64.saturating_add(offset))
+                .saturating_div(I96F32::saturating_from_num(1_000)),
+        );
     }
 }
 

--- a/pallets/subtensor/src/benchmarks/helpers.rs
+++ b/pallets/subtensor/src/benchmarks/helpers.rs
@@ -15,6 +15,40 @@ pub(super) fn set_reserves<T: Config>(
     SubnetAlphaIn::<T>::insert(netuid, alpha_in);
 }
 
+/// Fill the chain with prunable subnets so a registration benchmark runs against a realistic
+/// `NetworksAdded` map rather than an empty one.
+///
+/// `do_register_network` counts every entry in `NetworksAdded` on every call, and once that count
+/// reaches `SubnetLimit` it also walks `get_network_to_prune`. Registering into an empty chain
+/// measures neither. The two outcomes are mutually exclusive and neither dominates the other:
+/// below the limit the call creates a subnet (many writes), at the limit it prunes and queues
+/// instead (far more reads). Callers pick which one they are measuring via `subnets`.
+///
+/// Immunity is set to one block and `NetworkRegisteredAt` to zero so no candidate is skipped.
+/// Requires a current block above zero.
+pub(super) fn fill_subnets<T: Config>(owner: &T::AccountId, subnets: u16) {
+    NetworkImmunityPeriod::<T>::set(1);
+
+    for netuid in 1..=subnets {
+        let netuid = NetUid::from(netuid);
+        Subtensor::<T>::init_new_network(netuid, 1);
+        NetworkRegisteredAt::<T>::insert(netuid, 0);
+        SubnetOwner::<T>::insert(netuid, owner.clone());
+    }
+}
+
+/// One below `SubnetLimit`: the registration still creates a subnet, but pays the full count.
+pub(super) fn fill_subnets_below_limit<T: Config>(owner: &T::AccountId) {
+    let limit = Subtensor::<T>::get_max_subnets();
+    fill_subnets::<T>(owner, limit.saturating_sub(1));
+}
+
+/// At `SubnetLimit`: the registration prunes a subnet and queues instead of creating one.
+pub(super) fn fill_subnets_to_limit<T: Config>(owner: &T::AccountId) {
+    let limit = Subtensor::<T>::get_max_subnets();
+    fill_subnets::<T>(owner, limit);
+}
+
 pub(super) fn benchmark_registration_burn() -> TaoBalance {
     TaoBalance::from(1_000_000)
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1002,8 +1002,9 @@ mod dispatches {
 
         /// User register a new subnetwork
         ///
-        /// Below `SubnetLimit` this creates a subnet; at the limit it prunes one and queues
-        /// instead. The two are mutually exclusive and neither dominates, so charge the worse.
+        /// Below `SubnetLimit` this creates a subnet; at the limit it either prunes one and queues,
+        /// or queues to wait on a cleanup already in flight. The first two are mutually exclusive
+        /// and neither dominates, so charge the worse; the third is dominated by the second.
         #[pallet::call_index(59)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network()
             .max(<T as crate::pallet::Config>::WeightInfo::register_network_pruning()))]
@@ -1186,7 +1187,7 @@ mod dispatches {
 
         /// User register a new subnetwork
         ///
-        /// Same two outcomes as `register_network`, so the same worst case applies.
+        /// Same outcomes as `register_network`, so the same worst case applies.
         #[pallet::call_index(79)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network_with_identity()
             .max(<T as crate::pallet::Config>::WeightInfo::register_network_pruning()))]

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1001,8 +1001,12 @@ mod dispatches {
         }
 
         /// User register a new subnetwork
+        ///
+        /// Below `SubnetLimit` this creates a subnet; at the limit it prunes one and queues
+        /// instead. The two are mutually exclusive and neither dominates, so charge the worse.
         #[pallet::call_index(59)]
-        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network())]
+        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network()
+            .max(<T as crate::pallet::Config>::WeightInfo::register_network_pruning()))]
         pub fn register_network(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
             Self::do_register_network(origin, &hotkey, 1, None)
         }
@@ -1181,8 +1185,11 @@ mod dispatches {
         }
 
         /// User register a new subnetwork
+        ///
+        /// Same two outcomes as `register_network`, so the same worst case applies.
         #[pallet::call_index(79)]
-        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network_with_identity())]
+        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_network_with_identity()
+            .max(<T as crate::pallet::Config>::WeightInfo::register_network_pruning()))]
         pub fn register_network_with_identity(
             origin: OriginFor<T>,
             hotkey: T::AccountId,

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -623,11 +623,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Swap::SwapBalancer` (r:1 w:0)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
 	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -713,11 +713,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3721`
-		//  Estimated: `323986`
-		// Minimum execution time: 2_130_304_000 picoseconds.
-		Weight::from_parts(2_160_771_000, 323986)
-			.saturating_add(T::DbWeight::get().reads(293_u64))
+		//  Measured:  `7696`
+		//  Estimated: `327961`
+		// Minimum execution time: 3_401_152_000 picoseconds.
+		Weight::from_parts(3_505_837_000, 327961)
+			.saturating_add(T::DbWeight::get().reads(671_u64))
 			.saturating_add(T::DbWeight::get().writes(49_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
@@ -742,7 +742,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::NetworkImmunityPeriod` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:1 w:0)
+	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetMovingPrice` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkLastLockCost` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworkLastLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -762,7 +762,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::TotalStake` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:0)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkRegistrationLockId` (r:1 w:1)
 	/// Proof: `SubtensorModule::NetworkRegistrationLockId` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -770,13 +770,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(899), added: 3374, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:0)
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(499), added: 2974, mode: `MaxEncodedLen`)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:0)
+	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
+	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	fn register_network_pruning() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3943`
-		//  Estimated: `326683`
-		// Minimum execution time: 2_210_744_000 picoseconds.
-		Weight::from_parts(2_283_058_000, 326683)
-			.saturating_add(T::DbWeight::get().reads(408_u64))
+		//  Measured:  `10544`
+		//  Estimated: `333284`
+		// Minimum execution time: 4_004_051_000 picoseconds.
+		Weight::from_parts(4_090_472_000, 333284)
+			.saturating_add(T::DbWeight::get().reads(916_u64))
 			.saturating_add(T::DbWeight::get().writes(10_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
@@ -2128,11 +2132,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Swap::SwapBalancer` (r:1 w:0)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
 	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -2206,6 +2210,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::ImmunityPeriod` (r:0 w:1)
 	/// Proof: `SubtensorModule::ImmunityPeriod` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetIdentitiesV3` (r:0 w:1)
+	/// Proof: `SubtensorModule::SubnetIdentitiesV3` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetEmissionEnabled` (r:0 w:1)
 	/// Proof: `SubtensorModule::SubnetEmissionEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkRegistrationAllowed` (r:0 w:1)
@@ -2220,12 +2226,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network_with_identity() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3657`
-		//  Estimated: `323922`
-		// Minimum execution time: 2_160_801_000 picoseconds.
-		Weight::from_parts(2_248_876_000, 323922)
-			.saturating_add(T::DbWeight::get().reads(292_u64))
-			.saturating_add(T::DbWeight::get().writes(48_u64))
+		//  Measured:  `7632`
+		//  Estimated: `327897`
+		// Minimum execution time: 3_420_479_000 picoseconds.
+		Weight::from_parts(3_487_302_000, 327897)
+			.saturating_add(T::DbWeight::get().reads(670_u64))
+			.saturating_add(T::DbWeight::get().writes(49_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4300,11 +4306,11 @@ impl WeightInfo for () {
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Swap::SwapBalancer` (r:1 w:0)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
 	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4390,11 +4396,11 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3721`
-		//  Estimated: `323986`
-		// Minimum execution time: 2_130_304_000 picoseconds.
-		Weight::from_parts(2_160_771_000, 323986)
-			.saturating_add(RocksDbWeight::get().reads(293_u64))
+		//  Measured:  `7696`
+		//  Estimated: `327961`
+		// Minimum execution time: 3_401_152_000 picoseconds.
+		Weight::from_parts(3_505_837_000, 327961)
+			.saturating_add(RocksDbWeight::get().reads(671_u64))
 			.saturating_add(RocksDbWeight::get().writes(49_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
@@ -4419,7 +4425,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::NetworkImmunityPeriod` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:1 w:0)
+	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetMovingPrice` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkLastLockCost` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworkLastLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4439,7 +4445,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::TotalStake` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:0)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:128 w:0)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkRegistrationLockId` (r:1 w:1)
 	/// Proof: `SubtensorModule::NetworkRegistrationLockId` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4447,13 +4453,17 @@ impl WeightInfo for () {
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(899), added: 3374, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:0)
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(499), added: 2974, mode: `MaxEncodedLen`)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:0)
+	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
+	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	fn register_network_pruning() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3943`
-		//  Estimated: `326683`
-		// Minimum execution time: 2_210_744_000 picoseconds.
-		Weight::from_parts(2_283_058_000, 326683)
-			.saturating_add(RocksDbWeight::get().reads(408_u64))
+		//  Measured:  `10544`
+		//  Estimated: `333284`
+		// Minimum execution time: 4_004_051_000 picoseconds.
+		Weight::from_parts(4_090_472_000, 333284)
+			.saturating_add(RocksDbWeight::get().reads(916_u64))
 			.saturating_add(RocksDbWeight::get().writes(10_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
@@ -5805,11 +5815,11 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Swap::SwapBalancer` (r:1 w:0)
+	/// Storage: `Swap::SwapBalancer` (r:127 w:0)
 	/// Proof: `Swap::SwapBalancer` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
 	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
 	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -5883,6 +5893,8 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::ImmunityPeriod` (r:0 w:1)
 	/// Proof: `SubtensorModule::ImmunityPeriod` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetIdentitiesV3` (r:0 w:1)
+	/// Proof: `SubtensorModule::SubnetIdentitiesV3` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetEmissionEnabled` (r:0 w:1)
 	/// Proof: `SubtensorModule::SubnetEmissionEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::NetworkRegistrationAllowed` (r:0 w:1)
@@ -5897,12 +5909,12 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network_with_identity() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `3657`
-		//  Estimated: `323922`
-		// Minimum execution time: 2_160_801_000 picoseconds.
-		Weight::from_parts(2_248_876_000, 323922)
-			.saturating_add(RocksDbWeight::get().reads(292_u64))
-			.saturating_add(RocksDbWeight::get().writes(48_u64))
+		//  Measured:  `7632`
+		//  Estimated: `327897`
+		// Minimum execution time: 3_420_479_000 picoseconds.
+		Weight::from_parts(3_487_302_000, 327897)
+			.saturating_add(RocksDbWeight::get().reads(670_u64))
+			.saturating_add(RocksDbWeight::get().writes(49_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -44,6 +44,7 @@ pub trait WeightInfo {
 	fn burned_register() -> Weight;
 	fn root_register() -> Weight;
 	fn register_network() -> Weight;
+	fn register_network_pruning() -> Weight;
 	fn commit_weights() -> Weight;
 	fn reveal_weights() -> Weight;
 	fn sudo_set_tx_childkey_take_rate_limit() -> Weight;
@@ -604,7 +605,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::NetworksAdded` (r:3 w:1)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:129 w:1)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:0)
 	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -620,7 +621,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `System::Account` (r:2 w:2)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
-	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -704,18 +705,79 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::NetworkRegistrationAllowed` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::Yuma3On` (r:0 w:1)
 	/// Proof: `SubtensorModule::Yuma3On` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::HotkeySuccessor` (r:0 w:1)
+	/// Proof: `SubtensorModule::HotkeySuccessor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:0 w:1)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::MaxAllowedUids` (r:0 w:1)
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1532`
-		//  Estimated: `9947`
-		// Minimum execution time: 145_000_000 picoseconds.
-		Weight::from_parts(153_000_000, 9947)
-			.saturating_add(T::DbWeight::get().reads(41_u64))
-			.saturating_add(T::DbWeight::get().writes(48_u64))
+		//  Measured:  `3721`
+		//  Estimated: `323986`
+		// Minimum execution time: 2_130_304_000 picoseconds.
+		Weight::from_parts(2_160_771_000, 323986)
+			.saturating_add(T::DbWeight::get().reads(293_u64))
+			.saturating_add(T::DbWeight::get().writes(49_u64))
+	}
+	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
+	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationStartBlock` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkRegistrationStartBlock` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRateLimit` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::LastRateLimitedBlock` (r:1 w:0)
+	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:130 w:1)
+	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:1)
+	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationQueue` (r:1 w:1)
+	/// Proof: `SubtensorModule::NetworkRegistrationQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegisteredAt` (r:128 w:0)
+	/// Proof: `SubtensorModule::NetworkRegisteredAt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkImmunityPeriod` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkImmunityPeriod` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:128 w:0)
+	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetMovingPrice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkLastLockCost` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkLastLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkMinLockCost` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkMinLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkLockReductionInterval` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkLockReductionInterval` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::TotalIssuance` (r:1 w:0)
+	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
+	/// Storage: `Swap::BalancerTaoReservoir` (r:1 w:1)
+	/// Proof: `Swap::BalancerTaoReservoir` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
+	/// Storage: `Swap::BalancerAlphaReservoir` (r:1 w:1)
+	/// Proof: `Swap::BalancerAlphaReservoir` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
+	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
+	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::TotalStake` (r:1 w:1)
+	/// Proof: `SubtensorModule::TotalStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationLockId` (r:1 w:1)
+	/// Proof: `SubtensorModule::NetworkRegistrationLockId` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(899), added: 3374, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(499), added: 2974, mode: `MaxEncodedLen`)
+	fn register_network_pruning() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3943`
+		//  Estimated: `326683`
+		// Minimum execution time: 2_210_744_000 picoseconds.
+		Weight::from_parts(2_283_058_000, 326683)
+			.saturating_add(T::DbWeight::get().reads(408_u64))
+			.saturating_add(T::DbWeight::get().writes(10_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2050,7 +2112,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::NetworksAdded` (r:3 w:1)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:129 w:1)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:0)
 	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -2064,7 +2126,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::NetworkLockReductionInterval` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::TotalIssuance` (r:1 w:0)
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2150,18 +2212,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::NetworkRegistrationAllowed` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::Yuma3On` (r:0 w:1)
 	/// Proof: `SubtensorModule::Yuma3On` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::HotkeySuccessor` (r:0 w:1)
+	/// Proof: `SubtensorModule::HotkeySuccessor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:0 w:1)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::MaxAllowedUids` (r:0 w:1)
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network_with_identity() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1468`
-		//  Estimated: `9883`
-		// Minimum execution time: 143_000_000 picoseconds.
-		Weight::from_parts(148_000_000, 9883)
-			.saturating_add(T::DbWeight::get().reads(40_u64))
-			.saturating_add(T::DbWeight::get().writes(47_u64))
+		//  Measured:  `3657`
+		//  Estimated: `323922`
+		// Minimum execution time: 2_160_801_000 picoseconds.
+		Weight::from_parts(2_248_876_000, 323922)
+			.saturating_add(T::DbWeight::get().reads(292_u64))
+			.saturating_add(T::DbWeight::get().writes(48_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4218,7 +4282,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::NetworksAdded` (r:3 w:1)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:129 w:1)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:0)
 	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4234,7 +4298,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `System::Account` (r:2 w:2)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
-	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4318,18 +4382,79 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::NetworkRegistrationAllowed` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::Yuma3On` (r:0 w:1)
 	/// Proof: `SubtensorModule::Yuma3On` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::HotkeySuccessor` (r:0 w:1)
+	/// Proof: `SubtensorModule::HotkeySuccessor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:0 w:1)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::MaxAllowedUids` (r:0 w:1)
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1532`
-		//  Estimated: `9947`
-		// Minimum execution time: 145_000_000 picoseconds.
-		Weight::from_parts(153_000_000, 9947)
-			.saturating_add(RocksDbWeight::get().reads(41_u64))
-			.saturating_add(RocksDbWeight::get().writes(48_u64))
+		//  Measured:  `3721`
+		//  Estimated: `323986`
+		// Minimum execution time: 2_130_304_000 picoseconds.
+		Weight::from_parts(2_160_771_000, 323986)
+			.saturating_add(RocksDbWeight::get().reads(293_u64))
+			.saturating_add(RocksDbWeight::get().writes(49_u64))
+	}
+	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
+	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationStartBlock` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkRegistrationStartBlock` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRateLimit` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::LastRateLimitedBlock` (r:1 w:0)
+	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:130 w:1)
+	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:1)
+	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationQueue` (r:1 w:1)
+	/// Proof: `SubtensorModule::NetworkRegistrationQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegisteredAt` (r:128 w:0)
+	/// Proof: `SubtensorModule::NetworkRegisteredAt` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkImmunityPeriod` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkImmunityPeriod` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:128 w:0)
+	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetMovingPrice` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetMovingPrice` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkLastLockCost` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkLastLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkMinLockCost` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkMinLockCost` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkLockReductionInterval` (r:1 w:0)
+	/// Proof: `SubtensorModule::NetworkLockReductionInterval` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::TotalIssuance` (r:1 w:0)
+	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
+	/// Storage: `Swap::BalancerTaoReservoir` (r:1 w:1)
+	/// Proof: `Swap::BalancerTaoReservoir` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
+	/// Storage: `Swap::BalancerAlphaReservoir` (r:1 w:1)
+	/// Proof: `Swap::BalancerAlphaReservoir` (`max_values`: None, `max_size`: Some(18), added: 2493, mode: `MaxEncodedLen`)
+	/// Storage: `SubtensorModule::TotalNetworks` (r:1 w:1)
+	/// Proof: `SubtensorModule::TotalNetworks` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::TotalStake` (r:1 w:1)
+	/// Proof: `SubtensorModule::TotalStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::SubnetTAO` (r:1 w:0)
+	/// Proof: `SubtensorModule::SubnetTAO` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::NetworkRegistrationLockId` (r:1 w:1)
+	/// Proof: `SubtensorModule::NetworkRegistrationLockId` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(899), added: 3374, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(499), added: 2974, mode: `MaxEncodedLen`)
+	fn register_network_pruning() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `3943`
+		//  Estimated: `326683`
+		// Minimum execution time: 2_210_744_000 picoseconds.
+		Weight::from_parts(2_283_058_000, 326683)
+			.saturating_add(RocksDbWeight::get().reads(408_u64))
+			.saturating_add(RocksDbWeight::get().writes(10_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -5664,7 +5789,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::LastRateLimitedBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetLimit` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::NetworksAdded` (r:3 w:1)
+	/// Storage: `SubtensorModule::NetworksAdded` (r:129 w:1)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::DissolveCleanupQueue` (r:1 w:0)
 	/// Proof: `SubtensorModule::DissolveCleanupQueue` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -5678,7 +5803,7 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::NetworkLockReductionInterval` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::TotalIssuance` (r:1 w:0)
 	/// Proof: `SubtensorModule::TotalIssuance` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:1)
+	/// Storage: `SubtensorModule::SubnetMechanism` (r:127 w:1)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::SubnetAlphaIn` (r:1 w:1)
 	/// Proof: `SubtensorModule::SubnetAlphaIn` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -5764,18 +5889,20 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::NetworkRegistrationAllowed` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::Yuma3On` (r:0 w:1)
 	/// Proof: `SubtensorModule::Yuma3On` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::HotkeySuccessor` (r:0 w:1)
+	/// Proof: `SubtensorModule::HotkeySuccessor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:0 w:1)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::MaxAllowedUids` (r:0 w:1)
 	/// Proof: `SubtensorModule::MaxAllowedUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn register_network_with_identity() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `1468`
-		//  Estimated: `9883`
-		// Minimum execution time: 143_000_000 picoseconds.
-		Weight::from_parts(148_000_000, 9883)
-			.saturating_add(RocksDbWeight::get().reads(40_u64))
-			.saturating_add(RocksDbWeight::get().writes(47_u64))
+		//  Measured:  `3657`
+		//  Estimated: `323922`
+		// Minimum execution time: 2_160_801_000 picoseconds.
+		Weight::from_parts(2_248_876_000, 323922)
+			.saturating_add(RocksDbWeight::get().reads(292_u64))
+			.saturating_add(RocksDbWeight::get().writes(48_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 440,
+    spec_version: 441,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## What

`register_network`'s benchmark registers into a chain with no subnets on it. Everything expensive the extrinsic does scales with how many subnets already exist, so none of it lands in the measurement.

Three costs scale with the subnet count and the benchmark misses all three.

`do_register_network` counts the subnet map on every call:

```rust
let current_count: u16 = NetworksAdded::<T>::iter()
    .filter(|(netuid, added)| *added && *netuid != NetUid::ROOT)
    .count() as u16;
```

That runs unconditionally. On a chain at the 128-subnet limit the iterator reads all 129 entries, root included, before the filter drops it. The weight this replaces annotates `NetworksAdded (r:3 w:1)`.

If the count has reached `SubnetLimit`, `get_network_to_prune` walks the map a second time, reading `NetworkRegisteredAt` and the moving price for every entry, and `do_dissolve_network` runs on whichever subnet loses. `get_median_subnet_alpha_price` then walks it a third time, asking the swap pallet for each subnet's price. That one runs on both outcomes, on every call that clears the lock-cost check.

Measured against a full chain instead of an empty one, `register_network` is 671 reads and 25.18 ms of charged weight, against the 41 reads and 5.98 ms it charges today. Proof size goes from 9,947 to 327,961.

## Why now

The benchmark measures a branch mainnet does not take. At block 8,739,071, `NetworksAdded` holds 128 live non-root entries against a `SubnetLimit` of 128. The chain sits exactly at the cap, so every registration on finney right now takes the at-limit path: the full count, the median scan, the prune scan, then the queue. That path measures at 916 reads and charges 41.

The gap also gets worse soon. The v440 notes say the price of entry should fall toward the cost of the registration transaction, which leaves the weight as most of what a registration costs.

## The fix

A helper that fills `NetworksAdded` before the measurement, and a second benchmark for the branch that was never measured at all.

Filling the map isn't enough on its own. If you're checking the fixture, check this: both price scans exit early on a subnet that is stable or has an empty pool.

- `get_moving_alpha_price` returns on `SubnetMechanism == 0` without reading `SubnetMovingPrice`. `init_new_network` doesn't set a mechanism, so a naively built subnet is stable.
- Swap `current_price` returns on a non-dynamic mechanism, and on a dynamic one still returns before reading the TAO reserve or the balancer unless the alpha reserve is nonzero.

A fixture of stable, empty-pool subnets therefore walks 128 entries while pricing none, which is the same mistake in a subtler form. So every synthetic subnet gets a mechanism of 1 and a funded pool, and the prices are staggered rather than identical, because the median builds a `BTreeMap` keyed on price and one repeated value collapses it to a single entry.

Where an identity is in play it is measured at its maximum of 6,656 bytes, the largest `is_valid_subnet_identity` accepts. `register_network` takes no identity argument, so that row measures `None`; `register_network_with_identity` and `register_network_pruning` carry a full one. It matters most on the queueing path, which encodes the identity into the queue entry and again into the event.

## The three outcomes

`do_register_network` has three successful ends, not two:

| | what happens |
| --- | --- |
| below the limit | creates a subnet |
| at the limit | prunes one and queues |
| at the limit, cleanups already in flight | queues to wait |

The third joins the second at the same queueing block but gets there without running `get_network_to_prune` or `do_dissolve_network`, so at equal queue depth it is strictly cheaper and needs no separate measurement.

The first two are mutually exclusive:

| | ref_time | proof_size | reads | writes | charged |
| --- | ---: | ---: | ---: | ---: | ---: |
| creating, one below the limit | 3,505,837,000 | 327,961 | 671 | 49 | 25.18 ms |
| pruning, at the limit | 4,090,472,000 | 333,284 | 916 | 10 | 27.99 ms |

So `register_network` is benchmarked one below the limit, where it still pays the count and the median scan but takes the creation path, and a new `register_network_pruning` covers the other one. `register_network_pruning` is not an extrinsic. It exists only so the dispatches that can reach that branch have a worst case to charge.

Both dispatches charge the componentwise `.max()` of the pair. Pruning happens to dominate both dimensions under `RocksDbWeight`, but that isn't structural: creation does 39 more writes and 245 fewer reads, so the ordering depends on the read/write ratio in `DbWeight`. `.max()` is correct whichever way that falls.

## What this still doesn't measure

Two pieces of the state these weights depend on have no bound, so no constant can cover them:

- `sudo_set_subnet_limit` only checks `ensure_root`. The subnet count is root-settable with no ceiling.
- `DissolveCleanupQueue` and `NetworkRegistrationQueue` are plain `Vec` rather than `BoundedVec`, and both get decoded on every call before any branch is chosen. Reaching the queueing branch appends to the second one.

I measured the second one on `register_network`, so it gets a number instead of a caveat. Every figure above is taken with both queues empty. A `NetworkRegistrationInfo` entry encodes to 6,775 bytes at a maximum identity, so filling the queue to one entry per subnet slot adds 860,805 bytes of proof, 3.6x the table. The annotation set does not change: no new key is read, the keys already being read just hold more. `register_network_pruning` moves the same way for the same reason. I am not quoting a figure for it, because the only measurement I have of that path came off a branch carrying unrelated changes.

So this correction is partial. Empty-queue is not a defensible worst case, and neither is any particular depth while the type is unbounded. Fixing it properly means bounding the storage or adding a weight component, which needs its own migration and review. I kept that out of a measurement fix, but I'll write it if you want both together.

The same empty-chain problem exists in a sibling I have not touched here. `register_leased_network` (`pallets/subtensor/src/benchmarks/benchmarks.rs:1797` on this branch) does not fill the subnet map either, so a lease that succeeds below the cap on a populated chain walks all of `NetworksAdded` and all of `SubnetOwner`, then refunds post-dispatch to a constant measured against an empty one. For a two-contributor lease that is a refund from roughly 1.30 MB down to about 15.4 KB. It is the same bug this PR describes, it predates this PR, and it is a two-line fixture change on top of the helper added here. I can include it if you want.

## One consequence

`LinearWeightToFee` is degree 1 with `coeff_frac` of 500,000 parts per billion, so the weight component of the fee tracks the declared weight directly. Correcting the weight raises that component from about 0.00299 TAO to about 0.0140 TAO. `pallet_transaction_payment` charges a base and a length fee on top, so those figures are not the whole of what a registration pays, only the part this PR moves. Both are small next to the lock, but the change is real, so it belongs in the description.

Because that is a runtime behavior change, `spec_version` goes 440 to 441. The weight constants live in the runtime wasm, so a corrected measurement only reaches a chain through a release. Mainnet is on 440. No migration: nothing moves storage or call index, so `transaction_version` stays 1.

## Testing

Existing tests unchanged and passing. No new tests: this changes a benchmark fixture and the weights generated from it, and the benchmark is the measurement. Weights measured locally with the repo's own flags from `scripts/benchmark_action.sh`. `run-benchmarks.yml` skips forks, so the bot will need to re-run these.

## Related Issue(s)

None that this fixes. #3024 depends on it, and #3023 is stacked on this branch: both cite these numbers, so a change here moves them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

No API or storage change. The declared weight of `register_network` and `register_network_with_identity` rises, which raises the weight component of the fee they pay from about 0.00299 TAO (0.00292 for the identity variant) to about 0.0140 TAO. That is the intended correction rather than a side effect, and it is why `spec_version` goes to 441.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to fix formatting and clippy issues
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

`run-benchmarks.yml` gates the self-hosted runner on `head.repo.fork == false`, so the benchmark bot will not run against this branch. Every number here was measured on my hardware with the repo's own flags from `scripts/benchmark_action.sh`. Treat them as a claim about the shape of the gap rather than as constants to ship, and re-run them on yours before merging. If it helps, add the `run-benchmarks` label or push the branch into the repo and I will rebase onto whatever it produces.

This is deliberately a partial correction, for the reasons in "What this still doesn't measure" above. Landing the measurement that is already wrong beat bundling a redesign into it. Tell me if you want both at once.

