### PR TITLE
Fix mainnet snapshot mirror digest handling

### DIFF
--- a/.github/scripts/test-r2-artifact-mirror.py
+++ b/.github/scripts/test-r2-artifact-mirror.py
@@ -19,6 +19,7 @@ PUBLISH_HELPER = Path(__file__).with_name("publish-artifact-mirror.sh")
 CURRENT_RUN_HELPER = Path(__file__).with_name(
     "publish-current-run-artifact-mirror.sh"
 )
+SNAPSHOT_WORKFLOW = Path(__file__).parents[1] / "workflows" / "refresh-mainnet-snapshot.yml"
 SPEC = importlib.util.spec_from_file_location("r2_artifact_mirror", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -30,6 +31,14 @@ assert MODULE.ALLOWED_ARTIFACT_NAMES == {
     "try-runtime-snap-v0.10.1-testnet",
     "try-runtime-snap-v0.10.1-devnet",
 }
+
+snapshot_workflow = SNAPSHOT_WORKFLOW.read_text(encoding="utf-8")
+mainnet_mirror_step = snapshot_workflow.split(
+    "  # try-runtime state snapshots", maxsplit=1
+)[0].split("      - name: Mirror snapshot for fleet prefetch", maxsplit=1)[1]
+assert "publish-current-run-artifact-mirror.sh" in mainnet_mirror_step
+assert "mainnet-snapshot" in mainnet_mirror_step
+assert "steps.upload-snapshot.outputs.artifact-digest" not in mainnet_mirror_step
 
 
 assert MODULE.validate_endpoint(

--- a/.github/workflows/refresh-mainnet-snapshot.yml
+++ b/.github/workflows/refresh-mainnet-snapshot.yml
@@ -112,16 +112,9 @@ jobs:
       - name: Mirror snapshot for fleet prefetch
         env:
           GH_TOKEN: ${{ github.token }}
-          ARTIFACT_ID: ${{ steps.upload-snapshot.outputs.artifact-id }}
-          ARTIFACT_DIGEST: ${{ steps.upload-snapshot.outputs.artifact-digest }}
-        run: |
-          set -euo pipefail
-          .github/scripts/publish-artifact-mirror.sh \
-            "$ARTIFACT_ID" \
-            mainnet-snapshot \
-            "$ARTIFACT_DIGEST" \
-            "$GITHUB_SHA" \
-            .github/workflows/refresh-mainnet-snapshot.yml
+        run: >-
+          .github/scripts/publish-current-run-artifact-mirror.sh
+          mainnet-snapshot
 
   # try-runtime state snapshots, one job per network so one flaky endpoint
   # doesn't prevent the others from publishing. The .snap format

--- a/.github/workflows/validate-sccache.yml
+++ b/.github/workflows/validate-sccache.yml
@@ -41,6 +41,7 @@ on:
       - ".github/workflows/check-node-compat.yml"
       - ".github/workflows/mainnet-clone-preview.yml"
       - ".github/workflows/runtime-checks.yml"
+      - ".github/workflows/refresh-mainnet-snapshot.yml"
       - ".github/workflows/sccache-warm.yml"
       - ".github/workflows/typescript-e2e.yml"
       - ".github/workflows/validate-sccache.yml"


### PR DESCRIPTION
## Summary

- publish the mainnet snapshot through the existing current-run artifact helper
- obtain the API-normalized `sha256:` digest instead of passing the raw upload-action output
- run cache-boundary validation when the snapshot workflow changes
- assert the mainnet mirror path cannot regress to the raw digest output

## Context

The snapshot artifact upload succeeds, but the mirror publisher rejects the upload action’s unprefixed digest. That makes the trusted producer run fail, so the local artifact cache correctly refuses it and consumers fall back to GitHub.

## Validation

- `.github/scripts/test-r2-artifact-mirror.py`
- YAML parsing for `refresh-mainnet-snapshot.yml` and `validate-sccache.yml`
- `git diff --check`