### PR TITLE
fix: sum emission across mechanisms instead of weighting it

### DIFF
--- a/pallets/subtensor/src/subnets/mechanism.rs
+++ b/pallets/subtensor/src/subnets/mechanism.rs
@@ -264,17 +264,6 @@ impl<T: Config> Pallet<T> {
             .saturating_to_num::<u16>()
     }
 
-    fn weighted_acc_alpha(
-        existing: AlphaBalance,
-        added: AlphaBalance,
-        weight: U64F64,
-    ) -> AlphaBalance {
-        U64F64::saturating_from_num(existing)
-            .saturating_add(U64F64::saturating_from_num(added).saturating_mul(weight))
-            .saturating_to_num::<u64>()
-            .into()
-    }
-
     /// Splits rao_emission between different sub-subnets using `split_emissions` function.
     ///
     /// Runs the epoch function for each sub-subnet and consolidates hotkey_emission
@@ -323,7 +312,14 @@ impl<T: Config> Pallet<T> {
                                 .server_emission
                                 .saturating_add(terms.server_emission);
 
-                            // The rest of the terms need to be aggregated as weighted sum
+                            // Combined emission is an absolute alpha amount, not a ratio:
+                            // per mechanism it equals server_emission + validator_emission, so
+                            // it has to be summed like those two. Weighting it would report a
+                            // fraction of what the hotkey was actually paid.
+                            acc_terms.emission = acc_terms.emission.saturating_add(terms.emission);
+
+                            // The rest of the terms are normalized ratios and are aggregated
+                            // as a weighted sum
                             acc_terms.dividend = Self::weighted_acc_u16(
                                 acc_terms.dividend,
                                 terms.dividend,
@@ -335,11 +331,6 @@ impl<T: Config> Pallet<T> {
                                 sub_weight,
                             );
                             acc_terms.active |= terms.active;
-                            acc_terms.emission = Self::weighted_acc_alpha(
-                                acc_terms.emission,
-                                terms.emission,
-                                sub_weight,
-                            );
                             acc_terms.consensus = Self::weighted_acc_u16(
                                 acc_terms.consensus,
                                 terms.consensus,
@@ -367,11 +358,7 @@ impl<T: Config> Pallet<T> {
                                     sub_weight,
                                 ),
                                 active: terms.active, // booleans are ORed across subs
-                                emission: Self::weighted_acc_alpha(
-                                    0u64.into(),
-                                    terms.emission,
-                                    sub_weight,
-                                ),
+                                emission: terms.emission, // absolute amount, summed across subs
                                 consensus: Self::weighted_acc_u16(0, terms.consensus, sub_weight),
                                 validator_trust: Self::weighted_acc_u16(
                                     0,

--- a/pallets/subtensor/src/tests/mechanism.rs
+++ b/pallets/subtensor/src/tests/mechanism.rs
@@ -29,6 +29,7 @@
 //   - [x] Mechanism limit can be set up to 8 (with admin pallet)
 //   - [x] When reduction of mechanism limit occurs, Weights, Incentive, LastUpdate, Bonds, and WeightCommits are cleared
 //   - [x] Epoch terms of subnet are weighted sum (or logical OR) of all mechanism epoch terms
+//   - [x] Emission is summed (not weighted) across mechanisms, matching paid emission
 //   - [x] Subnet epoch terms persist in state
 //   - [x] Mechanism epoch terms persist in state
 //   - [x] "Yuma Emergency Mode" (consensus sum is 0 for a mechanism), emission distributed by stake
@@ -803,10 +804,6 @@ fn epoch_with_mechanisms_persists_and_aggregates_all_terms() {
             (U64F64::saturating_from_num(a) * w0 + U64F64::saturating_from_num(b) * w1)
                 .saturating_to_num::<u16>()
         };
-        let wu64 = |a: u64, b: u64| -> u64 {
-            (U64F64::saturating_from_num(a) * w0 + U64F64::saturating_from_num(b) * w1)
-                .saturating_to_num::<u64>()
-        };
 
         // For each UID, compute expected aggregate from out0/out1 terms
         let check_uid = |uid: usize, hk: &U256| {
@@ -820,8 +817,9 @@ fn epoch_with_mechanisms_persists_and_aggregates_all_terms() {
                 t0.new_validator_permit || t1.new_validator_permit
             );
 
-            // Emission (u64)
-            let exp_em = wu64(u64::from(t0.emission), u64::from(t1.emission));
+            // Emission is an absolute alpha amount and is summed across mechanisms,
+            // not weighted, so it matches what the hotkey is actually paid.
+            let exp_em = u64::from(t0.emission).saturating_add(u64::from(t1.emission));
             assert_abs_diff_eq!(u64::from(emission_v[uid]), exp_em, epsilon = 1);
 
             // u16 terms
@@ -884,6 +882,64 @@ fn epoch_with_mechanisms_no_weight_no_incentive() {
         assert_eq!(actual_incentive_sub1[2], PerU16::zero());
         assert_eq!(actual_incentive_sub0.len(), 3);
         assert_eq!(actual_incentive_sub1.len(), 3);
+    });
+}
+
+// Persisted `Emission` is what the metagraph reports per UID. It has to equal the
+// alpha the hotkey is actually paid (server + validator emission summed over every
+// mechanism). Aggregating it as a weighted sum instead under-reported a multi-mechanism
+// subnet by roughly the mechanism count, and — because `Emission` also orders pruning
+// candidates — an uneven split could rank a higher earner below a lower one.
+#[test]
+fn epoch_with_mechanisms_persisted_emission_matches_paid_emission() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let idx0 = SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(0));
+        let idx1 = SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(1));
+
+        let ck0 = U256::from(1);
+        let hk0 = U256::from(2);
+        let ck1 = U256::from(3);
+        let hk1 = U256::from(4);
+        let hk2 = U256::from(6);
+        let emission = AlphaBalance::from(1_000_000_000u64);
+
+        mock_epoch_state(netuid, ck0, hk0, ck1, hk1);
+        mock_3_neurons(netuid, hk2);
+
+        // Two mechanisms on an uneven 25/75 split, with each miner favored by a
+        // different mechanism so the weighting cannot cancel out.
+        MechanismCountCurrent::<Test>::insert(netuid, MechId::from(2u8));
+        let split0 = u16::MAX / 4;
+        MechanismEmissionSplit::<Test>::insert(netuid, vec![split0, u16::MAX - split0]);
+
+        ValidatorPermit::<Test>::insert(netuid, vec![true, false, false]);
+        Weights::<Test>::insert(
+            idx0,
+            0,
+            vec![(1u16, 0xFFFF / 5 * 3), (2u16, 0xFFFF / 5 * 2)],
+        );
+        Weights::<Test>::insert(idx1, 0, vec![(1u16, 0xFFFF / 5), (2u16, 0xFFFF / 5 * 4)]);
+
+        let agg = SubtensorModule::epoch_with_mechanisms(netuid, emission);
+
+        // What each hotkey is actually credited this epoch.
+        let paid: BTreeMap<U256, u64> = agg
+            .into_iter()
+            .map(|(hk, se, ve)| (hk, u64::from(se).saturating_add(u64::from(ve))))
+            .collect();
+
+        let emission_v = Emission::<Test>::get(netuid);
+
+        for (uid, hk) in [(0_usize, hk0), (1_usize, hk1), (2_usize, hk2)] {
+            let reported = u64::from(emission_v[uid]);
+            let credited = paid.get(&hk).copied().expect("hotkey present in aggregate");
+            assert_abs_diff_eq!(reported, credited, epsilon = 8);
+        }
+
+        // The whole epoch emission is accounted for, not a weighted fraction of it.
+        let total_reported: u64 = emission_v.iter().map(|e| u64::from(*e)).sum();
+        assert_abs_diff_eq!(total_reported, u64::from(emission), epsilon = 16);
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 442,
+    spec_version: 443,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Fixes #2194.

## Problem

`epoch_with_mechanisms` merges each mechanism's `EpochTerms`, but aggregates two dimensionally different kinds of field the same way:

```rust
acc_terms.validator_emission = acc_terms.validator_emission.saturating_add(terms.validator_emission);
acc_terms.server_emission    = acc_terms.server_emission.saturating_add(terms.server_emission);
...
acc_terms.emission = Self::weighted_acc_alpha(acc_terms.emission, terms.emission, sub_weight);
```

The fields weighted alongside `emission` — `consensus`, `dividend`, `validator_trust`, `stake_weight` — are normalized ratios, where a weighted sum is correct. `emission` is an absolute alpha amount: per mechanism it equals `server_emission + validator_emission`, the two fields summed immediately above it. Weighting it reports a fraction of what the hotkey was actually paid.

`persist_netuid_epoch_terms` writes that value into `Emission`, which is what the metagraph reports per UID. On an even N-mechanism split it reads ~1/N of the real figure.

This was first reported in #2194 (Nov 2025) and independently confirmed by the owner of a subnet running mechanisms on mainnet. The issue was closed on 2026-07-31 with no linked commit or PR; the defect is unchanged on `main`.

## Not just display

`get_neuron_to_prune` reads `Emission` and selects the **lowest** value. On an uneven split the weighting can invert relative order between mechanism-specialized neurons:

> Subnet emits 1000, split 25/75. Neuron A earns 100 in mech0, neuron B earns 50 in mech1.
> Actual: A=100, B=50 — B is the lower earner.
> Reported: A=25, B=37.5 — **A is pruned instead.**

So on multi-mechanism subnets with a non-even split this can deregister the higher earner. That is a behaviour change, hence the `spec_version` bump.

## Payout-neutral

`epoch_with_mechanisms` returns `(hotkey, terms.server_emission, terms.validator_emission)` and never returns `terms.emission`. Those two were already summed and are untouched here, so **no hotkey's alpha changes**. This matches @dougsillars' original observation that miners were being paid correctly and only the reported value was wrong.

## Change

- Sum `emission` across mechanisms instead of weighting it, in both the `and_modify` and `or_insert_with` arms.
- Drop `weighted_acc_alpha`, now unused.
- `spec_version` 442 → 443.

## Tests

Added `epoch_with_mechanisms_persisted_emission_matches_paid_emission`: asserts persisted `Emission` per UID equals `server_emission + validator_emission` for that hotkey, and that the per-UID total accounts for the whole epoch emission. It uses an uneven 25/75 split with each miner favoured by a different mechanism, so the weighting cannot cancel out.

Against the unfixed aggregation it fails as expected:

```
assert_abs_diff_eq!(reported, credited, epsilon = 8)
    left  = 312505722   // Emission storage
    right = 500000000   // server_emission + validator_emission
```

Also updated the emission assertion in `epoch_with_mechanisms_persists_and_aggregates_all_terms`, which encoded the previous behaviour.

Locally: `cargo fmt --check --all` clean, `cargo clippy -p pallet-subtensor --all-targets -- -D warnings` clean, `cargo test -p pallet-subtensor --lib` 1397 passed / 0 failed.