### PR TITLE
Re-enable RootWeights proxy, scoped to set_root_weights

### DIFF
--- a/common/src/proxy.rs
+++ b/common/src/proxy.rs
@@ -36,7 +36,7 @@ pub enum ProxyType {
     Registration,
     Transfer,
     SmallTransfer,
-    RootWeights, // Deprecated
+    RootWeights,
     ChildKeys,
     SudoUncheckedSetCode,
     SwapHotkey,
@@ -99,10 +99,7 @@ impl From<ProxyType> for u8 {
 
 impl ProxyType {
     pub fn is_deprecated(&self) -> bool {
-        matches!(
-            self,
-            Self::Triumvirate | Self::Senate | Self::Governance | Self::RootWeights
-        )
+        matches!(self, Self::Triumvirate | Self::Senate | Self::Governance)
     }
 }
 

--- a/docs/tx/add-proxy.mdx
+++ b/docs/tx/add-proxy.mdx
@@ -21,7 +21,7 @@ only to keys you control or fully trust.
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `delegate_ss58` | string | yes | Key that will be allowed to sign for this account. |
-| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
+| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, and Governance are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. RootWeights covers exactly SubtensorModule.set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
 | `delay` | integer | no | Announcement delay in blocks: the delegate must announce each call and wait this long before executing it, giving you time to veto. 0 executes immediately. |
 
 Address parameters (`--hotkey`, `--coldkey`, `--dest`, ...) accept a raw ss58

--- a/docs/tx/create-pure-proxy.mdx
+++ b/docs/tx/create-pure-proxy.mdx
@@ -21,7 +21,7 @@ the pure proxy and anything it holds.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
+| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, and Governance are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. RootWeights covers exactly SubtensorModule.set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
 | `delay` | integer | no | Announcement delay in blocks: the delegate must announce each call and wait this long before executing it, giving you time to veto. 0 executes immediately. |
 | `index` | integer | no | Disambiguator so one signer can create several pure proxies in one block; also part of the derived address. Keep 0 unless batching. |
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 441,
+    spec_version: 442,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -630,6 +630,17 @@ call_filter_group!(SudoSetCodeCalls, [
         where nested(call) == RuntimeCall::System(SystemCall::set_code),
 ]);
 
+// `RootWeights`: exactly the root-weight vector call. Deliberately not the
+// whole `SubtensorCommonCalls` group it overlaps: the delegator hands out the
+// right to publish their root weights, not the validator's consensus-weight
+// surface (`set_weights`, batch/commit/reveal) that lives alongside it.
+call_filter_group!(
+    RootWeightCalls,
+    [RuntimeCall::SubtensorModule(
+        SubtensorCall::set_root_weights
+    ),]
+);
+
 // Full inventory of every runtime call, used only by the coverage test that
 // checks it against `RuntimeCall` metadata. Nested in three blocks so the
 // flattened tuple stays within the `CallFilterMetadata` tuple-impl arity;

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -117,11 +117,9 @@ pub(crate) fn proxy_type_filter(proxy_type: &ProxyType, call: &RuntimeCall) -> b
         ProxyType::SwapHotkey => HotkeySwapCalls::contains(call),
         ProxyType::SubnetLeaseBeneficiary => SubnetLeaseAllowed::contains(call),
         ProxyType::RootClaim => RootClaimCalls::contains(call),
+        ProxyType::RootWeights => RootWeightCalls::contains(call),
         ProxyType::SudoUncheckedSetCode => SudoSetCodeCalls::contains(call),
-        ProxyType::Triumvirate
-        | ProxyType::Senate
-        | ProxyType::Governance
-        | ProxyType::RootWeights => false,
+        ProxyType::Triumvirate | ProxyType::Senate | ProxyType::Governance => false,
     }
 }
 
@@ -154,6 +152,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 | ProxyType::SubnetLeaseBeneficiary
                 | ProxyType::RootClaim,
             ) => true,
