### PR TITLE
chore(subtensor): gate stake_into_basket pending state-growth review

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2009,9 +2009,14 @@ mod dispatches {
             hotkey: T::AccountId,
             amount_staked: TaoBalance,
         ) -> DispatchResultWithPostInfo {
+            // Temporarily gated pending a state-growth review: direct deposits open one
+            // escrow holding row per weight slot, so the per-call storage footprint is
+            // being reassessed before the path is re-enabled.
             let coldkey = ensure_signed(origin)?;
-            let weight = Self::do_stake_into_basket(coldkey, hotkey, amount_staked)?;
-            Ok((Some(weight), Pays::Yes).into())
+            log::debug!(
+                "stake_into_basket gated (c={coldkey:?} h={hotkey:?} amt={amount_staked:?})"
+            );
+            Err(Error::<T>::CallDisabled.into())
         }
 
         // Call indices 122 (`set_root_claim_type`) and 123 (`sudo_set_num_root_claims`) are

--- a/pallets/subtensor/src/tests/stake_into_basket.rs
+++ b/pallets/subtensor/src/tests/stake_into_basket.rs
@@ -64,8 +64,8 @@ fn test_stake_into_basket_round_trip_symmetric() {
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
 
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));
@@ -120,8 +120,8 @@ fn test_stake_into_basket_empty_fund_par_mint_equals_nav() {
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
 
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));
@@ -190,8 +190,8 @@ fn test_stake_into_basket_does_not_dilute_existing_holders() {
         // Bob (no root stake at all) buys in directly.
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));
@@ -233,29 +233,21 @@ fn test_stake_into_basket_rejections() {
 
         // Hotkey with no account.
         assert_noop!(
-            SubtensorModule::stake_into_basket(
-                RuntimeOrigin::signed(bob),
-                U256::from(777),
-                10_000_000u64.into(),
-            ),
+            SubtensorModule::do_stake_into_basket(bob, U256::from(777), 10_000_000u64.into(),),
             Error::<Test>::HotKeyAccountNotExists
         );
 
         // Below the minimum stake.
         let dust = DefaultMinStake::<Test>::get().to_u64().saturating_sub(1);
         assert_noop!(
-            SubtensorModule::stake_into_basket(RuntimeOrigin::signed(bob), hotkey, dust.into(),),
+            SubtensorModule::do_stake_into_basket(bob, hotkey, dust.into(),),
             Error::<Test>::AmountTooLow
         );
 
         // No balance.
         let pauper = U256::from(2002);
         assert_noop!(
-            SubtensorModule::stake_into_basket(
-                RuntimeOrigin::signed(pauper),
-                hotkey,
-                10_000_000u64.into(),
-            ),
+            SubtensorModule::do_stake_into_basket(pauper, hotkey, 10_000_000u64.into(),),
             Error::<Test>::NotEnoughBalanceToStake
         );
 
@@ -265,8 +257,8 @@ fn test_stake_into_basket_rejections() {
         set_root_weights_direct(&hotkey, 0, &[(NetUid::from(99u16), u16::MAX)]);
         let escrow = SubtensorModule::get_beta_escrow_account_id();
         let deposit = 10_000_000u64;
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             deposit.into(),
         ));
@@ -294,8 +286,8 @@ fn test_stake_into_basket_rejections() {
             deposit.into(),
         );
         let alpha_before = escrow_alpha(&hotkey, netuid);
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             deposit.into(),
         ));
@@ -353,8 +345,8 @@ fn test_stake_into_basket_credit_survives_stake_changes() {
         // Bob buys in directly with zero root stake.
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));
@@ -438,8 +430,8 @@ fn test_stake_into_basket_gets_no_dividend_accrual() {
 
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));
@@ -585,8 +577,8 @@ fn test_root_slot_yield_accrues_to_share_holders() {
         // Bob buys in directly: all-root basket at N/P = 1, so his TAO mints 1:1 exactly.
         let b = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * b));
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             b.into(),
         ));
@@ -696,8 +688,8 @@ fn test_stake_into_basket_cannot_skim_compounding() {
         // his immediate payout is ~his TAO — none of alice's compounding.
         let amount = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * amount));
-        assert_ok!(SubtensorModule::stake_into_basket(
-            RuntimeOrigin::signed(bob),
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
             hotkey,
             amount.into(),
         ));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 442,
+    spec_version: 443,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

Temporarily gates the `stake_into_basket` extrinsic while we review the state-growth characteristics of direct basket deposits.

Each direct deposit deploys across a validator's weight vector and can open a new escrow holding row per slot. Before we let that path keep accumulating rows we want to reassess the per-call storage footprint and the resulting scan cost on downstream claims (every claim pays a per-row scan). Rather than leave it open while that review is pending, the extrinsic now returns the generic `CallDisabled`.

## Details

- `stake_into_basket` returns `CallDisabled` for now. Signature, call index (147), params, and declared weight are unchanged, so runtime metadata and the generated SDK bindings are unaffected.
- The deployment engine (`do_stake_into_basket` / `deploy_tao_into_basket`) is untouched; the `stake_into_basket` tests now exercise it directly, so coverage of ΔNAV minting, round-trip symmetry, and root-slot yield attribution is preserved.
- Re-enabling is a one-line revert of the dispatch body once the review clears.

## Test plan

- [x] `cargo fmt --check --all`
- [x] `cargo clippy -p pallet-subtensor --all-targets --all-features -- -D warnings`
- [x] `cargo test -p pallet-subtensor --all-features stake_into_basket` (9 passed)

Made with [Cursor](https://cursor.com)