### PR TITLE
fix(cli): resolve local hotkey names before ss58 decode

### DIFF
--- a/sdk/python/bittensor/cli/commands/lock.py
+++ b/sdk/python/bittensor/cli/commands/lock.py
@@ -162,9 +162,10 @@ def add_lock(
     except ValueError as error:
         app_ctx.output.error(f"invalid value for `--amount-alpha`: {error}")
         raise typer.Exit(2)
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
     if perpetual:
         app_ctx.submit(SetPerpetualLock(netuid=netuid, enabled=True))
-    app_ctx.submit(LockStake(netuid=netuid, amount_alpha=amount, hotkey_ss58=hotkey_ss58))
+    app_ctx.submit(LockStake(netuid=netuid, amount_alpha=amount, hotkey_ss58=hotkey))
 
 
 @app.command("mode")

--- a/sdk/python/bittensor/cli/commands/stake.py
+++ b/sdk/python/bittensor/cli/commands/stake.py
@@ -210,7 +210,8 @@ def set_auto_stake(
     default) instead of accruing unstaked.
     """
     app_ctx: AppContext = ctx_of(ctx)
-    app_ctx.submit(SetAutoStake(netuid=netuid, hotkey_ss58=hotkey_ss58))
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
+    app_ctx.submit(SetAutoStake(netuid=netuid, hotkey_ss58=hotkey))
 
 
 @app.command("set-claim", rich_help_panel=PANEL_AUTO)
@@ -305,13 +306,14 @@ def child_set(
     chain rate-limits how often the child list can change.
     """
     app_ctx: AppContext = ctx_of(ctx)
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
     try:
         parsed = json.loads(children)
     except json.JSONDecodeError as error:
         app_ctx.output.error(f"invalid --children JSON: {error}")
         raise typer.Exit(1)
     try:
-        intent = SetChildren(netuid=netuid, children=parsed, hotkey_ss58=hotkey_ss58)
+        intent = SetChildren(netuid=netuid, children=parsed, hotkey_ss58=hotkey)
     except ValueError as error:
         app_ctx.output.error(str(error))
         raise typer.Exit(2)
@@ -333,7 +335,8 @@ def child_revoke(
     weight. Subject to the same rate limit as `btcli stake child set`.
     """
     app_ctx: AppContext = ctx_of(ctx)
-    app_ctx.submit(SetChildren(netuid=netuid, children=[], hotkey_ss58=hotkey_ss58))
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
+    app_ctx.submit(SetChildren(netuid=netuid, children=[], hotkey_ss58=hotkey))
 
 
 @child_app.command("take")
@@ -353,8 +356,9 @@ def child_take(
     (e.g. 0.09) or the raw u16 proportion (0 to 65535).
     """
     app_ctx: AppContext = ctx_of(ctx)
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
     try:
-        intent = SetChildkeyTake(netuid=netuid, take=take, hotkey_ss58=hotkey_ss58)
+        intent = SetChildkeyTake(netuid=netuid, take=take, hotkey_ss58=hotkey)
     except ValueError as error:
         app_ctx.output.error(str(error))
         raise typer.Exit(2)

--- a/sdk/python/bittensor/cli/commands/subnets.py
+++ b/sdk/python/bittensor/cli/commands/subnets.py
@@ -390,7 +390,8 @@ def register_subnet(
     `btcli subnets burn-cost`.
     """
     app_ctx: AppContext = ctx_of(ctx)
-    app_ctx.submit(BurnedRegister(netuid=netuid, hotkey_ss58=hotkey_ss58))
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
+    app_ctx.submit(BurnedRegister(netuid=netuid, hotkey_ss58=hotkey))
 
 
 @app.command("create", rich_help_panel=PANEL_REGISTER)

--- a/sdk/python/bittensor/cli/commands/sudo.py
+++ b/sdk/python/bittensor/cli/commands/sudo.py
@@ -366,12 +366,13 @@ def stake_burn(
     except ValueError as error:
         app_ctx.output.error(f"invalid value for `--amount-tao`: {error}")
         raise typer.Exit(2)
+    hotkey = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
     app_ctx.submit(
         StakeBurn(
             netuid=netuid,
             amount_tao=amount,
             limit_price=limit_price,
-            hotkey_ss58=hotkey_ss58,
+            hotkey_ss58=hotkey,
         )
     )
 

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -415,3 +415,114 @@ class TestTransactions:
         ) in updates
         assert "subnet 6 registered" in result.output
         assert "queued · registered after deregistration of subnet 6" in result.output
+
+
+def test_local_hotkey_name_is_not_valid_ss58():
+    """Local wallet names must be resolved before ss58 decode.
+
+    Passing a name like ``hotkey1`` straight into the codec raises Substrate's
+    opaque ``Length is bad`` — the failure mode ``btcli s register --hotkey
+    hotkey1`` hit before CLI call sites resolved ``*_ss58`` options.
+    """
+    from bittensor._transport.codec import ss58_decode
+
+    with pytest.raises(ValueError, match="Length is bad"):
+        ss58_decode("hotkey1")
+
+
+class TestResolveHotkeySs58:
+    """Hand-written CLI commands must resolve ``--hotkey`` like generated ``tx``."""
+
+    @pytest.fixture()
+    def alt_hotkey(self, wallet_dir) -> str:
+        wallets.new_hotkey(
+            name=_WALLET_NAME, hotkey="hotkey1", path=wallet_dir, overwrite=True
+        )
+        return wallets.open_wallet(_WALLET_NAME, "hotkey1", wallet_dir).hotkey.ss58_address
+
+    def test_subnets_register_resolves_local_hotkey_name(
+        self, fake: FakeSubstrate, monkeypatch, alt_hotkey: str
+    ):
+        captured: list = []
+
+        def capture(self, intent, **kwargs):
+            captured.append(intent)
+            return None
+
+        monkeypatch.setattr(cli_context.AppContext, "submit", capture)
+        result = invoke(
+            "subnets", "register", "--netuid", "18", "--hotkey", "hotkey1"
+        )
+        assert result.exit_code == 0, result.output
+        assert len(captured) == 1
+        assert captured[0].op == "burned_register"
+        assert captured[0].hotkey_ss58 == alt_hotkey
+
+    def test_set_auto_stake_resolves_local_hotkey_name(
+        self, fake: FakeSubstrate, monkeypatch, alt_hotkey: str
+    ):
+        captured: list = []
+
+        def capture(self, intent, **kwargs):
+            captured.append(intent)
+            return None
+
+        monkeypatch.setattr(cli_context.AppContext, "submit", capture)
+        result = invoke("stake", "set-auto", "--netuid", "1", "--hotkey", "hotkey1")
+        assert result.exit_code == 0, result.output
+        assert captured[0].hotkey_ss58 == alt_hotkey
+
+    def test_lock_add_resolves_local_hotkey_name(
+        self, fake: FakeSubstrate, monkeypatch, alt_hotkey: str
+    ):
+        captured: list = []
+
+        def capture(self, intent, **kwargs):
+            captured.append(intent)
+            return None
+
+        monkeypatch.setattr(cli_context.AppContext, "submit", capture)
+        result = invoke(
+            "lock", "add", "--netuid", "1", "--amount-alpha", "1", "--hotkey", "hotkey1"
+        )
+        assert result.exit_code == 0, result.output
+        assert captured[0].hotkey_ss58 == alt_hotkey
+
+    def test_stake_burn_resolves_local_hotkey_name(
+        self, fake: FakeSubstrate, monkeypatch, alt_hotkey: str
+    ):
+        captured: list = []
+
+        def capture(self, intent, **kwargs):
+            captured.append(intent)
+            return None
+
+        monkeypatch.setattr(cli_context.AppContext, "submit", capture)
+        result = invoke(
+            "sudo",
+            "stake-burn",
+            "--netuid",
+            "1",
+            "--amount-tao",
+            "1",
+            "--limit-price",
+            "1000",
+            "--hotkey",
+            "hotkey1",
+        )
+        assert result.exit_code == 0, result.output
+        assert captured[0].hotkey_ss58 == alt_hotkey
+
+    def test_child_revoke_resolves_local_hotkey_name(
+        self, fake: FakeSubstrate, monkeypatch, alt_hotkey: str
+    ):
+        captured: list = []
+
+        def capture(self, intent, **kwargs):
+            captured.append(intent)
+            return None
+
+        monkeypatch.setattr(cli_context.AppContext, "submit", capture)
+        result = invoke("stake", "child", "revoke", "--netuid", "1", "--hotkey", "hotkey1")
+        assert result.exit_code == 0, result.output
+        assert captured[0].hotkey_ss58 == alt_hotkey


### PR DESCRIPTION
## Summary
- Hand-written CLI commands (`subnets register`, `stake set-auto`, `lock add`, `stake child set/revoke/take`, `sudo stake-burn`) passed `--hotkey` values into intents without `AppContext.resolve_address`, so a local name like `hotkey1` was treated as an SS58 and failed with `invalid ss58 address: Length is bad`.
- Resolve those options the same way generated `btcli tx` commands already do.
- Add regression tests covering the failure mode and the fixed call sites.

## Test plan
- [x] `pytest tests/unit/test_cli.py::test_local_hotkey_name_is_not_valid_ss58 tests/unit/test_cli.py::TestResolveHotkeySs58`
- [ ] `btcli s register -w <wallet> --hotkey <local-hotkey-name> --netuid <n> --dry-run` resolves the name (no Length is bad)