+            // `NonFungible` already allows `set_root_weights` (via
+            // `SubtensorCommonCalls`), so it may also manage the
+            // strictly-narrower `RootWeights` delegation.
+            (ProxyType::NonFungible, ProxyType::RootWeights) => true,
             (ProxyType::Transfer, ProxyType::SmallTransfer) => true,
             _ => false,
         }
@@ -183,11 +185,11 @@ fn proxy_filter_mode(proxy_type: ProxyType) -> FilterMode {
         ProxyType::SwapHotkey => FilterMode::Allow(HotkeySwapCalls::call_infos()),
         ProxyType::SubnetLeaseBeneficiary => FilterMode::Allow(SubnetLeaseAllowed::call_infos()),
         ProxyType::RootClaim => FilterMode::Allow(RootClaimCalls::call_infos()),
+        ProxyType::RootWeights => FilterMode::Allow(RootWeightCalls::call_infos()),
         ProxyType::SudoUncheckedSetCode => FilterMode::Allow(SudoSetCodeCalls::call_infos()),
-        ProxyType::Triumvirate
-        | ProxyType::Senate
-        | ProxyType::Governance
-        | ProxyType::RootWeights => FilterMode::Allow(Vec::new()),
+        ProxyType::Triumvirate | ProxyType::Senate | ProxyType::Governance => {
+            FilterMode::Allow(Vec::new())
+        }
     }
 }
 
@@ -291,10 +293,68 @@ mod tests {
             ProxyType::Triumvirate,
             ProxyType::Senate,
             ProxyType::Governance,
-            ProxyType::RootWeights,
         ] {
             assert!(allowed_calls(deprecated).is_empty());
         }
