### PR TITLE
fix(cli): natural-sort wallet and hotkey names

### DIFF
--- a/sdk/python/bittensor/cli/commands/wallet.py
+++ b/sdk/python/bittensor/cli/commands/wallet.py
@@ -919,7 +919,7 @@ def wallet_balance(
 
         rows_data = app_ctx.run(_all)
         key_map = {
-            "name": lambda r: r["wallet"].lower(),
+            "name": lambda r: wallets.natural_name_key(r["wallet"]),
             "free": lambda r: r["free_tao"],
             "stake-value": lambda r: r["stake_value_tao"],
             "total-value": lambda r: r["total_value_tao"],

--- a/sdk/python/bittensor/wallets.py
+++ b/sdk/python/bittensor/wallets.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -421,21 +422,45 @@ def _is_hotkey_companion_file(name: str) -> bool:
     return name.endswith(".lock") or name.endswith("pub.txt")
 
 
+_NATURAL_NAME_SPLIT = re.compile(r"(\d+)")
+
+
+def natural_name_key(name: str) -> tuple[tuple[int, int | str], ...]:
+    """Sort key for wallet / hotkey names with embedded numbers.
+
+    Digit runs compare as integers (``coldkey2`` before ``coldkey10``); text
+    runs compare case-insensitively. Each chunk is tagged so int and str
+    chunks never raise ``TypeError`` when compared.
+    """
+    pieces: list[tuple[int, int | str]] = []
+    for part in _NATURAL_NAME_SPLIT.split(name):
+        if not part:
+            continue
+        if part.isdigit():
+            pieces.append((0, int(part)))
+        else:
+            pieces.append((1, part.casefold()))
+    return tuple(pieces)
+
+
 def list_wallets(path: str = DEFAULT_WALLET_PATH) -> dict[str, list[str]]:
     """Map coldkey wallet name -> list of its hotkey names on disk."""
     root = Path(path).expanduser()
     if not root.is_dir():
         return {}
     out: dict[str, list[str]] = {}
-    for coldkey_dir in sorted(root.iterdir()):
+    for coldkey_dir in sorted(root.iterdir(), key=lambda p: natural_name_key(p.name)):
         if not coldkey_dir.is_dir():
             continue
         hotkeys_dir = coldkey_dir / "hotkeys"
         hotkeys = (
             sorted(
-                hk.name
-                for hk in hotkeys_dir.iterdir()
-                if hk.is_file() and not _is_hotkey_companion_file(hk.name)
+                (
+                    hk.name
+                    for hk in hotkeys_dir.iterdir()
+                    if hk.is_file() and not _is_hotkey_companion_file(hk.name)
+                ),
+                key=natural_name_key,
             )
             if hotkeys_dir.is_dir()
             else []
@@ -484,14 +509,14 @@ def list_wallets_detailed(path: str = DEFAULT_WALLET_PATH) -> list[ColdkeyInfo]:
     if not root.is_dir():
         return []
     coldkeys: list[ColdkeyInfo] = []
-    for coldkey_dir in sorted(root.iterdir()):
+    for coldkey_dir in sorted(root.iterdir(), key=lambda p: natural_name_key(p.name)):
         if not coldkey_dir.is_dir():
             continue
         ss58, crypto_type = _read_keyfile(coldkey_dir / "coldkeypub.txt")
         info = ColdkeyInfo(name=coldkey_dir.name, ss58=ss58, crypto_type=crypto_type)
         hotkeys_dir = coldkey_dir / "hotkeys"
         if hotkeys_dir.is_dir():
-            for hk in sorted(hotkeys_dir.iterdir(), key=lambda p: p.name):
+            for hk in sorted(hotkeys_dir.iterdir(), key=lambda p: natural_name_key(p.name)):
                 if hk.is_file() and not _is_hotkey_companion_file(hk.name):
                     hk_ss58, hk_crypto = _read_keyfile(hk)
                     info.hotkeys.append(

--- a/sdk/python/tests/unit/test_natural_name_key.py
+++ b/sdk/python/tests/unit/test_natural_name_key.py
@@ -1,0 +1,67 @@
+"""Natural ordering for wallet and hotkey names (``coldkey2`` before ``coldkey10``)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bittensor.wallets import list_wallets, list_wallets_detailed, natural_name_key
+
+
+def test_natural_name_key_orders_numbered_suffixes():
+    names = ["coldkey10", "coldkey2", "coldkey1", "coldkey11", "coldkey"]
+    assert sorted(names, key=natural_name_key) == [
+        "coldkey",
+        "coldkey1",
+        "coldkey2",
+        "coldkey10",
+        "coldkey11",
+    ]
+
+
+def test_natural_name_key_is_case_insensitive():
+    names = ["Coldkey10", "coldkey2", "COLDKEY1"]
+    assert sorted(names, key=natural_name_key) == [
+        "COLDKEY1",
+        "coldkey2",
+        "Coldkey10",
+    ]
+
+
+def test_natural_name_key_compares_digit_and_text_chunks():
+    # Must not raise TypeError when a digit run and a text run meet.
+    names = ["2wallet", "awallet", "wallet"]
+    assert sorted(names, key=natural_name_key) == ["2wallet", "awallet", "wallet"]
+
+
+def _write_pub(path: Path, ss58: str) -> None:
+    path.write_text(json.dumps({"ss58Address": ss58, "cryptoType": 1}))
+
+
+def test_list_wallets_uses_natural_order(tmp_path: Path):
+    for name in ("coldkey10", "coldkey2", "coldkey1"):
+        hotkeys = tmp_path / name / "hotkeys"
+        hotkeys.mkdir(parents=True)
+        for hk in ("hotkey10", "hotkey2", "hotkey1"):
+            (hotkeys / hk).write_text("{}")
+
+    listed = list_wallets(str(tmp_path))
+    assert list(listed) == ["coldkey1", "coldkey2", "coldkey10"]
+    assert listed["coldkey1"] == ["hotkey1", "hotkey2", "hotkey10"]
+
+
+def test_list_wallets_detailed_uses_natural_order(tmp_path: Path):
+    for i, name in enumerate(("coldkey10", "coldkey2", "coldkey1"), start=1):
+        wallet = tmp_path / name
+        (wallet / "hotkeys").mkdir(parents=True)
+        _write_pub(wallet / "coldkeypub.txt", f"ck{i}")
+        for j, hk in enumerate(("hotkey10", "hotkey2", "hotkey1"), start=1):
+            _write_pub(wallet / "hotkeys" / hk, f"{name}-hk{j}")
+
+    detailed = list_wallets_detailed(str(tmp_path))
+    assert [ck.name for ck in detailed] == ["coldkey1", "coldkey2", "coldkey10"]
+    assert [hk.name for hk in detailed[0].hotkeys] == [
+        "hotkey1",
+        "hotkey2",
+        "hotkey10",
+    ]


### PR DESCRIPTION
## Summary
- `btcli wallet list` (and other consumers of `list_wallets` / `list_wallets_detailed`) sorted names lexicographically, so `coldkey10` appeared before `coldkey2`.
- Add a small `natural_name_key` and use it for coldkey and hotkey ordering in the list helpers, plus `wallet overview --all --sort name`.

## Test plan
- [x] `pytest tests/unit/test_natural_name_key.py`
- [ ] `btcli w list` shows `coldkey1`, `coldkey2`, … `coldkey10` in numeric order