+    }
+
+    // Re-enabled `RootWeights` is the narrowest weight grant: the root-weight
+    // vector call and nothing else — not consensus weights, stake movement,
+    // key rotation, or child keys.
+    #[test]
+    fn root_weights_grants_exactly_set_root_weights() {
+        use pallet_subtensor::Call as SubtensorCall;
+        use subtensor_runtime_common::{AccountId, AlphaBalance, NetUid, TaoBalance};
+
+        let hotkey = AccountId::new([1u8; 32]);
+
+        let set_root_weights = RuntimeCall::SubtensorModule(SubtensorCall::set_root_weights {
+            dests: vec![0],
+            weights: vec![0],
+        });
+        assert!(proxy_type_filter(
+            &ProxyType::RootWeights,
+            &set_root_weights
+        ));
+
+        let denied = [
+            RuntimeCall::SubtensorModule(SubtensorCall::set_weights {
+                netuid: NetUid::from(1),
+                dests: vec![0],
+                weights: vec![0],
+                version_key: 0,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+                hotkey: hotkey.clone(),
+                netuid: NetUid::from(1),
+                amount_staked: TaoBalance::from(1),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::remove_stake {
+                hotkey: hotkey.clone(),
+                netuid: NetUid::from(1),
+                amount_unstaked: AlphaBalance::from(1),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::swap_hotkey {
+                hotkey: hotkey.clone(),
+                new_hotkey: AccountId::new([2u8; 32]),
+                netuid: None,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::set_children {
+                hotkey,
+                netuid: NetUid::from(1),
+                children: vec![],
+            }),
+        ];
+        for call in &denied {
+            assert!(
+                !proxy_type_filter(&ProxyType::RootWeights, call),
+                "RootWeights must not allow {:?}",
+                call
+            );
+        }
+
+        // The metadata view agrees: exactly one allowed call.
+        assert_eq!(allowed_calls(ProxyType::RootWeights).len(), 1);
     }
 
     // Broad proxies are specified subtractively here (all calls minus a few
@@ -406,6 +466,19 @@ mod tests {
     }
 
     #[test]
+    fn non_fungible_superset_is_explicit_allowlist() {
+        let actual = all_proxy_types()
+            .into_iter()
+            .filter(|proxy_type| ProxyType::NonFungible.is_superset(proxy_type))
+            .collect::<BTreeSet<_>>();
+        let expected = [ProxyType::NonFungible, ProxyType::RootWeights]
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn owner_allows_only_owner_settable_config() {
         let owner = allowed_calls(ProxyType::Owner);
         // Owner-settable subnet params + subnet identity.
@@ -512,6 +585,10 @@ mod tests {
                 "SubtensorModule::claim_root",
                 "SubtensorModule::claim_root_with_hotkey",
             ])
+        );
+        assert_eq!(
+            allowed_calls(ProxyType::RootWeights),
+            expected(&["SubtensorModule::set_root_weights"])
         );
         assert_eq!(
             allowed_calls(ProxyType::SudoUncheckedSetCode),

--- a/sdk/python/bittensor/intents/proxy.py
+++ b/sdk/python/bittensor/intents/proxy.py
@@ -56,10 +56,11 @@ def check_proxy_type(proxy_type: str) -> str:
 PROXY_TYPE_HELP = (
     "Scope of calls the delegation covers. One of: "
     + ", ".join(PROXY_TYPES)
-    + ". Triumvirate, Senate, Governance, and RootWeights are deprecated on "
-    "the current runtime: they deny all calls, so a proxy of those types can "
-    "dispatch nothing. Prefer the narrowest type that covers your use; Any "
-    "can do everything the account can, including transfers."
+    + ". Triumvirate, Senate, and Governance are deprecated on the current "
+    "runtime: they deny all calls, so a proxy of those types can dispatch "
+    "nothing. RootWeights covers exactly SubtensorModule.set_root_weights. "
+    "Prefer the narrowest type that covers your use; Any can do everything "
+    "the account can, including transfers."
 )
 
 DELAY_HELP = (

--- a/website/apps/bittensor-website/public/catalog/intents.json
+++ b/website/apps/bittensor-website/public/catalog/intents.json
@@ -86,7 +86,7 @@
         },
         "proxy_type": {
           "type": "string",
-          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
+          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, and Governance are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. RootWeights covers exactly SubtensorModule.set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
         },
         "delay": {
           "type": "integer",
@@ -847,7 +847,7 @@
       "properties": {
         "proxy_type": {
           "type": "string",
-          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
+          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, and Governance are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. RootWeights covers exactly SubtensorModule.set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
         },
         "delay": {
           "type": "integer",


### PR DESCRIPTION
## What

Re-enables `ProxyType::RootWeights` with a deliberately minimal scope: a `RootWeights` proxy can dispatch `SubtensorModule::set_root_weights` and nothing else.

## Why

The variant (SCALE index 12) was neutralized when proxy filters moved to deny-by-default allowlists: `proxy.add_proxy(delegate, RootWeights, 0)` still **succeeds** and the delegation shows up in `Proxy.Proxies`, but every subsequent `proxy.proxy(...)` is filtered. The grant looks placed yet does nothing — the worst of both worlds. With root reborn (#2968) making per-coldkey root weights meaningful again, delegating exactly that call to a low-value operational key (keeping the coldkey offline) is a real use case.

## Changes

- **`runtime/src/proxy_filters/call_groups.rs`** — new `RootWeightCalls` group containing only `SubtensorModule::set_root_weights`. It lives with the proxy-specific groups and overlaps `SubtensorCommonCalls` (the same way `SmallTransferCalls` overlaps `BalanceTransferCalls`) rather than granting that whole group: the validator's consensus-weight surface (`set_weights`, batch/commit/reveal) stays out of reach — that is precisely what this proxy type must not delegate.
- **`runtime/src/proxy_filters/mod.rs`** — `RootWeights` maps to `RootWeightCalls` in both the executable filter (`proxy_type_filter`) and the runtime-API metadata (`proxy_filter_mode`); both derive from the same group, so they cannot drift.
- **`is_superset`** — `NonTransfer ⊃ RootWeights` already held. Added `NonFungible ⊃ RootWeights`: `NonFungible` already allows `set_root_weights` itself (via `SubtensorCommonCalls`), so it would be incoherent for a NonFungible proxy to be unable to manage a delegation that is a strict subset of its own rights. (`is_superset` gates a proxy adding/removing other delegations through `proxy.proxy`.)
- **`common/src/proxy.rs`** — `RootWeights` no longer reports `is_deprecated()`, so the runtime API's `deprecated` flag follows. Variant order is untouched: index 12 stays 12 and existing on-chain delegations keep their type.
- **SDK/docs** — `add_proxy` / `create_pure` help text no longer lists RootWeights among the deny-all types; docs reference pages regenerated from the registries.

`spec_version` bumped 441 → 442: mainnet already runs 441 (root-reborn deployed), and the `runtime-checks` spec-version gate requires runtime-affecting PRs to carry a spec newer than mainnet unless labeled `no-spec-version-bump` (which is for changes deliberately shipping without a runtime release — not this one).

## Existing on-chain grants

This change retroactively activates `RootWeights` delegations registered while the type was inert. Scan of `Proxy.Proxies` on finney at finalized block **8,765,950** (2026-08-03): 7,758 delegations across 6,722 delegator accounts — **exactly one** of type `RootWeights`:

| delegator | delegate | delay |
|---|---|---|
| `5HiFDVNX4ivCJFt9RvgRCtQKmAPgAXGX8BRgX3XKqfY9fFve` | `5FeNcqhfbLxkCeYtrKdDLkfNznmhCyvbAUMQNCfhddy8vHyX` | 0 |

Two options were weighed:

1. **Accept the existing grant** (chosen). The right that activates is exactly what the type's name promises — `add_proxy(RootWeights)` had no other plausible intent — and the delegator can revoke at any time with `remove_proxy`. A one-shot purge migration to strip a single row adds more code and upgrade risk than the retroactive grant it would remove.
2. Ship a storage migration purging pre-activation `RootWeights` entries. Rejected for the reason above; if reviewers prefer it, the affected entry is the single row listed here.

Additional mitigation: `set_root_weights` itself is still globally gated by `RootWeightSettingEnabled` (default off — it fails with `RootWeightSettingDisabled` until governance flips it via `AdminUtils::sudo_set_root_weight_setting_enabled`). The pre-existing delegation therefore cannot dispatch anything until that flag is enabled, leaving a clear window to revoke.

## Tests

- `root_weights_grants_exactly_set_root_weights` (new) — the filter accepts `set_root_weights`; rejects `set_weights`, `add_stake`, `remove_stake`, `swap_hotkey`, `set_children`; the metadata view exposes exactly one call.
- `narrow_proxies_have_exact_allow_lists` — now pins `allowed_calls(RootWeights) == {SubtensorModule::set_root_weights}`.
- `non_fungible_superset_is_explicit_allowlist` (new) — pins `NonFungible`'s superset set to `{NonFungible, RootWeights}`, mirroring the existing NonTransfer pin.
- `any_allows_everything_and_deprecated_allow_nothing` — RootWeights removed from the deny-all list (Triumvirate / Senate / Governance remain pinned there).
- The pre-existing `superset_relations_match_allowed_call_sets` and `all_call_groups_cover_runtime_call_metadata` invariants cover the new superset edge and the group inventory (no duplicate in `AllCalls`).

## Verification

- `SKIP_WASM_BUILD=1 cargo test -p node-subtensor-runtime -p subtensor-runtime-common` — green (25 proxy tests, full crate suites).
- `cargo clippy` (runtime + common, with tests) and `cargo fmt` — clean.
- SDK: `ruff`, proxy pytest subset (34 passed), and the docs staleness check (`generate.py --check`) — green.
